### PR TITLE
Add ldap query option

### DIFF
--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -13,6 +13,7 @@ def proto_args(parser, std_parser, module_parser):
     egroup.add_argument("--kerberoasting", help="Output TGS ticket to crack with hashcat to file")
 
     vgroup = ldap_parser.add_argument_group("Retrieve useful information on the domain", "Options to to play with Kerberos")
+    vgroup.add_argument("--query", nargs=2, help="Query LDAP with a custom filter and attributes")
     vgroup.add_argument("--trusted-for-delegation", action="store_true", help="Get the list of users and computers with flag TRUSTED_FOR_DELEGATION")
     vgroup.add_argument("--password-not-required", action="store_true", help="Get the list of users with flag PASSWD_NOTREQD")
     vgroup.add_argument("--admin-count", action="store_true", help="Get objets that had the value adminCount=1")


### PR DESCRIPTION
Adding a query option to LDAP with the standard ldapsearch syntax to be able to quickly look up attributes in LDAP.
Nothing specially, just a raw ldap query with raw values :)

Example:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/85431055-c311-4628-90c5-bc2b94ec14af)
