### PR TITLE
[NXCDB] Add support for CTRL-D

### DIFF
--- a/nxc/nxcdb.py
+++ b/nxc/nxcdb.py
@@ -513,6 +513,11 @@ class NXCDBMenu(cmd.Cmd):
         sys.exit()
 
     @staticmethod
+    def do_EOF(line):
+        sys.exit()
+
+
+    @staticmethod
     def help_exit():
         help_string = """
         Exits


### PR DESCRIPTION
Added do_EOF method in NXCDBMenu, so that nxcdb can be exited by typing CTRL-D