### PR TITLE
Fix: WCC Module - do not create log file on every file load

### DIFF
--- a/nxc/modules/wcc.py
+++ b/nxc/modules/wcc.py
@@ -152,7 +152,7 @@ class HostChecker:
 
     def __init__(self, context, connection):
         self.context = context
-        self.connection = connection       
+        self.connection = connection
         remoteOps = RemoteOperations(smbConnection=connection.conn, doKerberos=False)
         remoteOps.enableRegistry()
         self.dce = remoteOps._RemoteOperations__rrp
@@ -480,9 +480,6 @@ class HostChecker:
 
         return success, reasons
 
-    # Methods for getting values from the remote registry #
-    #######################################################
-
     def _open_root_key(self, dce, connection, root_key):
         ans = None
         retries = 1
@@ -592,9 +589,6 @@ class HostChecker:
                     return data
             return DCERPCSessionError(error_code=ERROR_OBJECT_NOT_FOUND)
 
-    # Methods for getting values from SAMR and SCM #
-    ################################################
-
     def get_service(self, service_name, connection):
         """Get the service status and configuration for specified service"""
         remoteOps = RemoteOperations(smbConnection=connection.conn, doKerberos=False)
@@ -642,22 +636,14 @@ class HostChecker:
             self.context.log.error(f"ls(): C:\\{path} {e}\n")
         return file_listing
 
-
-# Comparison operators #
-########################
-
-
 def le(reg_sz_string, number):
     return int(reg_sz_string[:-1]) <= number
-
 
 def in_(obj, seq):
     return obj in seq
 
-
 def startswith(string, start):
     return string.startswith(start)
-
 
 def not_(boolean_operator):
     def wrapper(*args, **kwargs):

--- a/nxc/modules/wcc.py
+++ b/nxc/modules/wcc.py
@@ -161,7 +161,6 @@ class HostChecker:
         self.init_checks()
         self.check_config()
         
-
     def init_checks(self):
         # Declare the checks to do and how to do them
         self.checks = [

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1126,7 +1126,8 @@ class smb(connection):
                     record = wmi_results.getProperties()
                     records.append(record)
                     for k, v in record.items():
-                        self.logger.highlight(f"{k} => {v['value']}")
+                        if k != "TimeGenerated":  # from the wcc module, but this is a small hack to get it to stop spamming - TODO: add in method to disable output for this function
+                            self.logger.highlight(f"{k} => {v['value']}")
                 except Exception as e:
                     if str(e).find("S_FALSE") < 0:
                         raise e


### PR DESCRIPTION
Currently when someone runs -L, all modules are referenced to get their name/proto, but unfortunately with WCC this means the create log file code is called.
This fixes #256, but I will update this module again later when I normalize module logging