### PR TITLE
Logging in DEBUG mode: change normal output from DEBUG to INFO

### DIFF
--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -18,7 +18,7 @@ def create_temp_logger(caller_frame, formatted_text, args, kwargs):
     temp_logger = logging.getLogger("temp")
     formatter = logging.Formatter("%(message)s", datefmt="[%X]")
     handler = SmartDebugRichHandler(formatter=formatter)
-    handler.handle(LogRecord(temp_logger.name, logging.DEBUG, caller_frame.f_code.co_filename, caller_frame.f_lineno, formatted_text, args, kwargs, caller_frame=caller_frame))
+    handler.handle(LogRecord(temp_logger.name, logging.INFO, caller_frame.f_code.co_filename, caller_frame.f_lineno, formatted_text, args, kwargs, caller_frame=caller_frame))
 
 
 class SmartDebugRichHandler(RichHandler):


### PR DESCRIPTION
per @NeffIsBack's request in my other PR that got merged already - just display the normally output data as INFO, so it's easier to see:

![image](https://github.com/Pennyw0rth/NetExec/assets/1518719/b92b2610-8c7c-4638-b2f8-47321b4e8f1b)