### PR TITLE
Fix: module spider_plus with filtered folders

### DIFF
--- a/nxc/modules/spider_plus.py
+++ b/nxc/modules/spider_plus.py
@@ -255,7 +255,7 @@ class SMBSpiderPlus:
             # Check file-dir exclusion filter.
             if any(d in next_filedir.lower() for d in self.exclude_filter):
                 self.logger.info(f'The {result_type} "{next_filedir}" has been excluded')
-                self.stats[f"{result_type}s_filtered"] += 1
+                self.stats[f"num_{result_type}s_filtered"] += 1
                 continue
 
             if result_type == "folder":


### PR DESCRIPTION
With option to filter folders is set and a folder matches the filter, there is a typo in the incremented counter.

The counter should be `self.stats[f"num_{result_type}s_filtered"]`  and not `self.stats[f"{result_type}s_filtered"]`.

The latter does not exists and trigger the following error:
```
KeyError: 'folders_filtered'
```