### PR TITLE
Adding some logger when users have been dumped

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -752,7 +752,7 @@ class ldap(connection):
 
             users = parse_result_attributes(resp)
             # we print the total records after we parse the results since often SearchResultReferences are returned
-            self.logger.success(f"Enumerated {len(users):d} domain users: {self.domain}")
+            self.logger.display(f"Enumerated {len(users):d} domain users: {self.domain}")
             self.logger.highlight(f"{'-Username-':<30}{'-Last PW Set-':<20}{'-BadPW-':<8}{'-Description-':<60}")
             for user in users:
                 # TODO: functionize this - we do this calculation in a bunch of places, different, including in the `pso` module

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -752,7 +752,7 @@ class ldap(connection):
 
             users = parse_result_attributes(resp)
             # we print the total records after we parse the results since often SearchResultReferences are returned
-            self.logger.display(f"Total records returned: {len(users):d}")
+            self.logger.success(f"Enumerated {len(users):d} domain users: {self.domain}")
             self.logger.highlight(f"{'-Username-':<30}{'-Last PW Set-':<20}{'-BadPW-':<8}{'-Description-':<60}")
             for user in users:
                 # TODO: functionize this - we do this calculation in a bunch of places, different, including in the `pso` module

--- a/nxc/protocols/smb/samruser.py
+++ b/nxc/protocols/smb/samruser.py
@@ -166,6 +166,7 @@ class UserSamrDump:
         return users
 
     def print_user_info(self, users):
+        self.logger.success("Enumerated local users")
         self.logger.highlight(f"{'-Username-':<30}{'-Last PW Set-':<20}{'-BadPW-':<8}{'-Description-':<60}")
         for user in users:
             self.logger.debug(f"Full user info: {user}")

--- a/nxc/protocols/smb/samruser.py
+++ b/nxc/protocols/smb/samruser.py
@@ -166,7 +166,7 @@ class UserSamrDump:
         return users
 
     def print_user_info(self, users):
-        self.logger.success("Enumerated local users")
+        self.logger.display(f"Enumerated {len(users):d} local users")
         self.logger.highlight(f"{'-Username-':<30}{'-Last PW Set-':<20}{'-BadPW-':<8}{'-Description-':<60}")
         for user in users:
             self.logger.debug(f"Full user info: {user}")


### PR DESCRIPTION
Hello there,
Just a little PR because I saw that the log "Enumerated domain users" disappeared, so i just added it back (I don't know if this was for a specific reason).

The purpose of these prints make sense when we try to enumerate local users and logged_on users. There is no separation between these two informations
![image](https://github.com/Pennyw0rth/NetExec/assets/49342114/25d77dde-cb8c-44e1-b1b8-5e2d0d6313c3)

And I also changed it when enumerating domain users just to make it a little consistent. There are other cases where the "-Username- -LastPwdSet-" is printed without further detail of what it is but since i do not use actively these features i prefer not touching it.

Cordially :)