### PR TITLE
Add a cli flag to hide host information

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -34,6 +34,7 @@ def gen_cli_args():
     parser.add_argument("--timeout", default=None, type=int, help="max timeout in seconds of each thread (default: None)")
     parser.add_argument("--jitter", metavar="INTERVAL", type=str, help="sets a random delay between each connection (default: None)")
     parser.add_argument("--no-progress", action="store_true", help="Not displaying progress bar during scan")
+    parser.add_argument("--no-host-info", action="store_true", help="Not displaying operating system information")
     parser.add_argument("--verbose", action="store_true", help="enable verbose output")
     parser.add_argument("--debug", action="store_true", help="enable debug level information")
     parser.add_argument("--version", action="store_true", help="Display nxc version")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -292,18 +292,19 @@ class ldap(connection):
         self.output_filename = os.path.expanduser(f"~/.nxc/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-"))
 
     def print_host_info(self):
-        self.logger.debug("Printing host info for LDAP")
-        if self.args.no_smb:
-            self.logger.extra["protocol"] = "LDAP"
-            self.logger.extra["port"] = "389"
-            self.logger.display(f"Connecting to LDAP {self.hostname}")
-        else:
-            self.logger.extra["protocol"] = "SMB" if not self.no_ntlm else "LDAP"
-            self.logger.extra["port"] = "445" if not self.no_ntlm else "389"
-            signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
-            smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=["bold"]) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=["bold"])
-            self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({smbv1})")
-            self.logger.extra["protocol"] = "LDAP"
+        if not self.args.no_host_info:
+            self.logger.debug("Printing host info for LDAP")
+            if self.args.no_smb:
+                self.logger.extra["protocol"] = "LDAP"
+                self.logger.extra["port"] = "389"
+                self.logger.display(f"Connecting to LDAP {self.hostname}")
+            else:
+                self.logger.extra["protocol"] = "SMB" if not self.no_ntlm else "LDAP"
+                self.logger.extra["port"] = "445" if not self.no_ntlm else "389"
+                signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
+                smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=["bold"]) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=["bold"])
+                self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({smbv1})")
+                self.logger.extra["protocol"] = "LDAP"
         return True
 
     def kerberos_login(

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -105,10 +105,11 @@ class mssql(connection):
             self.conn.disconnect()
 
     def print_host_info(self):
-        self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
-        # if len(self.mssql_instances) > 0:
-        #     for i, instance in enumerate(self.mssql_instances):
-        #         for key in instance.keys():
+        if not self.args.no_host_info:
+            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+            # if len(self.mssql_instances) > 0:
+            #     for i, instance in enumerate(self.mssql_instances):
+            #         for key in instance.keys():
 
     def create_conn_obj(self):
         try:

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -97,11 +97,12 @@ class rdp(connection):
         )
 
     def print_host_info(self):
-        nla = colored(f"nla:{self.nla}", host_info_colors[3], attrs=["bold"]) if self.nla else colored(f"nla:{self.nla}", host_info_colors[2], attrs=["bold"])
-        if self.domain is None:
-            self.logger.display("Probably old, doesn't not support HYBRID or HYBRID_EX ({nla})")
-        else:
-            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain}) ({nla})")
+        if not self.args.no_host_info:
+            nla = colored(f"nla:{self.nla}", host_info_colors[3], attrs=["bold"]) if self.nla else colored(f"nla:{self.nla}", host_info_colors[2], attrs=["bold"])
+            if self.domain is None:
+                self.logger.display("Probably old, doesn't not support HYBRID or HYBRID_EX ({nla})")
+            else:
+                self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain}) ({nla})")
         return True
 
     def create_conn_obj(self):

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -346,11 +346,12 @@ class smb(connection):
         return True
 
     def print_host_info(self):
-        signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
-        smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=["bold"]) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=["bold"])
-        self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({smbv1})")
-        if self.args.laps:
-            return self.laps_search(self.args.username, self.args.password, self.args.hash, self.domain)
+        if not self.args.no_host_info:
+            signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
+            smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=["bold"]) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=["bold"])
+            self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({smbv1})")
+            if self.args.laps:
+                return self.laps_search(self.args.username, self.args.password, self.args.hash, self.domain)
         return True
 
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):

--- a/nxc/protocols/ssh.py
+++ b/nxc/protocols/ssh.py
@@ -52,7 +52,8 @@ class ssh(connection):
         )
 
     def print_host_info(self):
-        self.logger.display(self.remote_version if self.remote_version != "Unknown SSH Version" else f"{self.remote_version}, skipping...")
+        if not self.args.no_host_info:
+            self.logger.display(self.remote_version if self.remote_version != "Unknown SSH Version" else f"{self.remote_version}, skipping...")
         return True
 
     def enum_host_info(self):

--- a/nxc/protocols/vnc.py
+++ b/nxc/protocols/vnc.py
@@ -46,7 +46,8 @@ class vnc(connection):
         )
 
     def print_host_info(self):
-        self.logger.display(f"VNC connecting to {self.hostname}")
+        if not self.args.no_host_info:
+            self.logger.display(f"VNC connecting to {self.hostname}")
 
     def create_conn_obj(self):
         try:

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -183,19 +183,20 @@ class winrm(connection):
         return True
 
     def print_host_info(self):
-        if self.args.no_smb:
-            self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
-            self.logger.extra["port"] = self.port
-            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
-        else:
-            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
-            self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
-            self.logger.extra["port"] = self.port
-        
-        self.logger.info(f"Connection information: {self.endpoint} (auth type:{self.auth_type}) (domain:{self.domain if self.args.domain else ''})")
+        if not self.args.no_host_info:
+            if self.args.no_smb:
+                self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
+                self.logger.extra["port"] = self.port
+                self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+            else:
+                self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+                self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
+                self.logger.extra["port"] = self.port
+            
+            self.logger.info(f"Connection information: {self.endpoint} (auth type:{self.auth_type}) (domain:{self.domain if self.args.domain else ''})")
 
-        if self.args.laps:
-            return self.laps_search(self.args.username, self.args.password, self.args.hash, self.domain)
+            if self.args.laps:
+                return self.laps_search(self.args.username, self.args.password, self.args.hash, self.domain)
         return True
 
     def create_conn_obj(self):

--- a/nxc/protocols/wmi.py
+++ b/nxc/protocols/wmi.py
@@ -159,9 +159,10 @@ class wmi(connection):
         self.output_filename = os.path.expanduser(f"~/.nxc/logs/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-"))
 
     def print_host_info(self):
-        self.logger.extra["protocol"] = "RPC"
-        self.logger.extra["port"] = "135"
-        self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
+        if not self.args.no_host_info:
+            self.logger.extra["protocol"] = "RPC"
+            self.logger.extra["port"] = "135"
+            self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
         return True
 
     def check_if_admin(self):


### PR DESCRIPTION
I added a global flag `--no-host-info` to hide informative lines. This unclutters nxc's output in very big networks where a lot of these lines could be produced and are not always useful for the pentester.

Without the flag:
```
SMB         192.168.101.5   445    InZOdIOG         [*] hooOjYWh (name:InZOdIOG) (domain:InZOdIOG) (signing:False) (SMBv1:True)
SMB         192.168.101.5   445    InZOdIOG         [+] InZOdIOG\toto:tata 
```
With `--no-host-info`:
```
└──╼ $poetry run NetExec --no-host-info smb 192.168.101.0/24 -u toto -p tata --local-auth
SMB         192.168.101.5   445    InZOdIOG         [+] InZOdIOG\toto:tata 
```