### PR TITLE
Fix spider_plus bug where len was applied to the count not an array

### DIFF
--- a/nxc/modules/spider_plus.py
+++ b/nxc/modules/spider_plus.py
@@ -3,7 +3,6 @@ import errno
 from os.path import abspath, join, split, exists, splitext, getsize, sep
 from os import makedirs, remove, stat
 import time
-import traceback
 from nxc.paths import TMP_PATH
 from nxc.protocols.smb.remotefile import RemoteFile
 from impacket.smb3structs import FILE_READ_DATA
@@ -159,8 +158,8 @@ class SMBSpiderPlus:
                     remote_file.__smbConnection = self.smb.conn
                     return self.read_chunk(remote_file)
 
-            except Exception:
-                traceback.print_exc()
+            except Exception as e:
+                self.logger.exception(e)
                 break
 
         return chunk
@@ -214,13 +213,13 @@ class SMBSpiderPlus:
                     # Start the spider at the root of the share folder
                     self.results[share_name] = {}
                     self.spider_folder(share_name, "")
-                except SessionError:
-                    traceback.print_exc()
+                except SessionError as e:
+                    self.logger.exception(e)
                     self.logger.fail("Got a session error while spidering.")
                     self.reconnect()
 
         except Exception as e:
-            traceback.print_exc()
+            self.logger.exception(e)
             self.logger.fail(f"Error enumerating shares: {e!s}")
 
         # Save the metadata.
@@ -412,8 +411,7 @@ class SMBSpiderPlus:
         self.logger.display(f"Total folders found:  {num_folders}")
         num_folders_filtered = self.stats.get("num_folders_filtered", 0)
         if num_folders_filtered:
-            num_filtered_folders = len(num_folders_filtered)
-            self.logger.display(f"Folders Filtered:     {num_filtered_folders}")
+            self.logger.display(f"Folders Filtered:     {num_folders_filtered}")
 
         # File statistics.
         num_files = self.stats.get("num_files", 0)

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -142,7 +142,6 @@ def main():
 
     protocol_object = getattr(p_loader.load_protocol(protocol_path), args.protocol)
     nxc_logger.debug(f"Protocol Object: {protocol_object}, type: {type(protocol_object)}")
-    nxc_logger.debug(f"Protocol Object dir: {dir(protocol_object)}")
     protocol_db_object = p_loader.load_protocol(protocol_db_path).database
     nxc_logger.debug(f"Protocol DB Object: {protocol_db_object}")
 


### PR DESCRIPTION
#391 fixed a faulty reference, but not the resulting bug that the stat `num_folder_filtered` already counted the amount of folders that were filtered and didn't create a list (which then would be counted with `len`). 
Resulted in the following traceback:
![image](https://github.com/user-attachments/assets/26f276b4-3e88-43e2-99bd-eea08da0b421)

Fixed:
![image](https://github.com/user-attachments/assets/fbc0f8a1-5b50-4a22-9f99-7d8266ada6de)

Also converted raw tracebacks to our exception screen