### PR TITLE
Added --dns-tcp,--dns-timeout and --dns-server parameters to the ldap protocol when using --bloodhound

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1402,9 +1402,9 @@ class ldap(connection):
         ad = AD(
             auth=auth,
             domain=self.domain,
-            nameserver=self.args.nameserver,
-            dns_tcp=False,
-            dns_timeout=3,
+            nameserver=self.args.dns_server,
+            dns_tcp=self.args.dns_tcp,
+            dns_timeout=self.args.dns_timeout,
         )
         collect = resolve_collection_methods("Default" if not self.args.collection else self.args.collection)
         if not collect:

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -33,7 +33,6 @@ def proto_args(parser, parents):
 
     bgroup = ldap_parser.add_argument_group("Bloodhound Scan", "Options to play with Bloodhoud")
     bgroup.add_argument("--bloodhound", action="store_true", help="Perform a Bloodhound scan")
-    bgroup.add_argument("-ns", "--nameserver", help="Custom DNS IP")
     bgroup.add_argument("-c", "--collection", default="Collection", help="Which information to collect. Supported: Group, LocalAdmin, Session, Trusts, Default, DCOnly, DCOM, RDP, PSRemote, LoggedOn, Container, ObjectProps, ACL, All. You can specify more than one by separating them with a comma")
 
     return parser


### PR DESCRIPTION
removed -ns to instead use the --dns-server parameter, and enabled the use of --dns-tcp and --dns-timeout when using --bloodhound.