### PR TITLE
Restructure how laps login works to fix login issues

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -10,6 +10,7 @@ from nxc.config import pwned_label
 from nxc.helpers.logger import highlight
 from nxc.logger import nxc_logger, NXCAdapter
 from nxc.context import Context
+from nxc.protocols.ldap.laps import laps_search
 
 from impacket.dcerpc.v5 import transport
 import sys
@@ -458,6 +459,13 @@ class connection:
                 self.kerberos_login(self.domain, username, password, "", "", self.kdcHost, True)
                 self.logger.info("Successfully authenticated using Kerberos cache")
                 return True
+
+        if hasattr(self.args, "laps") and self.args.laps:
+            self.logger.debug("Trying to authenticate using LAPS")
+            username[0], secret[0], domain[0], ntlm_hash = laps_search(self, self.args.username, self.args.password, self.args.hash, self.domain)
+            cred_type = ["plaintext"]
+            if not (username[0] or secret[0] or domain[0]):
+                return False
 
         if not self.args.no_bruteforce:
             for secr_index, secr in enumerate(secret):

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -462,7 +462,7 @@ class connection:
 
         if hasattr(self.args, "laps") and self.args.laps:
             self.logger.debug("Trying to authenticate using LAPS")
-            username[0], secret[0], domain[0], ntlm_hash = laps_search(self, self.args.username, self.args.password, self.args.hash, self.domain)
+            username[0], secret[0], domain[0], ntlm_hash = laps_search(self, username, secret, cred_type, domain)
             cred_type = ["plaintext"]
             if not (username[0] or secret[0] or domain[0]):
                 return False

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -68,12 +68,6 @@ class NXCAdapter(logging.LoggerAdapter):
 
     def display(self, msg, *args, **kwargs):
         """Display text to console, formatted for nxc"""
-        try:
-            if self.extra and "protocol" in self.extra and not called_from_cmd_args():
-                return
-        except AttributeError:
-            pass
-
         msg, kwargs = self.format(f"{colored('[*]', 'blue', attrs=['bold'])} {msg}", kwargs)
         text = Text.from_ansi(msg)
         nxc_console.print(text, *args, **kwargs)
@@ -81,12 +75,6 @@ class NXCAdapter(logging.LoggerAdapter):
 
     def success(self, msg, color="green", *args, **kwargs):
         """Print some sort of success to the user"""
-        try:
-            if self.extra and "protocol" in self.extra and not called_from_cmd_args():
-                return
-        except AttributeError:
-            pass
-
         msg, kwargs = self.format(f"{colored('[+]', color, attrs=['bold'])} {msg}", kwargs)
         text = Text.from_ansi(msg)
         nxc_console.print(text, *args, **kwargs)
@@ -94,12 +82,6 @@ class NXCAdapter(logging.LoggerAdapter):
 
     def highlight(self, msg, *args, **kwargs):
         """Prints a completely yellow highlighted message to the user"""
-        try:
-            if self.extra and "protocol" in self.extra and not called_from_cmd_args():
-                return
-        except AttributeError:
-            pass
-
         msg, kwargs = self.format(f"{colored(msg, 'yellow', attrs=['bold'])}", kwargs)
         text = Text.from_ansi(msg)
         nxc_console.print(text, *args, **kwargs)
@@ -107,11 +89,6 @@ class NXCAdapter(logging.LoggerAdapter):
 
     def fail(self, msg, color="red", *args, **kwargs):
         """Prints a failure (may or may not be an error) - e.g. login creds didn't work"""
-        try:
-            if self.extra and "protocol" in self.extra and not called_from_cmd_args():
-                return
-        except AttributeError:
-            pass
         msg, kwargs = self.format(f"{colored('[-]', color, attrs=['bold'])} {msg}", kwargs)
         text = Text.from_ansi(msg)
         nxc_console.print(text, *args, **kwargs)

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -4,7 +4,6 @@ from logging.handlers import RotatingFileHandler
 import os.path
 import sys
 import re
-from nxc.helpers.misc import called_from_cmd_args
 from nxc.console import nxc_console
 from termcolor import colored
 from datetime import datetime

--- a/nxc/protocols/ldap/laps.py
+++ b/nxc/protocols/ldap/laps.py
@@ -1,3 +1,6 @@
+import binascii
+import hashlib
+from json import loads
 from pyasn1.codec.der import decoder
 from pyasn1_modules import rfc5652
 
@@ -258,3 +261,98 @@ class LAPSv2Extract:
         plaintext = decrypt_plaintext(cek, iv, remaining)
         self.logger.info(plaintext[:-18].decode("utf-16le"))
         return plaintext[:-18].decode("utf-16le")
+
+
+def laps_search(self, username, password, ntlm_hash, domain):
+    prev_protocol = self.logger.extra["protocol"]
+    prev_port = self.logger.extra["port"]
+    self.logger.extra["protocol"] = "LDAP"
+    self.logger.extra["port"] = "389"
+
+    ldapco = LDAPConnect(self.domain, "389", self.domain)
+
+    if self.kerberos:
+        if self.kdcHost is None:
+            self.logger.fail("Add --kdcHost parameter to use laps with kerberos")
+            return False
+
+        connection = ldapco.kerberos_login(
+            domain,
+            username[0] if username else "",
+            password[0] if password else "",
+            ntlm_hash[0] if ntlm_hash else "",
+            kdcHost=self.kdcHost,
+            aesKey=self.aesKey,
+        )
+    else:
+        connection = ldapco.auth_login(
+            domain,
+            username[0] if username else "",
+            password[0] if password else "",
+            ntlm_hash[0] if ntlm_hash else "",
+        )
+    if not connection:
+        self.logger.fail(f"LDAP connection failed with account {username[0]}")
+
+        return False
+
+    search_filter = "(&(objectCategory=computer)(|(msLAPS-EncryptedPassword=*)(ms-MCS-AdmPwd=*)(msLAPS-Password=*))(name=" + self.hostname + "))"
+    attributes = [
+        "msLAPS-EncryptedPassword",
+        "msLAPS-Password",
+        "ms-MCS-AdmPwd",
+        "sAMAccountName",
+    ]
+    results = connection.search(searchFilter=search_filter, attributes=attributes, sizeLimit=0)
+
+    msMCSAdmPwd = ""
+    sAMAccountName = ""
+    username_laps = ""
+
+    from impacket.ldap import ldapasn1 as ldapasn1_impacket
+
+    results = [r for r in results if isinstance(r, ldapasn1_impacket.SearchResultEntry)]
+    if len(results) != 0:
+        for host in results:
+            values = {str(attr["type"]).lower(): attr["vals"][0] for attr in host["attributes"]}
+            if "mslaps-encryptedpassword" in values:
+                msMCSAdmPwd = values["mslaps-encryptedpassword"]
+                d = LAPSv2Extract(bytes(msMCSAdmPwd), username[0] if username else "", password[0] if password else "", domain, ntlm_hash[0] if ntlm_hash else "", self.args.kerberos, self.args.kdcHost, 339)
+                try:
+                    data = d.run()
+                except Exception as e:
+                    self.logger.fail(str(e))
+                    return None
+                r = loads(data)
+                msMCSAdmPwd = r["p"]
+                username_laps = r["n"]
+            elif "mslaps-password" in values:
+                r = loads(str(values["mslaps-password"]))
+                msMCSAdmPwd = r["p"]
+                username_laps = r["n"]
+            elif "ms-mcs-admpwd" in values:
+                msMCSAdmPwd = str(values["ms-mcs-admpwd"])
+            else:
+                self.logger.fail("No result found with attribute ms-MCS-AdmPwd or msLAPS-Password")
+        self.logger.debug(f"Host: {sAMAccountName:<20} Password: {msMCSAdmPwd} {self.hostname}")
+    else:
+        self.logger.fail(f"msMCSAdmPwd or msLAPS-Password is empty or account cannot read LAPS property for {self.hostname}")
+
+        return False
+
+    self.username = username_laps if username_laps else self.args.laps
+    self.password = msMCSAdmPwd
+
+    if msMCSAdmPwd == "":
+        self.logger.fail(f"msMCSAdmPwd or msLAPS-Password is empty or account cannot read LAPS property for {self.hostname}")
+
+        return False
+    if ntlm_hash:
+        hash_ntlm = hashlib.new("md4", msMCSAdmPwd.encode("utf-16le")).digest()
+        self.hash = binascii.hexlify(hash_ntlm).decode()
+
+    self.args.local_auth = True
+    self.domain = self.hostname
+    self.logger.extra["protocol"] = prev_protocol
+    self.logger.extra["port"] = prev_port
+    return True

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -419,23 +419,19 @@ class smb(connection):
         lmhash = ""
         nthash = ""
         try:
-            if not self.args.laps:
-                self.username = username
-                # This checks to see if we didn't provide the LM Hash
-                if ntlm_hash.find(":") != -1:
-                    lmhash, nthash = ntlm_hash.split(":")
-                    self.hash = nthash
-                else:
-                    nthash = ntlm_hash
-                    self.hash = ntlm_hash
-                if lmhash:
-                    self.lmhash = lmhash
-                if nthash:
-                    self.nthash = nthash
-            else:
-                nthash = self.hash
-
             self.domain = domain
+            self.username = username
+            # This checks to see if we didn't provide the LM Hash
+            if ntlm_hash.find(":") != -1:
+                lmhash, nthash = ntlm_hash.split(":")
+                self.hash = nthash
+            else:
+                nthash = ntlm_hash
+                self.hash = ntlm_hash
+            if lmhash:
+                self.lmhash = lmhash
+            if nthash:
+                self.nthash = nthash
 
             self.conn.login(self.username, "", domain, lmhash, nthash)
 

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -99,9 +99,6 @@ class winrm(connection):
         self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
         self.logger.extra["port"] = self.port
         self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
-
-        if self.args.laps:
-            return laps_search(self.args.username, self.args.password, self.args.hash, self.domain)
         return True
 
     def create_conn_obj(self):
@@ -154,9 +151,8 @@ class winrm(connection):
 
     def plaintext_login(self, domain, username, password):
         self.admin_privs = False
-        if not self.args.laps:
-            self.password = password
-            self.username = username
+        self.password = password
+        self.username = username
         self.domain = domain
         try:
             self.conn = Client(

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -17,7 +17,6 @@ from nxc.config import process_secret
 from nxc.connection import connection
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.misc import gen_random_string
-from nxc.protocols.ldap.laps import laps_search
 from nxc.logger import NXCAdapter
 
 

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -190,15 +190,13 @@ class winrm(connection):
         self.admin_privs = False
         lmhash = "00000000000000000000000000000000"
         nthash = ""
-        if not self.args.laps:
-            self.username = username
-            # This checks to see if we didn't provide the LM Hash
-            if ntlm_hash.find(":") != -1:
-                lmhash, nthash = ntlm_hash.split(":")
-            else:
-                nthash = ntlm_hash
+        self.username = username
+        # This checks to see if we didn't provide the LM Hash
+        if ntlm_hash.find(":") != -1:
+            lmhash, nthash = ntlm_hash.split(":")
         else:
-            nthash = self.hash
+            nthash = ntlm_hash
+
         self.lmhash = lmhash
         self.nthash = nthash
         self.domain = domain


### PR DESCRIPTION
Restructured the `--laps` login method which should work now with all login methods like database credentials for example (not multiple user at once, but that doesn't make sense anyway right?!).
Fixes #47 

<img width="688" alt="image" src="https://github.com/Pennyw0rth/NetExec/assets/61382599/31e0e025-62ea-4f84-a5f7-545fe873c796">

My kerberos login with laps didnt work tho, so this must be thoroughly tested!

@mpgn it seemed to support hash login, but does that make sense in combination with laps? When would that happen? Maybe i missed something here with the hash functionality, but so far its not needed and will always do the plaintext login.