### PR TITLE
Fix import error on windows

### DIFF
--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -26,7 +26,7 @@ from rich.progress import Progress
 import platform
 
 # Increase file_limit to prevent error "Too many open files"
-if platform != "Windows":
+if platform.system() != "Windows":
     import resource
 
     file_limit = list(resource.getrlimit(resource.RLIMIT_NOFILE))


### PR DESCRIPTION
As @XiaoliChan pointed out currently the OS check in `netexec.py` fails (oops). That PR will properly check the hosts OS.
Before:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/4fd68a50-51df-41f1-aae2-a9b12048bbfb)
