### PR TITLE
BloodHound & hash_spider fixes

### DIFF
--- a/nxc/data/nxc.conf
+++ b/nxc/data/nxc.conf
@@ -13,7 +13,7 @@ bh_enabled = False
 bh_uri = 127.0.0.1
 bh_port = 7687
 bh_user = neo4j
-bh_pass = neo4j
+bh_pass = bloodhoundcommunityedition
 
 [Empire]
 api_host = 127.0.0.1

--- a/nxc/helpers/bloodhound.py
+++ b/nxc/helpers/bloodhound.py
@@ -52,14 +52,14 @@ def add_user_bh(user, domain, logger, config):
                         _add_with_domain(user_info, domain, tx, logger)
         except AuthError:
             logger.fail(f"Provided Neo4J credentials ({config.get('BloodHound', 'bh_user')}:{config.get('BloodHound', 'bh_pass')}) are not valid.")
-            return
+            exit()
         except ServiceUnavailable:
             logger.fail(f"Neo4J does not seem to be available on {uri}.")
-            return
+            exit()
         except Exception as e:
             logger.fail(f"Unexpected error with Neo4J: {e}")
-            return
-        driver.close()
+        finally:
+            driver.close()
 
 
 def _add_with_domain(user_info, domain, tx, logger):

--- a/nxc/modules/hash_spider.py
+++ b/nxc/modules/hash_spider.py
@@ -146,7 +146,7 @@ class NXCModule:
 
     @staticmethod
     def save_credentials(context, connection, domain, username, password, lmhash, nthash):
-        host_id = context.db.get_computers(connection.host)[0][0]
+        host_id = context.db.get_hosts(connection.host)[0][0]
         if password is not None:
             credential_type = "plaintext"
         else:


### PR DESCRIPTION
- fail out right away if BloodHound is enabled and authentication fails to the BH API or if the URL isn't available
- fix old db function call for hosts in hash_spider; fixes #221 
- update default bloodhound neo4j password, as the docker compose file from them uses a new password by default