### PR TITLE
Updated github workflows

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ["3.11"]
         #python-version: ["3.8", "3.9", "3.10", "3.11"] # for binary builds we only need one version
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: NetExec set up python on ${{ matrix.os }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build Native Binary

--- a/.github/workflows/build-zipapps.yml
+++ b/.github/workflows/build-zipapps.yml
@@ -12,9 +12,9 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: NetExec set up python on ${{ matrix.os }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build Python ZipApp with Shiv

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,7 @@ name: Lint Python code with ruff
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,12 @@ jobs:
       github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install poetry
         run: |
           pipx install poetry
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install poetry
         run: |
           pipx install poetry
       - name: NetExec set up python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry


### PR DESCRIPTION
Updated `actions/checkout` to v4 and `actions/setup-python` to v5, as the older versions are deprecated and throw warnings.