### PR TITLE
Revert a9bd576392af8ec5ee284446bc99ffd24b9b696a

### DIFF
--- a/nxc/helpers/bloodhound.py
+++ b/nxc/helpers/bloodhound.py
@@ -52,10 +52,8 @@ def add_user_bh(user, domain, logger, config):
                         _add_with_domain(user_info, domain, tx, logger)
         except AuthError:
             logger.fail(f"Provided Neo4J credentials ({config.get('BloodHound', 'bh_user')}:{config.get('BloodHound', 'bh_pass')}) are not valid.")
-            exit()
         except ServiceUnavailable:
             logger.fail(f"Neo4J does not seem to be available on {uri}.")
-            exit()
         except Exception as e:
             logger.fail(f"Unexpected error with Neo4J: {e}")
         finally:


### PR DESCRIPTION
Revert behaviour to not exiting when bloodhound adapter is configured, but bloodhound is not available for some reason. This can cause a lot of headache if you don't know that the behaviour changed