### PR TITLE
Update README.md - one grammatical error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 This project was initially created in 2015 by @byt3bl33d3r, known as CrackMapExec. In 2019 @mpgn_x64 started maintaining the project for the next 4 years, adding a lot of great tools and features. In September 2023 he retired from maintaining the project.
 
-Along with many other contributors, we (NeffIsBack, Marshall-Hallenbeck, and zblurx) developed new features, bugfixes, and helped maintain the original project CrackMapExec.
+Along with many other contributors, we (NeffIsBack, Marshall-Hallenbeck, and zblurx) developed new features, bug fixes, and helped maintain the original project CrackMapExec.
 During this time, with both a private and public repository, community contributions were not easily merged into the project. The 6-8 month discrepancy between the code bases caused many development issues and heavily reduced community-driven development.
 With the end of mpgn's maintainer role, we (the remaining most active contributors) decided to maintain the project together as a fully free and open source project under the new name **NetExec** 🚀
 Going forward, our intent is to maintain a community-driven and maintained project with regular updates for everyone to use.


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**NetExec - The Network Execution Tool**"

"**bugfixes**"  should be "**bug fixes**"

Screenshot-

![Screenshot (144)](https://github.com/Pennyw0rth/NetExec/assets/115995339/2ecc0fde-ff47-4333-9eb3-f23d243749f3)

