### PR TITLE
Added domain name for --users with samr

### DIFF
--- a/nxc/protocols/smb/samruser.py
+++ b/nxc/protocols/smb/samruser.py
@@ -78,10 +78,11 @@ class UserSamrDump:
         if resp2["ErrorCode"] != 0:
             raise Exception("Connect error")
 
+        domain_name = resp2["Buffer"]["Buffer"][0]["Name"]
         resp3 = samr.hSamrLookupDomainInSamServer(
             self.dce,
             serverHandle=resp["ServerHandle"],
-            name=resp2["Buffer"]["Buffer"][0]["Name"],
+            name=domain_name,
         )
         if resp3["ErrorCode"] != 0:
             raise Exception("Connect error")
@@ -132,7 +133,7 @@ class UserSamrDump:
                 # set these for the while loop
                 enumerationContext = enumerate_users_resp["EnumerationContext"]
                 status = enumerate_users_resp["ErrorCode"]
-        self.print_user_info(users)
+        self.print_user_info(users, domain_name)
         self.dce.disconnect()
 
     def get_user_info(self, domain_handle, user_ids):
@@ -165,8 +166,8 @@ class UserSamrDump:
             samr.hSamrCloseHandle(self.dce, open_user_resp["UserHandle"])
         return users
 
-    def print_user_info(self, users):
-        self.logger.display(f"Enumerated {len(users):d} local users")
+    def print_user_info(self, users, domain_name):
+        self.logger.display(f"Enumerated {len(users):d} local users: {domain_name}")
         self.logger.highlight(f"{'-Username-':<30}{'-Last PW Set-':<20}{'-BadPW-':<8}{'-Description-':<60}")
         for user in users:
             self.logger.debug(f"Full user info: {user}")


### PR DESCRIPTION
Hey again ! 
This PR follows the previous one changing logging for the --users command using SAMR and LDAP.
It only adds the domain name that listed users belong to. It can be useful when a local computer and a domain have 2 differents accounts but with the same username.

Using samr to list users makes their domain unsure. (It can be part of a domain or local only)
![image](https://github.com/Pennyw0rth/NetExec/assets/49342114/cc5ebfc3-ad72-4449-a901-2704adb37726)
 
This PR only adds the domain name when using samr.
Querying an AD, getting the correct domain
![image](https://github.com/Pennyw0rth/NetExec/assets/49342114/5452ce39-44a8-42d9-bb90-bf56132dc682)

Querying a user computer
![image](https://github.com/Pennyw0rth/NetExec/assets/49342114/42c3e4ef-d3ec-41eb-91c0-331e875e646e)