### PR TITLE
Write without delete will now be displayed as write access

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -741,12 +741,18 @@ class smb(connection):
             if not self.args.no_write_check:
                 try:
                     self.conn.createDirectory(share_name, temp_dir)
-                    self.conn.deleteDirectory(share_name, temp_dir)
                     write = True
                     share_info["access"].append("WRITE")
                 except SessionError as e:
                     error = get_error_string(e)
-                    self.logger.debug(f"Error checking WRITE access on share: {error}")
+                    self.logger.debug(f"Error checking WRITE access on share {share_name}: {error}")
+
+                if write:
+                    try:
+                        self.conn.deleteDirectory(share_name, temp_dir)
+                    except SessionError as e:
+                        error = get_error_string(e)
+                        self.logger.debug(f"Error DELETING created temp dir {temp_dir} on share {share_name}: {error}")
 
             permissions.append(share_info)
 


### PR DESCRIPTION
Write without delete privileges will now be displayed as write access when enumerating shares:

![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/7c0ab189-c6b7-4e5d-8209-f30e602ded93)
