### PR TITLE
Fix #284

### DIFF
--- a/netexec.spec
+++ b/netexec.spec
@@ -42,6 +42,7 @@ a = Analysis(
         'nxc.helpers.bash',
         'nxc.helpers.bloodhound',
         'nxc.helpers.msada_guids',
+        'nxc.helpers.ntlm_parser',
         'paramiko',
         'pypsrp.client',
         'pywerview.cli.helpers',


### PR DESCRIPTION
Import `nxc.helpers.ntlm_parser` was missing in the netexec.spec file. Fixes #284 

Before&After:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/aa8761b1-2ee4-4b60-9612-f9774798504f)
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/e85262a3-b19d-4467-a51a-4553c0719e5a)
