### PR TITLE
Module 'get-desc-users' Update - Marshall's #201 Issue Bug Fix

### DIFF
--- a/nxc/modules/get-desc-users.py
+++ b/nxc/modules/get-desc-users.py
@@ -103,7 +103,7 @@ class NXCModule:
                         conditionPasswordPolicy = True
 
                 if conditionFilter and not self.PASSWORDPOLICY:
-                    context.log.highlight(f"'{self.FILTER}'  found in description: '{description}'")
+                    context.log.highlight(f"'{self.FILTER}' found in description: '{description}'")
                 elif (self.FILTER == "" and (conditionPasswordPolicy == self.PASSWORDPOLICY)):
                     answersFiltered.append([answer[0], description])
                 elif (self.FILTER != "" and conditionFilter) and (conditionPasswordPolicy == self.PASSWORDPOLICY):


### PR DESCRIPTION
Regex edited and output lines added.

```
NetExec ldap 192.168.37.101 -u userd1 -p '$Password' -M get-desc-users              
SMB         192.168.37.101  445    DC2              [*] Windows Server 2022 Datacenter Evaluation 20348 x64 (name:DC2) (domain:test.local) (signing:True) (SMBv1:True)
LDAP        192.168.37.101  389    DC2              [+] test.local\userd1:$Password 
GET-DESC... 192.168.37.101  389    DC2              [+] Found following users: 
GET-DESC... 192.168.37.101  389    DC2              User: Administrator description: Built-in account for administering the computer/domain
GET-DESC... 192.168.37.101  389    DC2              User: Guest description: Built-in account for guest access to the computer/domain
GET-DESC... 192.168.37.101  389    DC2              User: krbtgt description: Key Distribution Center Service Account
GET-DESC... 192.168.37.101  389    DC2              User: UserD1 description: Password!
                                                                                                                                                                            
NetExec ldap 192.168.37.101 -u userd1 -p '$Password' -M get-desc-users -o PASSWORDPOLICY=True MINLENGTH=8 
SMB         192.168.37.101  445    DC2              [*] Windows Server 2022 Datacenter Evaluation 20348 x64 (name:DC2) (domain:test.local) (signing:True) (SMBv1:True)
LDAP        192.168.37.101  389    DC2              [+] test.local\userd1:$Password 
GET-DESC... 192.168.37.101  389    DC2              [+] Found following users: 
GET-DESC... 192.168.37.101  389    DC2              User: UserD1 description: Password!
                                                                                                                                                                            
NetExec ldap 192.168.37.101 -u userd1 -p '$Password' -M get-desc-users -o PASSWORDPOLICY=True MINLENGTH=8 FILTER='!'
SMB         192.168.37.101  445    DC2              [*] Windows Server 2022 Datacenter Evaluation 20348 x64 (name:DC2) (domain:test.local) (signing:True) (SMBv1:True)
LDAP        192.168.37.101  389    DC2              [+] test.local\userd1:$Password 
GET-DESC... 192.168.37.101  389    DC2              '!' found in user: 'UserD1' description: 'Password!'
                                                                                                                                                                            
NetExec ldap 192.168.37.101 -u userd1 -p '$Password' -M get-desc-users -o FILTER='!'                   
SMB         192.168.37.101  445    DC2              [*] Windows Server 2022 Datacenter Evaluation 20348 x64 (name:DC2) (domain:test.local) (signing:True) (SMBv1:True)
LDAP        192.168.37.101  389    DC2              [+] test.local\userd1:$Password 
GET-DESC... 192.168.37.101  389    DC2              '!' found in description: 'Password!'
                                                                                                                                                                            
NetExec ldap 192.168.37.101 -u userd1 -p '$Password' -M get-desc-users -o FILTER='$'
SMB         192.168.37.101  445    DC2              [*] Windows Server 2022 Datacenter Evaluation 20348 x64 (name:DC2) (domain:test.local) (signing:True) (SMBv1:True)
LDAP        192.168.37.101  389    DC2              [+] test.local\userd1:$Password 
```