### PR TITLE
[library] termcolor: enable force color to avoid weird output

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -6,7 +6,6 @@ import sys
 from argparse import RawTextHelpFormatter
 from nxc.loaders.protocolloader import ProtocolLoader
 from nxc.helpers.logger import highlight
-from termcolor import colored
 from nxc.logger import nxc_logger
 import importlib.metadata
 

--- a/nxc/helpers/logger.py
+++ b/nxc/helpers/logger.py
@@ -13,6 +13,6 @@ def write_log(data, log_name):
 
 def highlight(text, color="yellow"):
     if color == "yellow":
-        return f"{colored(text, 'yellow', attrs=['bold'])}"
+        return f"{colored(text, 'yellow', attrs=['bold'], force_color=True)}"
     elif color == "red":
-        return f"{colored(text, 'red', attrs=['bold'])}"
+        return f"{colored(text, 'red', attrs=['bold'], force_color=True)}"

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -51,22 +51,22 @@ class NXCAdapter(logging.LoggerAdapter):
         # If the logger is being called when hooking the 'options' module function
         if len(self.extra) == 1 and ("module_name" in self.extra.keys()):
             return (
-                f"{colored(self.extra['module_name'], 'cyan', attrs=['bold']):<64} {msg}",
+                f"{colored(self.extra['module_name'], 'cyan', attrs=['bold'], force_color=True):<64} {msg}",
                 kwargs,
             )
 
         # If the logger is being called from nxcServer
         if len(self.extra) == 2 and ("module_name" in self.extra.keys()) and ("host" in self.extra.keys()):
             return (
-                f"{colored(self.extra['module_name'], 'cyan', attrs=['bold']):<24} {self.extra['host']:<39} {msg}",
+                f"{colored(self.extra['module_name'], 'cyan', attrs=['bold'], force_color=True):<24} {self.extra['host']:<39} {msg}",
                 kwargs,
             )
 
         # If the logger is being called from a protocol
         if "module_name" in self.extra.keys():
-            module_name = colored(self.extra["module_name"], "cyan", attrs=["bold"])
+            module_name = colored(self.extra["module_name"], "cyan", attrs=["bold"], force_color=True)
         else:
-            module_name = colored(self.extra["protocol"], "blue", attrs=["bold"])
+            module_name = colored(self.extra["protocol"], "blue", attrs=["bold"], force_color=True)
 
         return (
             f"{module_name:<24} {self.extra['host']:<15} {self.extra['port']:<6} {self.extra['hostname'] if self.extra['hostname'] else 'NONE':<16} {msg}",
@@ -83,7 +83,7 @@ class NXCAdapter(logging.LoggerAdapter):
         except AttributeError:
             pass
 
-        msg, kwargs = self.format(f"{colored('[*]', 'blue', attrs=['bold'])} {msg}", kwargs)
+        msg, kwargs = self.format(f"{colored('[*]', 'blue', attrs=['bold'], force_color=True)} {msg}", kwargs)
         text = Text.from_ansi(msg)
         nxc_console.print(text, *args, **kwargs)
         self.log_console_to_file(text, *args, **kwargs)
@@ -98,7 +98,7 @@ class NXCAdapter(logging.LoggerAdapter):
         except AttributeError:
             pass
 
-        msg, kwargs = self.format(f"{colored('[+]', color, attrs=['bold'])} {msg}", kwargs)
+        msg, kwargs = self.format(f"{colored('[+]', color, attrs=['bold'], force_color=True)} {msg}", kwargs)
         text = Text.from_ansi(msg)
         nxc_console.print(text, *args, **kwargs)
         self.log_console_to_file(text, *args, **kwargs)
@@ -113,7 +113,7 @@ class NXCAdapter(logging.LoggerAdapter):
         except AttributeError:
             pass
 
-        msg, kwargs = self.format(f"{colored(msg, 'yellow', attrs=['bold'])}", kwargs)
+        msg, kwargs = self.format(f"{colored(msg, 'yellow', attrs=['bold'], force_color=True)}", kwargs)
         text = Text.from_ansi(msg)
         nxc_console.print(text, *args, **kwargs)
         self.log_console_to_file(text, *args, **kwargs)
@@ -127,7 +127,7 @@ class NXCAdapter(logging.LoggerAdapter):
                 return
         except AttributeError:
             pass
-        msg, kwargs = self.format(f"{colored('[-]', color, attrs=['bold'])} {msg}", kwargs)
+        msg, kwargs = self.format(f"{colored('[-]', color, attrs=['bold'], force_color=True)} {msg}", kwargs)
         text = Text.from_ansi(msg)
         nxc_console.print(text, *args, **kwargs)
         self.log_console_to_file(text, *args, **kwargs)

--- a/nxc/modules/wcc.py
+++ b/nxc/modules/wcc.py
@@ -77,7 +77,7 @@ class ConfigCheck:
         if self.module.quiet:
             return
 
-        status = colored('OK', 'green', attrs=['bold']) if self.ok else colored('KO', 'red', attrs=['bold'])
+        status = colored('OK', 'green', attrs=['bold'], force_color=True) if self.ok else colored('KO', 'red', attrs=['bold'], force_color=True)
         reasons = ": " + ', '.join(self.reasons)
         msg = f'{status} {self.name}'
         info_msg = f'{status} {self.name}{reasons}'

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -306,8 +306,8 @@ class ldap(connection):
         else:
             self.logger.extra["protocol"] = "SMB" if not self.no_ntlm else "LDAP"
             self.logger.extra["port"] = "445" if not self.no_ntlm else "389"
-            signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=['bold']) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=['bold'])
-            smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=['bold']) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=['bold'])
+            signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=['bold'], force_color=True) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=['bold'], force_color=True)
+            smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=['bold'], force_color=True) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=['bold'], force_color=True)
             self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({smbv1})")
             self.logger.extra["protocol"] = "LDAP"
             # self.logger.display(self.endpoint)
@@ -834,16 +834,16 @@ class ldap(connection):
             if isinstance(item, ldapasn1_impacket.SearchResultEntry) is not True:
                 continue
             name = ""
-            try:           	    
-            	for attribute in item["attributes"]:     
-            	    if str(attribute["type"]) == "dNSHostName":
-            	        name = str(attribute["vals"][0])
-            	try:
-            	    ip_address = socket.gethostbyname(name.split(".")[0])
-            	    if ip_address != True and name != "":
-                        self.logger.highlight(f"{name} = {colored(ip_address, host_info_colors[0])}")
-            	except socket.gaierror:
-            	    self.logger.fail(f"{name} = Connection timeout")
+            try:
+                for attribute in item["attributes"]:     
+                    if str(attribute["type"]) == "dNSHostName":
+                        name = str(attribute["vals"][0])
+                try:
+                    ip_address = socket.gethostbyname(name.split(".")[0])
+                    if ip_address != True and name != "":
+                        self.logger.highlight(f"{name} = {colored(ip_address, host_info_colors[0], force_color=True)}")
+                except socket.gaierror:
+                    self.logger.fail(f"{name} = Connection timeout")
             except Exception as e:
                 self.logger.fail("Exception:", exc_info=True)
                 self.logger.fail(f"Skipping item, cannot process due to error {e}")

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -104,7 +104,7 @@ class rdp(connection):
         )
 
     def print_host_info(self):
-        nla = colored(f"nla:{self.nla}", host_info_colors[3], attrs=['bold']) if self.nla else colored(f"nla:{self.nla}", host_info_colors[2], attrs=['bold'])
+        nla = colored(f"nla:{self.nla}", host_info_colors[3], attrs=['bold'], force_color=True) if self.nla else colored(f"nla:{self.nla}", host_info_colors[2], attrs=['bold'], force_color=True)
         if self.domain is None:
             self.logger.display("Probably old, doesn't not support HYBRID or HYBRID_EX" f" ({nla})")
         else:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -363,8 +363,8 @@ class smb(connection):
         return True
 
     def print_host_info(self):
-        signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=['bold']) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=['bold'])
-        smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=['bold']) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=['bold'])
+        signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=['bold'], force_color=True) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=['bold'], force_color=True)
+        smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=['bold'], force_color=True) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=['bold'], force_color=True)
         self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({smbv1})")
         if self.args.laps:
             return self.laps_search(self.args.username, self.args.password, self.args.hash, self.domain)

--- a/nxc/protocols/smb/db_navigator.py
+++ b/nxc/protocols/smb/db_navigator.py
@@ -6,8 +6,8 @@ from nxc.nxcdb import DatabaseNavigator, print_table, print_help
 from termcolor import colored
 import functools
 
-help_header = functools.partial(colored, color='cyan', attrs=['bold'])
-help_kw = functools.partial(colored, color='green', attrs=['bold'])
+help_header = functools.partial(colored, color='cyan', attrs=['bold'], force_color=True)
+help_kw = functools.partial(colored, color='green', attrs=['bold'], force_color=True)
 
 class navigator(DatabaseNavigator):
     def display_creds(self, creds):


### PR DESCRIPTION
Enable force colorized with termcolor to avoid weird output

Fix:
- color will missing when running with multiple target (only happened in `termcolor > 1.1.0`)

ENV;
- zsh
- zsh with tmux
-  windows cmd (ssh)

Compare:
- Before:
![image](https://github.com/Pennyw0rth/NetExec/assets/30458572/cb07d69b-845c-4396-afe2-68c35dfa8287)

- After:
![image](https://github.com/Pennyw0rth/NetExec/assets/30458572/a07e9957-ce91-4c93-99c1-c39b0f1ac5d9)
