### PR TITLE
ldap-checker: fix for Python 3.12 compatibility

### DIFF
--- a/nxc/modules/ldap-checker.py
+++ b/nxc/modules/ldap-checker.py
@@ -92,11 +92,12 @@ class NXCModule:
         def DoesLdapsCompleteHandshake(dcIp):
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(5)
-            ssl_sock = ssl.wrap_socket(
+            ssl_context = ssl.create_default_context()
+            ssl_context.check_hostname = False
+            ssl_sock = ssl_context.wrap_socket(
                 s,
-                cert_reqs=ssl.CERT_OPTIONAL,
-                suppress_ragged_eofs=False,
                 do_handshake_on_connect=False,
+                suppress_ragged_eofs=False,
             )
             ssl_sock.connect((dcIp, 636))
             try:


### PR DESCRIPTION
The `ldap-checker` module is currently not compatible with Python 3.12+ because `ssl.wrap_socket()` was deprecated and has been removed. Fixed this by using `SSLContext.wrap_socket()` instead.

While doing so, my code linter was complaining so I added a cleanup and code quality commit first. The commits are separate to make reviewing a cleanup commit and a compatibility fix commit easier.