### PR TITLE
[logger.py] remove condition in `logger.fail`

### DIFF
--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -107,11 +107,6 @@ class NXCAdapter(logging.LoggerAdapter):
 
     def fail(self, msg, color="red", *args, **kwargs):
         """Prints a failure (may or may not be an error) - e.g. login creds didn't work"""
-        try:
-            if self.extra and "protocol" in self.extra and not called_from_cmd_args():
-                return
-        except AttributeError:
-            pass
         msg, kwargs = self.format(f"{colored('[-]', color, attrs=['bold'])} {msg}", kwargs)
         text = Text.from_ansi(msg)
         nxc_console.print(text, *args, **kwargs)


### PR DESCRIPTION
The `try` condition in `fail()` should be removed, because it only works in `called_from_cmd_args()`, but sometimes, `logger.fail` will be used in other functions like `create_conn_obj` `enum_host_info`

For example, `logger.fail` in here is not working
![image](https://github.com/Pennyw0rth/NetExec/assets/30458572/973f4548-cd4e-4afe-b825-c123c297fb7e)

Another test case is in `winrm`, it will get a fail message if `smb` is blocked
![image](https://github.com/Pennyw0rth/NetExec/assets/30458572/1a544489-5447-49e3-aa74-d06988c459c2)

Also can test it with add `self. logger.fail("Can you see me")` in `enum_host_info` function
