### PR TITLE
Bug Fix While Using Bloodhound with --use-kcache Issue #363

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1418,8 +1418,8 @@ class ldap(connection):
             self.logger.highlight("Using kerberos auth without ccache, getting TGT")
             auth.get_tgt()
         if self.args.use_kcache:
-            auth.load_ccache()
             self.logger.highlight("Using kerberos auth from ccache")
+            auth.load_ccache()
 
         timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S") + "_"
         bloodhound = BloodHound(ad, self.hostname, self.host, self.port)

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1418,6 +1418,7 @@ class ldap(connection):
             self.logger.highlight("Using kerberos auth without ccache, getting TGT")
             auth.get_tgt()
         if self.args.use_kcache:
+            auth.load_ccache()
             self.logger.highlight("Using kerberos auth from ccache")
 
         timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S") + "_"


### PR DESCRIPTION
When we delved deeper into issue 363, I realized that the TGT could not be read because the load_ccache function in the authtectication file was not called.

![image](https://github.com/Pennyw0rth/NetExec/assets/50464194/b6bb9712-4001-457f-8178-d7b989a3ff60)

I first tried the relevant function manually in the authentication.py file and saw that it worked. The issue that would apply the --use-kcache feature when calling it via ldap in NetExec has been resolved.


![image](https://github.com/Pennyw0rth/NetExec/assets/50464194/b338f6fa-7385-4f27-8ca1-e018bb64cc08)
