### PR TITLE
Neff qol the second

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -36,7 +36,7 @@ def gen_cli_args():
     {highlight('Codename', 'red')}: {highlight(CODENAME)}
     """, formatter_class=RawTextHelpFormatter)
 
-    parser.add_argument("-t", type=int, dest="threads", default=100, help="set how many concurrent threads to use (default: 100)")
+    parser.add_argument("-t", type=int, dest="threads", default=256, help="set how many concurrent threads to use (default: 256)")
     parser.add_argument("--timeout", default=None, type=int, help="max timeout in seconds of each thread (default: None)")
     parser.add_argument("--jitter", metavar="INTERVAL", type=str, help="sets a random delay between each connection (default: None)")
     parser.add_argument("--no-progress", action="store_true", help="Not displaying progress bar during scan")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -121,7 +121,10 @@ class connection:
         try:
             self.proto_flow()
         except Exception as e:
-            self.logger.exception(f"Exception while calling proto_flow() on target {self.host}: {e}")
+            if "ERROR_DEPENDENT_SERVICES_RUNNING" in str(e):
+                self.logger.error(f"Exception while calling proto_flow() on target {self.host}: {e}")
+            else:
+                self.logger.exception(f"Exception while calling proto_flow() on target {self.host}: {e}")
 
     @staticmethod
     def proto_args(std_parser, module_parser):

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -42,11 +42,11 @@ async def start_run(protocol_obj, args, db, targets):
     futures = []
     nxc_logger.debug("Creating ThreadPoolExecutor")
     if args.no_progress or len(targets) == 1:
-        with ThreadPoolExecutor(max_workers=args.threads + 1) as executor:
+        with ThreadPoolExecutor(max_workers=args.threads) as executor:
             nxc_logger.debug(f"Creating thread for {protocol_obj}")
             futures = [executor.submit(protocol_obj, args, db, target) for target in targets]
     else:
-        with Progress(console=nxc_console) as progress, ThreadPoolExecutor(max_workers=args.threads + 1) as executor:
+        with Progress(console=nxc_console) as progress, ThreadPoolExecutor(max_workers=args.threads) as executor:
             current = 0
             total = len(targets)
             tasks = progress.add_task(


### PR DESCRIPTION
Another small QOL PR with some neat stuff:

1. We can catch the ERROR_DEPENDENT_SERVICES_RUNNING as this is known and can happen in windows environments, there is no need for a large traceback every time
2. I increased the max_worker from threadpool to 265. This will allow to scan an entire subnet with one execution, so that you don't have to wait 3x for connection time outs as you would scan only 100 hosts at a time until now. This safes a lot of time when scanning larger ranges

Before and after for the error:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/80d056ac-d788-44b9-93c5-4613bf473c3f)
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/12e67e50-85df-4036-9d60-faa03ac1adc4)
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/ec1802f2-e250-4135-b677-1067c69c405f)

Time comparison between main branch and this one for an entire subnet:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/0a7e9b4e-d51c-4444-bff4-f58958142c3a)
