### PR TITLE
schtask_as Improvement - Options for custom task, file, and location.

### DIFF
--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -15,12 +15,12 @@ class NXCModule:
     """
 
     def options(self, context, module_options):
-        """
+        r"""
         CMD            Command to execute
         USER           User to execute command as
         TASK           OPTIONAL: Set a name for the scheduled task name
         FILE           OPTIONAL: Set a name for the command output file
-        LOCATION       OPTIONAL: Set a location for the command output file
+        LOCATION       OPTIONAL: Set a location for the command output file (e.g. '\tmp\')
         """
         self.cmd = self.user = self.task = self.file = self.location = self.time = None
         if "CMD" in module_options:
@@ -28,16 +28,16 @@ class NXCModule:
 
         if "USER" in module_options:
             self.user = module_options["USER"]
-            
+
         if "TASK" in module_options:
             self.task = module_options["TASK"]
-            
+
         if "FILE" in module_options:
             self.file = module_options["FILE"]
- 
+
         if "LOCATION" in module_options:
             self.location = module_options["LOCATION"]
-           
+
     name = "schtask_as"
     description = "Remotely execute a scheduled task as a logged on user"
     supported_protocols = ["smb"]
@@ -117,7 +117,6 @@ class TSCH_EXEC:
         self.file = file
         self.task = task
         self.location = location
-        
 
         if hashes is not None:
             if hashes.find(":") != -1:
@@ -202,9 +201,9 @@ class TSCH_EXEC:
         if self.__retOutput:
             fileLocation = "\\Windows\\Temp\\" if self.location is None else self.location
             if self.file is None:
-                self.__output_filename = f"{fileLocation}{gen_random_string(6)}"
-            else: 	
-                self.__output_filename = f"{fileLocation}{self.file}"
+                self.__output_filename = os.path.join(fileLocation, gen_random_string(6))
+            else:
+                self.__output_filename = os.path.join(fileLocation, self.file)
             if fileless:
                 local_ip = self.__rpctransport.get_socket().getsockname()[0]
                 argument_xml = f"      <Arguments>/C {command} &gt; \\\\{local_ip}\\{self.__share_name}\\{self.__output_filename} 2&gt;&amp;1</Arguments>"

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -222,7 +222,7 @@ class TSCH_EXEC:
         if self.task is None:
             tmpName = gen_random_string(8)
         else: 	
-            tmpName = f"{self.task}"
+            tmpName = self.task
         xml = self.gen_xml(command, fileless)
 
         self.logger.info(f"Task XML: {xml}")

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -220,7 +220,7 @@ class TSCH_EXEC:
 
         #tmpName = gen_random_string(8)
         if self.task is None:
-            tmpName = f"{gen_random_string(8)}"
+            tmpName = gen_random_string(8)}
         else: 	
             tmpName = f"{self.task}"
         xml = self.gen_xml(command, fileless)

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -186,12 +186,9 @@ class TSCH_EXEC:
 """
         if self.__retOutput:
             if self.task is None:
-              self.__output_filename = f"\\Windows\\Temp\\{gen_random_string(6)}"
+                self.__output_filename = f"\\Windows\\Temp\\{gen_random_string(6)}"
             else: 	
-              self.__output_filename = f"\\Windows\\Temp\\{self.task}"
-            
-            
-            #self.__output_filename = f"\\Windows\\Temp\\{gen_random_string(6)}"
+                self.__output_filename = f"\\Windows\\Temp\\{self.task}"
             if fileless:
                 local_ip = self.__rpctransport.get_socket().getsockname()[0]
                 argument_xml = f"      <Arguments>/C {command} &gt; \\\\{local_ip}\\{self.__share_name}\\{self.__output_filename} 2&gt;&amp;1</Arguments>"
@@ -217,8 +214,6 @@ class TSCH_EXEC:
 
         dce.set_credentials(*self.__rpctransport.get_credentials())
         dce.connect()
-
-        #tmpName = gen_random_string(8)
         if self.task is None:
             tmpName = gen_random_string(8)
         else: 	

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -220,7 +220,7 @@ class TSCH_EXEC:
 
         #tmpName = gen_random_string(8)
         if self.task is None:
-            tmpName = gen_random_string(8)}
+            tmpName = gen_random_string(8)
         else: 	
             tmpName = f"{self.task}"
         xml = self.gen_xml(command, fileless)

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -18,9 +18,9 @@ class NXCModule:
         """
         CMD            Command to execute
         USER           User to execute command as
-        TASK           Set a name for the scheduled task name
-        FILE           Set a name for the command output file
-        LOCATION       Set a location for the command output file
+        TASK           OPTIONAL: Set a name for the scheduled task name
+        FILE           OPTIONAL: Set a name for the command output file
+        LOCATION       OPTIONAL: Set a location for the command output file
         """
         self.cmd = self.user = self.task = self.file = self.location = self.time = None
         if "CMD" in module_options:
@@ -94,7 +94,7 @@ class NXCModule:
 
 
 class TSCH_EXEC:
-    def __init__(self, target, share_name, username, password, domain, user, cmd, file2, task2, location, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None):
+    def __init__(self, target, share_name, username, password, domain, user, cmd, file, task, location, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None):
         self.__target = target
         self.__username = username
         self.__password = password
@@ -114,8 +114,8 @@ class TSCH_EXEC:
         self.logger = logger
         self.cmd = cmd
         self.user = user
-        self.file = file2
-        self.task = task2
+        self.file = file
+        self.task = task
         self.location = location
         
 
@@ -235,7 +235,7 @@ class TSCH_EXEC:
 
         self.logger.info(f"Task XML: {xml}")
         taskCreated = False
-        self.logger.display(f"Creating task \\{tmpName}")
+        self.logger.info(f"Creating task \\{tmpName}")
         try:
             # windows server 2003 has no MSRPC_UUID_TSCHS, if it bind, it will return abstract_syntax_not_supported
             dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
@@ -287,7 +287,7 @@ class TSCH_EXEC:
                 tries = 1
                 while True:
                     try:
-                        self.logger.display(f"Attempting to read {self.__share}\\{self.__output_filename}")
+                        self.logger.info(f"Attempting to read {self.__share}\\{self.__output_filename}")
                         smbConnection.getFile(self.__share, self.__output_filename, self.output_callback)
                         break
                     except Exception as e:

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -214,10 +214,7 @@ class TSCH_EXEC:
 
         dce.set_credentials(*self.__rpctransport.get_credentials())
         dce.connect()
-        if self.task is None:
-            tmpName = gen_random_string(8)
-        else: 	
-            tmpName = self.task
+        tmpName = gen_random_string(8) if self.task is None else self.task
         xml = self.gen_xml(command, fileless)
 
         self.logger.info(f"Task XML: {xml}")

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -200,10 +200,7 @@ class TSCH_EXEC:
       <Command>cmd.exe</Command>
 """
         if self.__retOutput:
-            if self.location is None:
-                fileLocation = "\\Windows\\Temp\\"
-            else:
-                fileLocation = self.location
+            fileLocation = "\\Windows\\Temp\\" if self.location is None else self.location
             if self.file is None:
                 self.__output_filename = f"{fileLocation}{gen_random_string(6)}"
             else: 	


### PR DESCRIPTION
Added following options to try and avoid detection when using this module:

TASK           Set a name for the scheduled task name
FILE           Set a name for the command output file
LOCATION       Set a location for the command output file

Example:

```
nxc smb [ip] -u [user] -p [pwd] -M schtask_as -o USER=Administrator CMD="whoami" TASK="Windows Update Service" FILE="update.log" LOCATION="\\Windows\\Tasks\\"
```


![Screenshot from 2024-06-11 03-44-52](https://github.com/Pennyw0rth/NetExec/assets/46513413/73ad973e-8b71-46b3-9e34-576acf63bbdf)
