### PR TITLE
[FIX][MAC] Fix dependency error `aardwolf` installing via `PIPX` on MacOS ARM

### DIFF
--- a/fix-mac-issue.md
+++ b/fix-mac-issue.md
@@ -5,13 +5,13 @@ The other day trying to install `NetExec` on MacOS ARM arch ( M2 Pro ) I got the
 ```bash
 $ pipx install git+https://github.com/PennywOrth/NetExec --force
   Fatal error from pip prevented installation. Full pip output in file:
-  /Users/0xh311x/.local/pipx/logs/cmd_2024-02-15_01.41.45._pip_errors.log
-pip failed to build package:
-  aardwolf
-Some possibly relevant errors from pip install:
-  error: subprocess-exited-with-error error: can't find Rust compiler
-  Error installing netexec from
-spec 'gitthttps://github.com/PennywOrth/NetExeC'
+    /Users/0xh311x/.local/pipx/logs/cmd_2024-02-15_01.41.45._pip_errors.log
+  pip failed to build package:
+    aardwolf
+  Some possibly relevant errors from pip install:
+    error: subprocess-exited-with-error error: can't find Rust compiler
+    Error installing netexec from
+  spec 'gitthttps://github.com/PennywOrth/NetExeC'
 ```
 
 # Quick fix

--- a/fix-mac-issue.md
+++ b/fix-mac-issue.md
@@ -1,0 +1,22 @@
+# Quick explanation about the issue.
+
+The other day trying to install `NetExec` on MacOS ARM arch ( M2 Pro ) I got the following error:
+
+```bash
+$ pipx install git+https://github.com/PennywOrth/NetExec --force
+  Fatal error from pip prevented installation. Full pip output in file:
+  /Users/0xh311x/.local/pipx/logs/cmd_2024-02-15_01.41.45._pip_errors.log
+pip failed to build package:
+  aardwolf
+Some possibly relevant errors from pip install:
+  error: subprocess-exited-with-error error: can't find Rust compiler
+  Error installing netexec from
+spec 'gitthttps://github.com/PennywOrth/NetExeC'
+```
+
+# Quick fix
+
+You need to install / re-install your `rust` compiler using `homebrew`
+```bash
+brew install rust
+```


### PR DESCRIPTION
Hi all!!

I just want to help adding some info on the following issue 

![image](https://github.com/Pennyw0rth/NetExec/assets/62616592/0668bbd8-16a0-4bbc-abf5-269259be2868)

The error I was getting when installing it via `PIPX` on my *Macbook M2 Pro* was as follows:

![image](https://github.com/Pennyw0rth/NetExec/assets/62616592/bc7e00de-c5f6-487d-b7d5-b5bec094f346)

It is fixed by installing / reinstalling the rust compiler on the mackbook (the brew version works great).

```bash
$ brew install rust
```
![image](https://github.com/Pennyw0rth/NetExec/assets/62616592/0a2b4d9d-2e40-4b4d-8007-132e0d467cb1)

In case someone has the error and can help you! ❤️

![image](https://github.com/Pennyw0rth/NetExec/assets/62616592/b231b6f9-688c-475e-80dc-c3646e15bb57)

