### PR TITLE
Fix tmp PATH on windows for msol and scuffy

### DIFF
--- a/nxc/modules/msol.py
+++ b/nxc/modules/msol.py
@@ -3,7 +3,7 @@
 # Based on the article : https://blog.xpnsec.com/azuread-connect-for-redteam/
 from sys import exit
 from os import path
-import sys
+from nxc.paths import TMP_PATH
 from nxc.helpers.powershell import get_ps_script
 
 
@@ -49,14 +49,14 @@ class NXCModule:
 
     def on_admin_login(self, context, connection):
         if self.use_embedded:
-            file_to_upload = "/tmp/msol.ps1"
+            file_to_upload =(f"{TMP_PATH}/msol.ps1")
 
             try:
                 with open(file_to_upload, "w") as msol:
                     msol.write(self.msol_embedded)
             except FileNotFoundError:
                 context.log.fail(f"Impersonate file specified '{file_to_upload}' does not exist!")
-                sys.exit(1)
+                exit(1)
             
         else:
             if path.isfile(self.MSOL_PS1):

--- a/nxc/modules/scuffy.py
+++ b/nxc/modules/scuffy.py
@@ -1,5 +1,6 @@
 import ntpath
 from sys import exit
+from nxc.paths import TMP_PATH
 
 
 class NXCModule:
@@ -44,7 +45,7 @@ class NXCModule:
             exit(1)
 
         self.scf_name = module_options["NAME"]
-        self.scf_path = f"/tmp/{self.scf_name}.scf"
+        self.scf_path = f"{TMP_PATH}/{self.scf_name}.scf"
         self.file_path = ntpath.join("\\", f"{self.scf_name}.scf")
 
         if not self.cleanup:


### PR DESCRIPTION
This fixes #145 as the temp directory from where the file should be uploaded was hardcoded to "/tmp/", which is not compatible to windows. Now fixed with using the TMP_PATH variable in NetExec.

