### PR TITLE
Remove unnecessary remote ops check

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1258,12 +1258,11 @@ class smb(connection):
                     os.remove(download_path)
 
     def enable_remoteops(self):
-        if self.remote_ops is not None and self.bootkey is not None:
-            return
         try:
             self.remote_ops = RemoteOperations(self.conn, self.kerberos, self.kdcHost)
             self.remote_ops.enableRegistry()
-            self.bootkey = self.remote_ops.getBootKey()
+            if self.bootkey is None:
+                self.bootkey = self.remote_ops.getBootKey()
         except Exception as e:
             self.logger.fail(f"RemoteOperations failed: {e}")
 


### PR DESCRIPTION
Impacket checks if remote ops is already running on the target system. If it does it does not "start it again", therefore we can remove the check in nxc.
Besides that, it intruduces a bug where, if we want to use remote ops, but it has been closed without setting the `self.remote_ops` variable to None, nxc thinks remote_ops are running, leading to a crash inside impacket. This happens for example if the target has not rrp running and we do `--sam` together with `--lsa` (lsa dump will not succeed, because of missing remote ops).