### PR TITLE
Small Bug Fix on Listing SMB Shares with Kerberos Auth

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -763,6 +763,11 @@ class smb(connection):
         try:
             self.logger.debug(f"domain: {self.domain}")
             user_id = self.db.get_user(self.domain.upper(), self.username)[0][0]
+        except IndexError as e:
+            if self.use_kcache:
+                pass
+            else
+                self.logger.fail(f"IndexError: {str(e)}")
         except Exception as e:
             error = get_error_string(e)
             self.logger.fail(f"Error getting user: {error}")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -766,7 +766,7 @@ class smb(connection):
         except IndexError as e:
             if self.use_kcache:
                 pass
-            else
+            else:
                 self.logger.fail(f"IndexError: {str(e)}")
         except Exception as e:
             error = get_error_string(e)


### PR DESCRIPTION
This is a bug I came across while working with Kerberos on another project.  If the information of the user in the ticket is not in the workspace database, it gives an index error cause of user_id is empty. I thought about adding the ticket information as user_id, but since it wouldn't have any meaning when it expired, I proceeded with pass.

**_Before:_**

```
└─# impacket-getST test.local/userd1:'Password!123' -dc-ip 192.168.37.101 -spn ldap/DC2.test.local
Impacket v0.12.0.dev1+20240327.181547.f8899e65 - Copyright 2023 Fortra

[*] Getting TGT for user
[*] Getting ST for user
[*] Saving ticket in userd1.ccache
                                                                                                                                                                                 
┌──(venv)─(root㉿kali)-[/opt/NetExec]
└─# export KRB5CCNAME=userd1.ccache
                                                                                                                                                                                 
┌──(venv)─(root㉿kali)-[/opt/NetExec]
└─# klist
Ticket cache: FILE:userd1.ccache
Default principal: userd1@TEST.LOCAL

Valid starting       Expires              Service principal
06/25/2024 18:26:51  06/26/2024 04:26:50  ldap/DC2.test.local@TEST.LOCAL
        renew until 06/26/2024 18:26:51
```

![image](https://github.com/Pennyw0rth/NetExec/assets/50464194/e38cf322-218c-49b4-9209-91ed0c696c55)

Note: If we tried with Kerberos after authenticating with the user with username and password, there is no error because user_id is assigned with same user. 

![image](https://github.com/Pennyw0rth/NetExec/assets/50464194/1d33da69-cbd9-4176-b135-dc84febe3f04)

**_After:_**

![image](https://github.com/Pennyw0rth/NetExec/assets/50464194/f2ef1a88-fb30-45e0-8cc3-70ec0e92a403)

