### PR TITLE
Add verbosity to dpapi, so the user knows if no secrets were found

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -257,7 +257,6 @@ class smb(connection):
         except Exception as e:
             self.logger.debug(f"Error logging off system: {e}")
 
-
     def print_host_info(self):
         signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
         smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=["bold"]) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=["bold"])
@@ -1010,7 +1009,6 @@ class smb(connection):
     def users(self):
         if len(self.args.users) > 0:
             self.logger.debug(f"Dumping users: {', '.join(self.args.users)}")
-             
         return UserSamrDump(self).dump(self.args.users)
 
     def hosts(self):
@@ -1491,12 +1489,14 @@ class smb(connection):
                 credential.url,
             )
 
-        if dump_cookies:
+        if dump_cookies and cookies:
             self.logger.display("Start Dumping Cookies")
             for cookie in cookies:
                 if cookie.cookie_value != "":
                     self.logger.highlight(f"[{credential.winuser}][{cookie.browser.upper()}] {cookie.host}{cookie.path} - {cookie.cookie_name}:{cookie.cookie_value}")
             self.logger.display("End Dumping Cookies")
+        elif dump_cookies:
+            self.logger.fail("No cookies found")
 
         vaults = []
         try:
@@ -1536,6 +1536,9 @@ class smb(connection):
                 credential.password,
                 credential.url,
             )
+
+        if not (credentials and system_credentials and browser_credentials and cookies and vaults and firefox_credentials):
+            self.logger.fail("No secrets found")
 
     @requires_admin
     def lsa(self):


### PR DESCRIPTION
Looking at #164 users find it confusing if there is no output when no secrets are found (and i can see why). Therefore i added a bit verbosity to print a fail message if no secrets or cookies are found:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/c5e82515-226b-409c-99fc-9a42b663c151)

ToDo issue was #168 