### PR TITLE
Remove domain DN from ldap query, fixes #144

### DIFF
--- a/nxc/modules/trust.py
+++ b/nxc/modules/trust.py
@@ -17,12 +17,11 @@ class NXCModule:
         pass
 
     def on_login(self, context, connection):
-        domain_dn = ",".join(["DC=" + dc for dc in connection.domain.split(".")])
         search_filter = "(&(objectClass=trustedDomain))"
         attributes = ["flatName", "trustPartner", "trustDirection", "trustAttributes"]
 
         context.log.debug(f"Search Filter={search_filter}")
-        resp = connection.ldapConnection.search(searchBase=domain_dn, searchFilter=search_filter, attributes=attributes, sizeLimit=0)
+        resp = connection.ldapConnection.search(searchFilter=search_filter, attributes=attributes, sizeLimit=0)
 
         trusts = []
         context.log.debug(f"Total of records returned {len(resp)}")


### PR DESCRIPTION
As the DN of the domain is not needed we can remove it to fix the ldap search when using the NetBIOS name of the domain to login.
Fixes #144 

<img width="633" alt="image" src="https://github.com/Pennyw0rth/NetExec/assets/61382599/00b5d4a4-0008-4906-bb72-4ba9f941d659">
