### PR TITLE
Fix issues with kerberos and non NTLM domains

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -134,7 +134,7 @@ class connection:
         # Authentication info
         self.password = ""
         self.username = ""
-        self.kerberos = bool(self.args.kerberos or self.args.use_kcache or self.args.aesKey)
+        self.kerberos = bool(self.args.kerberos or self.args.use_kcache or self.args.aesKey or (hasattr(self.args, "delegate") and self.args.delegate))
         self.aesKey = None if not self.args.aesKey else self.args.aesKey[0]
         self.use_kcache = None if not self.args.use_kcache else self.args.use_kcache
         self.admin_privs = False
@@ -157,7 +157,7 @@ class connection:
         else:
             return
 
-        if self.args.kerberos:
+        if self.kerberos:
             self.host = self.hostname
 
         self.logger.info(f"Socket info: host={self.host}, hostname={self.hostname}, kerberos={self.kerberos}, ipv6={self.is_ipv6}, link-local ipv6={self.is_link_local_ipv6}")
@@ -469,8 +469,6 @@ class connection:
             return False
         if self.args.continue_on_success and owned:
             return False
-        if hasattr(self.args, "delegate") and self.args.delegate:
-            self.args.kerberos = True
 
         if self.args.jitter:
             jitter = self.args.jitter
@@ -485,7 +483,7 @@ class connection:
 
         with sem:
             if cred_type == "plaintext":
-                if self.args.kerberos:
+                if self.kerberos:
                     self.logger.debug("Trying to authenticate using Kerberos")
                     return self.kerberos_login(domain, username, secret, "", "", self.kdcHost, False)
                 elif hasattr(self.args, "domain"):  # Some protocols don't use domain for login
@@ -498,7 +496,7 @@ class connection:
                     self.logger.debug("Trying to authenticate using plaintext")
                     return self.plaintext_login(username, secret)
             elif cred_type == "hash":
-                if self.args.kerberos:
+                if self.kerberos:
                     return self.kerberos_login(domain, username, "", secret, "", self.kdcHost, False)
                 return self.hash_login(domain, username, secret)
             elif cred_type == "aesKey":

--- a/nxc/protocols/ldap/laps.py
+++ b/nxc/protocols/ldap/laps.py
@@ -356,7 +356,7 @@ def laps_search(self, username, password, cred_type, domain, dns_server):
     password = msMCSAdmPwd
     domain = self.hostname
     self.args.local_auth = True
-    self.args.kerberos = False
+    self.kerberos = False
     self.logger.extra["protocol"] = prev_protocol
     self.logger.extra["port"] = prev_port
     return username, password, domain


### PR DESCRIPTION
This is an issue from discord.
The problem is if we use flags like `--use-kcache` we need to use kerberos. Though, some checks are still done with `if self.args.kerberos` and not `if self.kerberos` which would be correctly set to `true` when using `--use-kcache`. Therefore, in non-NTLM environments the authentication does not work, because for example:
```py
if self.args.kerberos:
    self.host = self.hostname
```
is not triggered before, when actually `self.kerberos` by the `self.args.use_kcache` flag.

This PR should fix edge case issues, like these:
_NTLM is not supported_
`nxc smb winterfell.north.sevenkingdoms.local --use-kcache` -> fails (because of the aforementioned issue)
`nxc smb winterfell.north.sevenkingdoms.local --use-kcache -k` -> succeeds