### PR TITLE
[winrm] disable logger & add miss port args

### DIFF
--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -4,6 +4,7 @@ import os
 import requests
 import urllib3
 import contextlib
+import logging
 import xml.etree.ElementTree as ET
 
 from io import StringIO
@@ -38,6 +39,8 @@ class winrm(connection):
         connection.__init__(self, args, db, host)
 
     def proto_logger(self):
+        logging.getLogger("pypsrp").disabled = True
+        logging.getLogger("pypsrp.wsman").disabled = True
         self.logger = NXCAdapter(
             extra={
                 "protocol": "WINRM",
@@ -242,6 +245,7 @@ class winrm(connection):
         try:
             self.conn = Client(
                 self.host,
+                port=self.port,
                 auth="ntlm",
                 username=f"{self.domain}\\{self.username}",
                 password=self.password,
@@ -291,6 +295,7 @@ class winrm(connection):
         try:
             self.conn = Client(
                 self.host,
+                port=self.port,
                 auth="ntlm",
                 username=f"{self.domain}\\{self.username}",
                 password=f"{self.lmhash}:{self.nthash}",


### PR DESCRIPTION
- disable `pypsrp` logger
- add missing port in `pypsrp.client`

![image](https://github.com/Pennyw0rth/NetExec/assets/30458572/24dd066b-326d-4d7d-bf10-39f00b94e7db)