### PR TITLE
Fix for tests referencing files, password/username variable, and a couple KERBEROS space issues

### DIFF
--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -150,9 +150,9 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M spooler 
 netexec smb TARGET_HOST -u '' -p '' -M zerologon
 netexec smb TARGET_HOST -u '' -p '' -M petitpotam
 ##### SMB Auth File
-netexec smb TARGET_HOST -u data/test_users.txt -p data/test_passwords.txt --no-bruteforce
-netexec smb TARGET_HOST -u data/test_users.txt -p data/test_passwords.txt --no-bruteforce --continue-on-success
-netexec smb TARGET_HOST -u data/test_users.txt -p data/test_passwords.txt
+netexec smb TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE--no-bruteforce
+netexec smb TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE--no-bruteforce --continue-on-success
+netexec smb TARGET_HOST -u TEST_USER_FILE -p data/test_passwords.txt
 ##### WMI
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --wmi-namespace root/cimv2
@@ -163,7 +163,9 @@ netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M spooler
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M zerologon 
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M enum_dns
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M get_netconnections
-netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M rdp
+netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M rdp --options
+#netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M rdp -o ACTION=enable
+#netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M rdp -o ACTION=disable
 ##### LDAP
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --users
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --groups
@@ -217,7 +219,7 @@ netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --port 59
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --check-proto http --port 5985
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --check-proto https --port 5986
 ##### MSSQL
-netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS
+netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # Need a space at the end for kerb regex
 ##### MSSQL Modules
 # netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD -M empire_exec
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -L
@@ -237,22 +239,22 @@ netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M web_de
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --nla-screenshot
 ##### SSH - Default test passwords and random key; switch these out if you want correct authentication
-netexec ssh TARGET_HOST -u USERNAME -p PASSWORD
-netexec ssh TARGET_HOST -u data/test_users.txt -p data/test_passwords.txt --no-bruteforce
-netexec ssh TARGET_HOST -u data/test_users.txt -p data/test_passwords.txt --no-bruteforce --continue-on-success
-netexec ssh TARGET_HOST -u data/test_users.txt -p data/test_passwords.txt
-netexec ssh TARGET_HOST -u USERNAME -p PASSWORD --key-file data/test_key.priv
-netexec ssh TARGET_HOST -u USERNAME -p '' --key-file data/test_key.priv
-netexec ssh TARGET_HOST -u USERNAME -p PASSWORD --sudo-check
-netexec ssh TARGET_HOST -u USERNAME -p PASSWORD --sudo-check --sudo-check-method sudo-stdin
-netexec ssh TARGET_HOST -u USERNAME -p PASSWORD --sudo-check --sudo-check-method sudo-stdin --get-output-tries 10
-netexec ssh TARGET_HOST -u USERNAME -p PASSWORD --sudo-check --sudo-check-method mkfifo
-netexec ssh TARGET_HOST -u USERNAME -p PASSWORD --sudo-check --sudo-check-method mkfifo --get-output-tries 10
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD
+netexec ssh TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE--no-bruteforce
+netexec ssh TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE--no-bruteforce --continue-on-success
+netexec ssh TARGET_HOST -u TEST_USER_FILE -p data/test_passwords.txt
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --key-file data/test_key.priv
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p '' --key-file data/test_key.priv
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-check-method sudo-stdin
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-check-method sudo-stdin --get-output-tries 10
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-check-method mkfifo
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-check-method mkfifo --get-output-tries 10
 ##### FTP- Default test passwords and random key; switch these out if you want correct authentication
-netexec ftp TARGET_HOST -u USERNAME -p PASSWORD
-netexec ftp TARGET_HOST -u USERNAME -p PASSWORD --ls
-netexec ftp TARGET_HOST -u USERNAME -p PASSWORD --put data/test_file.txt test_file.txt
-netexec ftp TARGET_HOST -u USERNAME -p PASSWORD --get test_file.txt
-netexec ftp TARGET_HOST -u data/test_users.txt -p data/test_passwords.txt --no-bruteforce
-netexec ftp TARGET_HOST -u data/test_users.txt -p data/test_passwords.txt --no-bruteforce --continue-on-success
-netexec ftp TARGET_HOST -u data/test_users.txt -p data/test_passwords.txt
+netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD
+netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --ls
+netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --put data/test_file.txt test_file.txt
+netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --get test_file.txt
+netexec ftp TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce
+netexec ftp TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce --continue-on-success
+netexec ftp TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE

--- a/tests/e2e_tests.py
+++ b/tests/e2e_tests.py
@@ -4,6 +4,19 @@ import subprocess
 from rich.console import Console
 import platform
 
+script_dir = os.path.dirname(os.path.abspath(__file__))
+run_dir = os.path.dirname(os.path.abspath(__file__))
+possible_locations = [
+    os.path.join(run_dir, "tests/data/test_users.txt"),
+    os.path.join(run_dir, "data/test_users.txt"),
+]
+test_user_file = next((loc for loc in possible_locations if os.path.isfile(loc)), None)
+possible_locations = [
+os.path.join(script_dir, "tests/data/test_passwords.txt"),
+os.path.join(script_dir, "data/test_passwords.txt"),
+]
+test_password_file = next((loc for loc in possible_locations if os.path.isfile(loc)), None)
+
 
 def get_cli_args():
     parser = argparse.ArgumentParser(description="Script for running end to end tests for nxc")
@@ -72,7 +85,21 @@ def get_cli_args():
         "--print-failures",
         action="store_true",
         required=False,
-        help="Prints all the commands of failed tests at the end"
+        help="Prints all the commands of failed tests at the end",
+    )
+    parser.add_argument(
+        "--test-user-file",
+        dest="test_user_file",
+        required=False,
+        default=test_user_file,
+        help="Path to the file containing test usernames",
+    )
+    parser.add_argument(
+        "--test-password-file",
+        dest="test_password_file",
+        required=False,
+        default=test_password_file,
+        help="Path to the file containing test passwords",
     )
     return parser.parse_args()
 
@@ -119,7 +146,13 @@ def generate_commands(args):
 def replace_command(args, line):
     kerberos = "-k " if args.kerberos else ""
 
-    line = line.replace("TARGET_HOST", args.target).replace("LOGIN_USERNAME", f'"{args.username}"').replace("LOGIN_PASSWORD", f'"{args.password}"').replace("KERBEROS ", kerberos)
+    line = line\
+        .replace("TARGET_HOST", args.target)\
+        .replace("LOGIN_USERNAME", f'"{args.username}"')\
+        .replace("LOGIN_PASSWORD", f'"{args.password}"')\
+        .replace("KERBEROS ", kerberos)\
+        .replace("TEST_USER_FILE", args.test_user_file)\
+        .replace("TEST_PASSWORD_FILE", args.test_password_file)
     if args.poetry:
         line = f"poetry run {line}"
     return line
@@ -147,6 +180,7 @@ def run_e2e_tests(args):
             # replace double quotes with single quotes for Linux due to special chars/escaping
             if platform.system() == "Linux":
                 task = task.replace('"', "'")
+            # we print the command before running because very often things will timeout and we want the last thing ran
             console.log(f"Running command: {task}")
             result = subprocess.Popen(
                 task,
@@ -169,6 +203,7 @@ def run_e2e_tests(args):
 
             if args.errors:
                 raw_text = text.decode("utf-8")
+                # this is not a good way to detect errors, but it does catch a lot of things
                 if "error" in raw_text.lower() or "failure" in raw_text.lower():
                     console.log("[bold red]Error Detected:")
                     console.log(f"{raw_text}")


### PR DESCRIPTION
Referencing test files was failing if you didnt call it from the proper folder, so this should fix that
There were a couple places where KERBEROS wasnt being replaced
And finally, changed the USERNAME/PASSWORD we replace because some modules/etc have "PASSWORD" as an option and that was being erroneously replaced