### PR TITLE
Fix "Too many open files"

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -14,6 +14,7 @@ from nxc.protocols.ldap.laps import laps_search
 
 from impacket.dcerpc.v5 import transport
 import sys
+import contextlib
 
 sem = BoundedSemaphore(1)
 global_failed_logins = 0
@@ -125,6 +126,10 @@ class connection:
                 self.logger.error(f"Exception while calling proto_flow() on target {self.host}: {e}")
             else:
                 self.logger.exception(f"Exception while calling proto_flow() on target {self.host}: {e}")
+        finally:
+            self.logger.debug(f"Closing connection to: {host}")
+            with contextlib.suppress(Exception):
+                self.conn.close()
 
     @staticmethod
     def proto_args(std_parser, module_parser):


### PR DESCRIPTION
Due to not properly closing the connection there are too many file descriptors when scanning large ranges. This Patch attempts to fix this problem, which resulted in a "Too many open files" exception.