### PR TITLE
disable use of ssh_agent 

### DIFF
--- a/nxc/protocols/ssh.py
+++ b/nxc/protocols/ssh.py
@@ -65,7 +65,7 @@ class ssh(connection):
         self.conn = paramiko.SSHClient()
         self.conn.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
-            self.conn.connect(self.host, port=self.port, timeout=self.args.ssh_timeout, look_for_keys=False)
+            self.conn.connect(self.host, port=self.port, timeout=self.args.ssh_timeout, look_for_keys=False, allow_agent=False)
         except AuthenticationException:
             return True
         except SSHException:


### PR DESCRIPTION
First fix for #105
By default paramiko would try to use ssh keys present in the ssh_agent. Performing unexpected auth attempts with those keys and... leading to potential exhaustion of auth attempts. 
