### PR TITLE
Fixing #263

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -930,9 +930,10 @@ class ldap(connection):
             if len(answers) > 0:
                 for user in answers:
                     hash_TGT = KerberosAttacks(self).get_tgt_asroast(user[0])
-                    self.logger.highlight(f"{hash_TGT}")
-                    with open(self.args.asreproast, "a+") as hash_asreproast:
-                        hash_asreproast.write(f"{hash_TGT}\n")
+                    if hash_TGT:
+                        self.logger.highlight(f"{hash_TGT}")
+                        with open(self.args.asreproast, "a+") as hash_asreproast:
+                            hash_asreproast.write(f"{hash_TGT}\n")
                 return True
             else:
                 self.logger.highlight("No entries found!")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -330,7 +330,7 @@ class ldap(connection):
             if hash_tgt:
                 self.logger.highlight(f"{hash_tgt}")
                 with open(self.args.asreproast, "a+") as hash_asreproast:
-                    hash_asreproast.write(hash_tgt + "\n")
+                    hash_asreproast.write(f"{hash_tgt}\n")
             return False
 
         kerb_pass = next(s for s in [self.nthash, password, aesKey] if s) if not all(s == "" for s in [self.nthash, password, aesKey]) else ""
@@ -436,7 +436,7 @@ class ldap(connection):
             if hash_tgt:
                 self.logger.highlight(f"{hash_tgt}")
                 with open(self.args.asreproast, "a+") as hash_asreproast:
-                    hash_asreproast.write(hash_tgt + "\n")
+                    hash_asreproast.write(f"{hash_tgt}\n")
             return False
 
         try:
@@ -525,7 +525,7 @@ class ldap(connection):
             if hash_tgt:
                 self.logger.highlight(f"{hash_tgt}")
                 with open(self.args.asreproast, "a+") as hash_asreproast:
-                    hash_asreproast.write(hash_tgt + "\n")
+                    hash_asreproast.write(f"{hash_tgt}\n")
             return False
 
         try:
@@ -886,7 +886,7 @@ class ldap(connection):
             "lastLogon",
         ]
         resp = self.search(search_filter, attributes, 0)
-        if resp == []:
+        if resp is None:
             self.logger.highlight("No entries found!")
         elif resp:
             answers = []
@@ -930,10 +930,9 @@ class ldap(connection):
             if len(answers) > 0:
                 for user in answers:
                     hash_TGT = KerberosAttacks(self).get_tgt_asroast(user[0])
-                    hash_TGT = KerberosAttacks(self).get_tgt_asroast(user[0])
                     self.logger.highlight(f"{hash_TGT}")
                     with open(self.args.asreproast, "a+") as hash_asreproast:
-                        hash_asreproast.write(hash_TGT + "\n")
+                        hash_asreproast.write(f"{hash_TGT}\n")
                 return True
             else:
                 self.logger.highlight("No entries found!")

--- a/nxc/protocols/ldap/kerberos.py
+++ b/nxc/protocols/ldap/kerberos.py
@@ -1,6 +1,7 @@
 import random
 from binascii import hexlify, unhexlify
 from datetime import datetime, timedelta
+import traceback
 try:
     # This is only available in python >= 3.11
     # if we are in a lower version, we will use the deprecated utcnow() method
@@ -237,7 +238,8 @@ class KerberosAttacks:
             elif e.getErrorCode() == constants.ErrorCodes.KDC_ERR_KEY_EXPIRED.value:
                 return f"Password of user {userName} expired but user doesn't require pre-auth"
             else:
-                nxc_logger.exception(e)
+                nxc_logger.fail(e)
+                nxc_logger.debug(traceback.format_exc())
                 return None
 
         # This should be the PREAUTH_FAILED packet or the actual TGT if the target principal has the

--- a/nxc/protocols/ldap/kerberos.py
+++ b/nxc/protocols/ldap/kerberos.py
@@ -1,6 +1,13 @@
 import random
 from binascii import hexlify, unhexlify
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta
+try:
+    # This is only available in python >= 3.11
+    # if we are in a lower version, we will use the deprecated utcnow() method
+    from datetime import UTC
+    utc_failed = False
+except ImportError:
+    utc_failed = True
 from os import getenv
 
 from impacket.krb5 import constants
@@ -203,7 +210,8 @@ class KerberosAttacks:
             return None
 
         req_body["realm"] = domain
-        now = datetime.now(UTC) + timedelta(days=1)
+        # When we drop python 3.10 support utcnow() can be removed, as it is deprecated
+        now = datetime.utcnow() + timedelta(days=1) if utc_failed else datetime.now(UTC) + timedelta(days=1)
         req_body["till"] = KerberosTime.to_asn1(now)
         req_body["rtime"] = KerberosTime.to_asn1(now)
         req_body["nonce"] = random.getrandbits(31)


### PR DESCRIPTION
Fixes #263 by changing return value from `False` to `None` to match expected value, when handling errors. Also add a bit of error handling (to actually display the correct error) and string concatenation to prevent errors such as these in the future.

Before:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/d5c4e52f-e100-4dc8-9cca-bc41990774d1)

After:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/ffe6a2f3-c828-4091-b086-fd739c3b6a6e)
