### PR TITLE
Several ldap bug fixes

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -661,7 +661,7 @@ class ldap(connection):
         attributes = ["objectSid"]
         resp = self.search(search_filter, attributes, sizeLimit=0)
         answers = []
-        if resp and self.password != "" and self.username != "":
+        if resp and (self.password != "" or self.lmhash != "" or self.nthash != "") and self.username != "":
             for attribute in resp[0][1]:
                 if str(attribute["type"]) == "objectSid":
                     sid = self.sid_to_str(attribute["vals"][0])

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -489,12 +489,15 @@ class ldap(connection):
                         f"{self.domain}\\{self.username}:{process_secret(self.password)} {ldap_error_status[error_code] if error_code in ldap_error_status else ''}",
                         color="magenta" if (error_code in ldap_error_status and error_code != 1) else "red",
                     )
+                    self.logger.fail("LDAPS channel binding might be enabled, this is only supported with kerberos authentication. Try using '-k'.")
             else:
                 error_code = str(e).split()[-2][:-1]
                 self.logger.fail(
                     f"{self.domain}\\{self.username}:{process_secret(self.password)} {ldap_error_status[error_code] if error_code in ldap_error_status else ''}",
                     color="magenta" if (error_code in ldap_error_status and error_code != 1) else "red",
                 )
+                if proto == "ldaps":
+                    self.logger.fail("LDAPS channel binding might be enabled, this is only supported with kerberos authentication. Try using '-k'.")
             return False
         except OSError as e:
             self.logger.fail(f"{self.domain}\\{self.username}:{process_secret(self.password)} {'Error connecting to the domain, are you sure LDAP service is running on the target?'} \nError: {e}")
@@ -582,12 +585,15 @@ class ldap(connection):
                         f"{self.domain}\\{self.username}:{process_secret(nthash)} {ldap_error_status[error_code] if error_code in ldap_error_status else ''}",
                         color="magenta" if (error_code in ldap_error_status and error_code != 1) else "red",
                     )
+                    self.logger.fail("LDAPS channel binding might be enabled, this is only supported with kerberos authentication. Try using '-k'.")
             else:
                 error_code = str(e).split()[-2][:-1]
                 self.logger.fail(
                     f"{self.domain}\\{self.username}:{process_secret(nthash)} {ldap_error_status[error_code] if error_code in ldap_error_status else ''}",
                     color="magenta" if (error_code in ldap_error_status and error_code != 1) else "red",
                 )
+                if proto == "ldaps":
+                    self.logger.fail("LDAPS channel binding might be enabled, this is only supported with kerberos authentication. Try using '-k'.")
             return False
         except OSError as e:
             self.logger.fail(f"{self.domain}\\{self.username}:{process_secret(self.password)} {'Error connecting to the domain, are you sure LDAP service is running on the target?'} \nError: {e}")


### PR DESCRIPTION
If ldap channel binding is enforced and LDAPS is used impacket only reports "invalidCredentials" as error code. As channel binding is only allowed with kerberos this will now be hinted, so the user also tries kerberos auth. Only applicable to LDAPS of course:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/1f4a99a9-aece-4502-8b9a-a21f0c47fba4)

Fixed wrong port displayed if an error occurs while authenticating (for example wrong credentials):
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/a9bf6cbf-f3f1-44a9-9e95-3d9a51122cee)

Fixed not identifying the user as DA if using hash login:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/e3f52d77-802f-49ab-9aac-8dd22b85e1df)

Also did some formating :)