### PR TITLE
Fix: hash_spider Lsassy Parser syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 data/nxc.db
 hash_spider_default.sqlite3
+hash_spider_testing.sqlite3
 *.bak
 *.log
 .venv

--- a/nxc/modules/hash_spider.py
+++ b/nxc/modules/hash_spider.py
@@ -70,11 +70,7 @@ def create_db(local_admins, dbconnection, cursor):
 
 
 def process_creds(context, connection, credentials_data, dbconnection, cursor, driver):
-    if connection.args.local_auth:
-        context.log.extra["host"] = connection.conn.getServerDNSDomainName()
-    else:
-        context.log.extra["host"] = connection.domain
-    context.log.extra["hostname"] = connection.host.upper()
+    domain = connection.conn.getServerDNSDomainName() if connection.args.local_auth else connection.domain
     for result in credentials_data:
         username = result["username"].upper().split("@")[0]
         nthash = result["nthash"]
@@ -85,7 +81,7 @@ def process_creds(context, connection, credentials_data, dbconnection, cursor, d
                 "UPDATE admin_users SET password = ? WHERE username LIKE '" + username + "%'",
                 [password],
             )
-            username = f"{username.upper()}@{context.log.extra['host'].upper()}"
+            username = f"{username.upper()}@{domain.upper()}"
             dbconnection.commit()
             session = driver.session()
             session.run('MATCH (u) WHERE (u.name = "' + username + '") SET u.owned=True RETURN u,u.name,u.owned')
@@ -99,7 +95,7 @@ def process_creds(context, connection, credentials_data, dbconnection, cursor, d
                 [nthash],
             )
             dbconnection.commit()
-            username = f"{username.upper()}@{context.log.extra['host'].upper()}"
+            username = f"{username.upper()}@{domain.upper()}"
             session = driver.session()
             session.run('MATCH (u) WHERE (u.name = "' + username + '") SET u.owned=True RETURN u,u.name,u.owned')
             path_to_da = session.run("MATCH p=shortestPath((n)-[*1..]->(m)) WHERE n.owned=true AND m.name=~ '.*DOMAIN ADMINS.*' RETURN p")

--- a/nxc/modules/hash_spider.py
+++ b/nxc/modules/hash_spider.py
@@ -202,7 +202,7 @@ class NXCModule:
         if file is None:
             context.log.fail("Unable to dump lsass")
             return False
-        credentials, tickets, masterkeys = Parser(file).parse()
+        credentials, tickets, masterkeys = Parser(host, file).parse()
         file.close()
         ImpacketFile.delete(session, file.get_file_path())
         if credentials is None:


### PR DESCRIPTION
hash_spider errors out since Lsassy changed it's Parser class init params here: https://github.com/login-securite/lsassy/commit/9fffbdfffb691dd3e726a9f4ee591785b861c238

This fixes it to pass in the host, and also adds the DB created during running tests

Error on top, then my fix implemented and re-ran:
![image](https://github.com/Pennyw0rth/NetExec/assets/1518719/ac0b3100-6750-497f-b51f-adf5e86b16d3)
