### PR TITLE
Handle paramiko error when bruteforcing

### DIFF
--- a/nxc/protocols/ssh.py
+++ b/nxc/protocols/ssh.py
@@ -182,7 +182,6 @@ class ssh(connection):
                 return
 
     def plaintext_login(self, username, password, private_key=""):
-        self.create_conn_obj()
         self.username = username
         self.password = password
         stdout = None
@@ -231,6 +230,8 @@ class ssh(connection):
         except SSHException as e:
             if "Invalid key" in str(e):
                 self.logger.fail(f"{username}:{process_secret(password)} Could not decrypt private key, error: {e}")
+            if "Error reading SSH protocol banner" in str(e):
+                self.logger.error(f"Internal Paramiko error for {username}:{process_secret(password)}, {e}")
             else:
                 self.logger.exception(e)
         except Exception as e:

--- a/nxc/protocols/ssh.py
+++ b/nxc/protocols/ssh.py
@@ -182,6 +182,7 @@ class ssh(connection):
                 return
 
     def plaintext_login(self, username, password, private_key=""):
+        self.create_conn_obj()
         self.username = username
         self.password = password
         stdout = None

--- a/nxc/protocols/ssh.py
+++ b/nxc/protocols/ssh.py
@@ -198,6 +198,7 @@ class ssh(connection):
                     timeout=self.args.ssh_timeout,
                     look_for_keys=False,
                     allow_agent=False,
+                    banner_timeout=self.args.ssh_timeout,
                 )
 
                 cred_id = self.db.add_credential(
@@ -217,6 +218,7 @@ class ssh(connection):
                     timeout=self.args.ssh_timeout,
                     look_for_keys=False,
                     allow_agent=False,
+                    banner_timeout=self.args.ssh_timeout,
                 )
                 cred_id = self.db.add_credential("plaintext", username, password)
 

--- a/nxc/protocols/ssh.py
+++ b/nxc/protocols/ssh.py
@@ -195,6 +195,7 @@ class ssh(connection):
                     username=username,
                     passphrase=password if password != "" else None,
                     key_filename=private_key if private_key else self.args.key_file,
+                    timeout=self.args.ssh_timeout,
                     look_for_keys=False,
                     allow_agent=False,
                 )
@@ -213,6 +214,7 @@ class ssh(connection):
                     port=self.port,
                     username=username,
                     password=password,
+                    timeout=self.args.ssh_timeout,
                     look_for_keys=False,
                     allow_agent=False,
                 )


### PR DESCRIPTION
Fixing #312 where paramiko fails to read the ssh banner when brute forcing credentials. This can be reproduced quite easily with some logins:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/a174f9c7-7a33-4fd2-baee-d8a5d12d4daa)

This PR will handle the error and continue with the authentication requests:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/3ab3861e-2237-45f4-9ad4-75bab2358a0a)
