### PR TITLE
Add Unix availability to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pipx ensurepath
 pipx install git+https://github.com/Pennyw0rth/NetExec
 ```
 
-## Availability on other Unix distributions
+## Availability on Unix distributions
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/netexec.svg)](https://repology.org/project/netexec/versions)
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ sudo apt install pipx git
 pipx ensurepath
 pipx install git+https://github.com/Pennyw0rth/NetExec
 ```
+
+## Availability on other Unix distributions
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/netexec.svg)](https://repology.org/project/netexec/versions)
+
 # Development
 Development guidelines and recommendations in development
 


### PR DESCRIPTION
As proposed by @noraj in https://github.com/Pennyw0rth/NetExec-Wiki/pull/15 i would add the packaging status for other distros directly to the README. Feel free to leave your thoughts