### PR TITLE
Reduce third party debug logging

### DIFF
--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -30,7 +30,7 @@ def setup_debug_logging():
         root_logger.setLevel(logging.INFO)
     elif debug_args.debug:
         nxc_logger.logger.setLevel(logging.DEBUG)
-        root_logger.setLevel(logging.DEBUG)
+        root_logger.setLevel(logging.INFO)
     else:
         nxc_logger.logger.setLevel(logging.ERROR)
         root_logger.setLevel(logging.ERROR)

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -53,12 +53,14 @@ class SmartDebugRichHandler(RichHandler):
             
     def emit(self, record):
         """Overrides the emit method of the RichHandler class so we can set the proper pathname and lineno"""
+        # for some reason in RDP, the exc_text is None which leads to a KeyError in Python logging
+        record.exc_text = record.getMessage() if record.exc_text is None else record.exc_text
+        
         if hasattr(record, "caller_frame"):
             frame_info = inspect.getframeinfo(record.caller_frame)
             record.pathname = frame_info.filename
             record.lineno = frame_info.lineno
         super().emit(record)
-
 
 def no_debug(func):
     """Stops logging non-debug messages when we are in debug mode


### PR DESCRIPTION
There was a lot of annoying useless logs being shown since we set the global logger to `DEBUG`. This sets the global logger higher, but keeps ours dependent on what the user specifies.

This also fixes a weird error noticed in #288 where the exception data wasn't being populated during debugging, so I added a check to make sure that its set, and if it's not, set it to the error message (which is what it should be).

Before, with a lot of annoying useless stuff:
![before_debug_logging](https://github.com/Pennyw0rth/NetExec/assets/1518719/dc6d7b4c-568e-4313-bffa-33590689d8f0)

After:
![after_debug_logging](https://github.com/Pennyw0rth/NetExec/assets/1518719/70907a40-556b-4b49-9588-aeb6bfd792d3)