### PR TITLE
Fix CLI

### DIFF
--- a/.github/workflows/crackmapexec-test.yml
+++ b/.github/workflows/crackmapexec-test.yml
@@ -1,11 +1,8 @@
 name: CrackMapExec Tests
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   build:

--- a/.github/workflows/crackmapexec.yml
+++ b/.github/workflows/crackmapexec.yml
@@ -1,12 +1,7 @@
-name: CrackMapExec Tests & Build
+name: CrackMapExec Build Binaries
 
 on:
   workflow_dispatch:
-    branches: [ main ]
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR should fix the problem that:
1. Binary building workflow run after every push -> now only when manually triggered
2. Test running after every push -> now only run after a review has been submitted