### PR TITLE
Remove message that could be too annoying

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -229,6 +229,7 @@ class smb(connection):
             try:
                 import socket
                 socket.inet_aton(self.host)
+                self.logger.debug("NTLM authentication not available! Authentication will fail without a valid hostname and domain name")
                 self.hostname = self.host
                 self.targetDomain = self.host
             except OSError:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -229,7 +229,6 @@ class smb(connection):
             try:
                 import socket
                 socket.inet_aton(self.host)
-                self.logger.fail("NTLM authentication not available! Authentication will fail without a valid hostname and domain name")
                 self.hostname = self.host
                 self.targetDomain = self.host
             except OSError:


### PR DESCRIPTION
In hindsight i figured the message "NTLM authentication is not available..." from this screenshot:
![image](https://github.com/Pennyw0rth/NetExec/assets/61382599/2b52f3ba-b9e2-4c83-a732-a6baf6333ca6)

is probably too much and could be very annoying (it will get displayed on every connection, with or without credentials being supplied). I will remove it and just update the wiki to inform users.