### PR TITLE
Fix bug where modules would be the same object across protocols

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -8,6 +8,7 @@ from socket import AF_UNSPEC, SOCK_DGRAM, IPPROTO_IP, AI_CANONNAME, getaddrinfo
 
 from nxc.config import pwned_label
 from nxc.helpers.logger import highlight
+from nxc.loaders.moduleloader import ModuleLoader
 from nxc.logger import nxc_logger, NXCAdapter
 from nxc.context import Context
 from nxc.protocols.ldap.laps import laps_search
@@ -145,16 +146,7 @@ class connection:
     def check_if_admin(self):
         return
 
-    def kerberos_login(
-        self,
-        domain,
-        username,
-        password="",
-        ntlm_hash="",
-        aesKey="",
-        kdcHost="",
-        useCache=False,
-    ):
+    def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
         return
 
     def plaintext_login(self, domain, username, password):
@@ -173,6 +165,7 @@ class connection:
             self.enum_host_info()
             if self.print_host_info() and (self.login() or (self.username == "" and self.password == "")):
                 if hasattr(self.args, "module") and self.args.module:
+                    self.load_modules()
                     self.logger.debug("Calling modules")
                     self.call_modules()
                 else:
@@ -206,7 +199,7 @@ class connection:
         It iterates over the modules specified in the command line arguments.
         For each module, it loads the module and creates a context object, then calls functions based on the module's attributes.
         """
-        for module in self.module:
+        for module in self.modules:
             self.logger.debug(f"Loading module {module.name} - {module}")
             module_logger = NXCAdapter(
                 extra={
@@ -491,3 +484,12 @@ class connection:
 
     def mark_pwned(self):
         return highlight(f"({pwned_label})" if self.admin_privs else "")
+
+    def load_modules(self):
+        self.logger.info(f"Loading modules for target: {self.host}")
+        loader = ModuleLoader(self.args, self.db, self.logger)
+        self.modules = []
+
+        for module_path in self.module_paths:
+            module = loader.init_module(module_path)
+            self.modules.append(module)

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -139,7 +139,8 @@ def main():
     nxc_logger.debug(f"Protocol DB Path: {protocol_db_path}")
 
     protocol_object = getattr(p_loader.load_protocol(protocol_path), args.protocol)
-    nxc_logger.debug(f"Protocol Object: {protocol_object}")
+    nxc_logger.debug(f"Protocol Object: {protocol_object}, type: {type(protocol_object)}")
+    nxc_logger.debug(f"Protocol Object dir: {dir(protocol_object)}")
     protocol_db_object = p_loader.load_protocol(protocol_db_path).database
     nxc_logger.debug(f"Protocol DB Object: {protocol_db_object}")
 
@@ -172,13 +173,15 @@ def main():
             nxc_logger.display(f"{module} module options:\n{modules[module]['options']}")
         exit(0)
     elif args.module:
-        nxc_logger.debug(f"Modules to be Loaded: {args.module}, {type(args.module)}")
+        # Check the modules for sanity before loading the protocol
+        nxc_logger.debug(f"Modules to be Loaded for sanity check: {args.module}, {type(args.module)}")
+        proto_module_paths = []
         for m in args.module:
             if m not in modules:
                 nxc_logger.error(f"Module not found: {m}")
                 exit(1)
 
-            nxc_logger.debug(f"Loading module {m} at path {modules[m]['path']}")
+            nxc_logger.debug(f"Loading module for sanity check {m} at path {modules[m]['path']}")
             module = loader.init_module(modules[m]["path"])
 
             if not module.opsec_safe:
@@ -186,22 +189,12 @@ def main():
                     nxc_logger.debug("ignore_opsec is set in the configuration, skipping prompt")
                     nxc_logger.display("Ignore OPSEC in configuration is set and OPSEC unsafe module loaded")
                 else:
-                    ans = input(
-                        highlight(
-                            "[!] Module is not opsec safe, are you sure you want to run this? [Y/n] For global configuration, change ignore_opsec value to True on ~/nxc/nxc.conf",
-                            "red",
-                        )
-                    )
+                    ans = input(highlight("[!] Module is not opsec safe, are you sure you want to run this? [Y/n] For global configuration, change ignore_opsec value to True on ~/nxc/nxc.conf", "red"))
                     if ans.lower() not in ["y", "yes", ""]:
                         exit(1)
 
             if not module.multiple_hosts and len(targets) > 1:
-                ans = input(
-                    highlight(
-                        "[!] Running this module on multiple hosts doesn't really make any sense, are you sure you want to continue? [Y/n] ",
-                        "red",
-                    )
-                )
+                ans = input(highlight("[!] Running this module on multiple hosts doesn't really make any sense, are you sure you want to continue? [Y/n] ", "red"))
                 if ans.lower() not in ["y", "yes", ""]:
                     exit(1)
 
@@ -212,21 +205,12 @@ def main():
                 if not args.server_port:
                     args.server_port = server_port_dict[args.server]
 
-            nxc_logger.debug(f"proto_object: {protocol_object}, type: {type(protocol_object)}")
-            nxc_logger.debug(f"proto object dir: {dir(protocol_object)}")
-            # get currently set modules, otherwise default to empty list
-            current_modules = getattr(protocol_object, "module", [])
-            current_modules.append(module)
-            protocol_object.module = current_modules
-            nxc_logger.debug(f"proto object module after adding: {protocol_object.module}")
+            # Add modules paths to the protocol object so it can load them itself
+            proto_module_paths.append(modules[m]["path"])
+        protocol_object.module_paths = proto_module_paths
 
     if hasattr(args, "ntds") and args.ntds and not args.userntds:
-        ans = input(
-            highlight(
-                "[!] Dumping the ntds can crash the DC on Windows Server 2019. Use the option --user <user> to dump a specific user safely or the module -M ntdsutil [Y/n] ",
-                "red",
-            )
-        )
+        ans = input(highlight("[!] Dumping the ntds can crash the DC on Windows Server 2019. Use the option --user <user> to dump a specific user safely or the module -M ntdsutil [Y/n] ", "red"))
         if ans.lower() not in ["y", "yes", ""]:
             exit(1)
 


### PR DESCRIPTION
As mentioned in https://github.com/Pennyw0rth/NetExec/pull/249#issuecomment-2041131931 modules were the same object across different targets resulting in potential variable overwrites on the module objects themselves. See issue in https://github.com/Pennyw0rth/NetExec/pull/249#issuecomment-2040326129

We will now only load specified modules at the beginning to do sanity checks (if we would do that in the protocol it would have already created connections and also print stuff multiple times). The modules are loaded in the protocol itself and only if specified.
Now we have different module objects for different protocols:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/8507a279-b458-4676-a4cb-fcee323a61ed)
