### PR TITLE
Stop NetBiosTimeout and error producing large stack traces

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -167,6 +167,7 @@ class connection:
         except Exception as e:
             if "ERROR_DEPENDENT_SERVICES_RUNNING" in str(e):
                 self.logger.error(f"Exception while calling proto_flow() on target {target}: {e}")
+            # Catching impacket SMB specific exceptions, which should not be imported due to performance reasons
             elif e.__class__.__name__ in ["NetBIOSTimeout", "NetBIOSError"]:
                 self.logger.error(f"{e.__class__.__name__} on target {target}: {e}")
             else:

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -167,6 +167,8 @@ class connection:
         except Exception as e:
             if "ERROR_DEPENDENT_SERVICES_RUNNING" in str(e):
                 self.logger.error(f"Exception while calling proto_flow() on target {target}: {e}")
+            elif e.__class__.__name__ in ["NetBIOSTimeout", "NetBIOSError"]:
+                self.logger.error(f"{e.__class__.__name__} on target {target}: {e}")
             else:
                 self.logger.exception(f"Exception while calling proto_flow() on target {target}: {e}")
         finally:


### PR DESCRIPTION
This fixes occasions where connections, using the smb connection from impacket (for example SMB and LDAP), timeout or produce an NetBIOSError which then throw a large stack trace. This should be "gracefully" handled now:

Before:
![image](https://github.com/user-attachments/assets/b531b38e-dcd9-4c88-b4f5-ef596211a976)
After:
![image](https://github.com/user-attachments/assets/a3e9373d-559a-493f-a510-3a9909827a71)

Fixes:
- #377
- #369
