### PR TITLE
[winrm] better output

### DIFF
--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -183,17 +183,11 @@ class winrm(connection):
         return True
 
     def print_host_info(self):
-        if not self.args.domain:
-            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+        self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
         
         self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
         self.logger.extra["port"] = self.port
-        winrm_info = "{} {} {}".format(
-            self.endpoint,
-            f"(auth type:{self.auth_type})",
-            f"(domain:{self.domain})" if self.args.domain else "",
-        )
-        self.logger.display(winrm_info)
+        self.logger.info(f"Connection information: {self.endpoint} (auth type:{self.auth_type}) (domain:{self.domain if self.args.domain else ''})")
 
         if self.args.laps:
             return self.laps_search(self.args.username, self.args.password, self.args.hash, self.domain)

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -183,10 +183,15 @@ class winrm(connection):
         return True
 
     def print_host_info(self):
-        self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+        if self.args.no_smb:
+            self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
+            self.logger.extra["port"] = self.port
+            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+        else:
+            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+            self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
+            self.logger.extra["port"] = self.port
         
-        self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
-        self.logger.extra["port"] = self.port
         self.logger.info(f"Connection information: {self.endpoint} (auth type:{self.auth_type}) (domain:{self.domain if self.args.domain else ''})")
 
         if self.args.laps:

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -35,17 +35,20 @@ class winrm(connection):
         self.lmhash = ""
         self.nthash = ""
         self.ssl = False
+        self.auth_type = None
 
         connection.__init__(self, args, db, host)
 
     def proto_logger(self):
+        # Reason why default is SMB/445, because default is enumerate over SMB.
+        # For more details, please check the function "print_host_info" 
         logging.getLogger("pypsrp").disabled = True
         logging.getLogger("pypsrp.wsman").disabled = True
         self.logger = NXCAdapter(
             extra={
-                "protocol": "WINRM",
+                "protocol": "SMB",
                 "host": self.host,
-                "port": "5985",
+                "port": "445",
                 "hostname": self.hostname,
             }
         )
@@ -180,9 +183,17 @@ class winrm(connection):
         return True
 
     def print_host_info(self):
+        if not self.args.domain:
+            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+        
         self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
         self.logger.extra["port"] = self.port
-        self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+        winrm_info = "{} {} {}".format(
+            self.endpoint,
+            f"(auth type:{self.auth_type})",
+            f"(domain:{self.domain})" if self.args.domain else "",
+        )
+        self.logger.display(winrm_info)
 
         if self.args.laps:
             return self.laps_search(self.args.username, self.args.password, self.args.hash, self.domain)
@@ -211,6 +222,7 @@ class winrm(connection):
                 self.logger.debug(f"Requesting URL: {endpoints[protocol]['url']}")
                 res = requests.post(endpoints[protocol]["url"], verify=False, timeout=self.args.http_timeout) 
                 self.logger.debug(f"Received response code: {res.status_code}")
+                self.auth_type = res.headers["WWW-Authenticate"] if "WWW-Authenticate" in res.headers else "NOAUTH"
                 self.endpoint = endpoints[protocol]["url"]
                 self.ssl = endpoints[protocol]["ssl"]
                 return True


### PR DESCRIPTION
As @NeffIsBack feedback, shouldn't show `WINRM` when doing `SMB` enumeration.

What news:
- get `auth type` from HTTP header `WWW-Authenticate`

![image](https://github.com/Pennyw0rth/NetExec/assets/30458572/98b58dad-f035-48e7-9a04-f50304a9efb7)
