### PR TITLE
Fixing module name check with windows backspace path

### DIFF
--- a/nxc/loaders/moduleloader.py
+++ b/nxc/loaders/moduleloader.py
@@ -24,7 +24,7 @@ class ModuleLoader:
         if not hasattr(module, "name"):
             self.logger.fail(f"{module_path} missing the name variable")
             module_error = True
-        elif hasattr(module, "name") and module.name != module_path.split("/")[-1][:-3]:
+        elif hasattr(module, "name") and module.name != module_path.split("/")[-1].split("\\")[-1][:-3]:
             self.logger.fail(f"{module_path} filename must match the module name {module.name}")
             module_error = True
         elif not hasattr(module, "description"):


### PR DESCRIPTION
Fixes #154.
Tested on Windows and Linux.
Previously the name check for modules were made on the assumption that the path is split by `/`. This is obviously not the case for windows so this PR also splits the path at `\` fixing the check for windows.