### PR TITLE
Fix: iis module cmd exec quotes

### DIFF
--- a/nxc/modules/appcmd.py
+++ b/nxc/modules/appcmd.py
@@ -37,7 +37,7 @@ class NXCModule:
             return
 
     def execute_appcmd(self, context, connection):
-        command = "powershell -c 'C:\\windows\\system32\\inetsrv\\appcmd.exe list apppool /@t:*'"
+        command = 'powershell -c "C:\\windows\\system32\\inetsrv\\appcmd.exe list apppool /@t:*"'
         context.log.info("Checking For Hidden Credentials With Appcmd.exe")
         output = connection.execute(command, True)
 


### PR DESCRIPTION
Came across a quote issue with the IIS module and the command was failing, thus not parsing any data.
Inverted `"` with `'`

![quote_fix_ncx](https://github.com/Pennyw0rth/NetExec/assets/44100908/024ce271-67b3-4286-9a3c-9a6d7ded005e)