### PR TITLE
Fix decode errors on password file decoding

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -309,7 +309,7 @@ class connection(object):
         # Parse passwords
         for password in self.args.password:
             if isfile(password):
-                with open(password, 'r') as password_file:
+                with open(password, 'r', errors='ignore') as password_file:
                     for line in password_file:
                         secret.append(line.strip())
                         cred_type.append('plaintext')


### PR DESCRIPTION
This should prevent errors when reading a file with some non utf-8 characters. As tread-off this will remove any non utf-8 characters tho.

See https://github.com/Porchetta-Industries/CrackMapExec/issues/806