### PR TITLE
fix mssql_priv

### DIFF
--- a/nxc/modules/adcs.py
+++ b/nxc/modules/adcs.py
@@ -27,7 +27,6 @@ class NXCModule:
         SERVER             PKI Enrollment Server to enumerate templates for. Default is None, use CN name
         BASE_DN            The base domain name for the LDAP query
         """
-        self.context = context
         self.regex = re.compile("(https?://.+)")
 
         self.server = None
@@ -39,6 +38,7 @@ class NXCModule:
 
     def on_login(self, context, connection):
         """On a successful LDAP login we perform a search for all PKI Enrollment Server or Certificate Templates Names."""
+        self.context = context
         if self.server is None:
             search_filter = "(objectClass=pKIEnrollmentService)"
         else:

--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -221,7 +221,6 @@ class NXCModule:
 
         Based on the work of @_nwodtuhs and @BlWasp_.
         """
-        self.context = context
 
         context.log.debug(f"module_options: {module_options}")
 
@@ -273,6 +272,7 @@ class NXCModule:
         self.filename = None
 
     def on_login(self, context, connection):
+        self.context = context
         """On a successful LDAP login we perform a search for the targets' SID, their Security Descriptors and the principal's SID if there is one specified"""
         context.log.highlight("Be careful, this module cannot read the DACLS recursively.")
         self.baseDN = connection.ldapConnection._baseDN

--- a/nxc/modules/mssql_priv.py
+++ b/nxc/modules/mssql_priv.py
@@ -42,12 +42,12 @@ class NXCModule:
             - rollback (remove sysadmin privilege)
         """
         self.action = None
-        self.context = context
 
         if "ACTION" in module_options:
             self.action = module_options["ACTION"]
 
     def on_login(self, context, connection):
+        self.context = context
         # get mssql connection
         self.mssql_conn = connection.conn
         # fetch the current user

--- a/nxc/modules/mssql_priv.py
+++ b/nxc/modules/mssql_priv.py
@@ -440,14 +440,15 @@ class NXCModule:
         :return: True if the username belongs to an admin user, False otherwise.
         :rtype: bool
         """
-        res = self.query_and_get_output(f"SELECT IS_SRVROLEMEMBER('sysadmin', '{username}')")
-        try:
-            if int(res):
-                self.admin_privs = True
-                return True
-            else:
-                return False
-        except Exception:
+        res = self.query_and_get_output(exec_as + "SELECT IS_SRVROLEMEMBER('sysadmin')")
+        self.revert_context(exec_as)
+        is_admin = res[0][""]
+        self.context.log.debug(f"IsAdmin Result: {is_admin}")
+        if is_admin:
+            self.context.log.debug("User is admin!")
+            self.admin_privs = True
+            return True
+        else:
             return False
 
     def revert_context(self, exec_as):

--- a/nxc/modules/mssql_priv.py
+++ b/nxc/modules/mssql_priv.py
@@ -440,12 +440,9 @@ class NXCModule:
         :return: True if the username belongs to an admin user, False otherwise.
         :rtype: bool
         """
-        res = self.query_and_get_output(exec_as + "SELECT IS_SRVROLEMEMBER('sysadmin')")
-        self.revert_context(exec_as)
+        res = self.query_and_get_output(f"SELECT IS_SRVROLEMEMBER('sysadmin', '{username}')")
         is_admin = res[0][""]
-        self.context.log.debug(f"IsAdmin Result: {is_admin}")
         if is_admin:
-            self.context.log.debug("User is admin!")
             self.admin_privs = True
             return True
         else:

--- a/nxc/modules/nanodump.py
+++ b/nxc/modules/nanodump.py
@@ -39,7 +39,6 @@ class NXCModule:
         NANO_EXE_NAME       Name of the nano executable (default: nano.exe)
         DIR_RESULT          Location where the dmp are stored (default: DIR_RESULT = NANO_PATH)
         """
-        self.context = context
         self.remote_tmp_dir = "C:\\Windows\\Temp\\"
         self.share = "C$"
         self.tmp_share = self.remote_tmp_dir.split(":")[1]

--- a/nxc/modules/user-desc.py
+++ b/nxc/modules/user-desc.py
@@ -37,7 +37,6 @@ class NXCModule:
         """
         self.log_file = None
         self.desc_count = 0
-        self.context = context
         self.account_names = set()
         self.keywords = {"pass", "creds", "creden", "key", "secret", "default"}
 
@@ -71,6 +70,7 @@ class NXCModule:
         On successful LDAP login we perform a search for all user objects that have a description.
         Users can specify additional LDAP filters that are applied to the query.
         """
+        self.context = context
         self.create_log_file(connection.conn.getRemoteHost(), datetime.now().strftime("%Y%m%d_%H%M%S"))
         context.log.info(f"Starting LDAP search with search filter '{self.search_filter}'")
 


### PR DESCRIPTION
Fixing the Issue #273 

The privileged user for the impersonation cannot be found, because there is an issue in the "is_admin_user" function.
Due to the try except statement the admin privileges are always wrong, because the if statement cannot be executed

TypeError: int() argument must be a string, a bytes-like object or a real number, not 'list'

I could sucessfully test my changes on the HTB Academy module “Using CrackMapExec” in the task “MSSQL Enumeration and Attacks”

```
└─$ docker run --privileged --network host netexec-fixed mssql 10.129.204.177 -u robert -p Inlanefreight01! -M mssql_priv -o ACTION=privesc
...
MSSQL       10.129.204.177  1433   DC01             [*] Windows 10 / Server 2019 Build 17763 (name:DC01) (domain:inlanefreight.htb)
MSSQL       10.129.204.177  1433   DC01             [+] inlanefreight.htb\robert:Inlanefreight01!
MSSQL_PRIV                                          [+] INLANEFREIGHT\robert can impersonate: julio (sysadmin)
MSSQL_PRIV                                          [+] INLANEFREIGHT\robert is now a sysadmin! (Pwn3d!)
```

```
└─$ docker run --privileged --network host netexec-fixed mssql 10.129.204.177 -u robert -p Inlanefreight01! -x whoami
...
MSSQL       10.129.204.177  1433   DC01             [*] Windows 10 / Server 2019 Build 17763 (name:DC01) (domain:inlanefreight.htb)
MSSQL       10.129.204.177  1433   DC01             [+] inlanefreight.htb\robert:Inlanefreight01! (Pwn3d!)
MSSQL       10.129.204.177  1433   DC01             [+] Executed command via mssqlexec
MSSQL       10.129.204.177  1433   DC01             inlanefreight\svc_mssql
``` 