### PR TITLE
[ldap-checker] Module fix

### DIFF
--- a/nxc/modules/ldap-checker.py
+++ b/nxc/modules/ldap-checker.py
@@ -9,7 +9,7 @@ from asyauth.common.constants import asyauthSecret
 from asyauth.common.credentials.ntlm import NTLMCredential
 from asyauth.common.credentials.kerberos import KerberosCredential
 
-from asysocks.unicomm.common.target import UniTarget, UniProto, UniSSL
+from asysocks.unicomm.common.target import UniTarget, UniProto
 import sys
 
 
@@ -131,12 +131,14 @@ class NXCModule:
                 if err is not None:
                     errstr = str(err).lower()
                     if "stronger" in errstr:
-                        return True #because LDAP server signing requirements ARE enforced
+                        return True 
+                        # because LDAP server signing requirements ARE enforced
                     else:
                         context.log.fail(str(err))
                 else:
-                    #LDAPS bind successful
-                    return False #because LDAP server signing requirements are not enforced
+                    # LDAPS bind successful
+                    return False 
+                    # because LDAP server signing requirements are not enforced
             except Exception as e:
                 context.log.debug(str(e))
                 return False

--- a/nxc/modules/ldap-checker.py
+++ b/nxc/modules/ldap-checker.py
@@ -39,10 +39,15 @@ class NXCModule:
         async def run_ldaps_noEPA(target, credential):
             ldapsClientConn = MSLDAPClientConnection(target, credential)
             _, err = await ldapsClientConn.connect()
+            
+            # Required step to try to bind without channel binding
+            ldapsClientConn.cb_data = None
+
             if err is not None:
                 context.log.fail("ERROR while connecting to " + str(connection.domain) + ": " + str(err))
                 sys.exit()
-            _, err = await ldapsClientConn.bind()
+
+            valid, err = await ldapsClientConn.bind()
             if "data 80090346" in str(err):
                 return True  # channel binding IS enforced
             elif "data 52e" in str(err):
@@ -116,9 +121,13 @@ class NXCModule:
         async def run_ldap(target, credential):
             ldapsClientConn = MSLDAPClientConnection(target, credential)
             _, err = await ldapsClientConn.connect()
+            
+            # Intentionnaly breaking the security context
+            ldapsClientConn.cb_data = None
+
             if err is None:
                 _, err = await ldapsClientConn.bind()
-                if "stronger" in str(err):
+                if "AcceptSecurityContext" in str(err):
                     return True  # because LDAP server signing requirements ARE enforced
                 elif ("data 52e") in str(err):
                     context.log.fail("Not connected... exiting")
@@ -148,9 +157,8 @@ class NXCModule:
                 stype=stype,
             )
 
-        target = MSLDAPTarget(connection.host, hostname=connection.hostname, domain=connection.domain, dc_ip=connection.domain)
+        target = MSLDAPTarget(connection.host, 636,UniProto.CLIENT_SSL_TCP, hostname=connection.hostname, domain=connection.domain, dc_ip=connection.domain)
         ldapIsProtected = asyncio.run(run_ldap(target, credential))
-
         if ldapIsProtected is False:
             context.log.highlight("LDAP Signing NOT Enforced!")
         elif ldapIsProtected is True:
@@ -162,7 +170,7 @@ class NXCModule:
         if DoesLdapsCompleteHandshake(connection.host) is True:
             target = MSLDAPTarget(connection.host, 636, UniProto.CLIENT_SSL_TCP, hostname=connection.hostname, domain=connection.domain, dc_ip=connection.domain)
             ldapsChannelBindingAlwaysCheck = asyncio.run(run_ldaps_noEPA(target, credential))
-            target = MSLDAPTarget(connection.host, hostname=connection.hostname, domain=connection.domain, dc_ip=connection.domain)
+            target = MSLDAPTarget(connection.host, 636, UniProto.CLIENT_SSL_TCP, hostname=connection.hostname, domain=connection.domain, dc_ip=connection.domain)
             ldapsChannelBindingWhenSupportedCheck = asyncio.run(run_ldaps_withEPA(target, credential))
             if ldapsChannelBindingAlwaysCheck is False and ldapsChannelBindingWhenSupportedCheck is True:
                 context.log.highlight('LDAPS Channel Binding is set to "When Supported"')


### PR DESCRIPTION
This PR fix ldap-checker module with the use of msldap
msldap 0.5.10 is required for the module to work properly