### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+##########################################
+#             code ownership
+##########################################
+
+# default ownership:
+* @zblurx @Marshall-Hallenbeck @NeffIsBack


### PR DESCRIPTION
This enables to set up CODEOWNERS so one of the specified individuals have to review a PR before merging