### PR TITLE
Fix file logging for display messages

### DIFF
--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -30,7 +30,7 @@ def setup_debug_logging():
         root_logger.setLevel(logging.INFO)
     elif debug_args.debug:
         nxc_logger.logger.setLevel(logging.DEBUG)
-        root_logger.setLevel(logging.INFO)
+        root_logger.setLevel(logging.DEBUG)
     else:
         nxc_logger.logger.setLevel(logging.ERROR)
         root_logger.setLevel(logging.ERROR)

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -163,7 +163,7 @@ class NXCAdapter(logging.LoggerAdapter):
         If debug or info logging is not enabled, we still want display/success/fail logged to the file specified,
         so we create a custom LogRecord and pass it to all the additional handlers (which will be all the file handlers)
         """
-        if self.logger.getEffectiveLevel() >= logging.INFO and len(self.logger.handlers):  # will be 0 if it's just the console output, so only do this if we actually have file loggers
+        if len(self.logger.handlers):  # will be 0 if it's just the console output, so only do this if we actually have file loggers
             try:
                 for handler in self.logger.handlers:
                     handler.handle(LogRecord("nxc", 20, "", kwargs, msg=text, args=args, exc_info=None))

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -163,15 +163,16 @@ class NXCAdapter(logging.LoggerAdapter):
         If debug or info logging is not enabled, we still want display/success/fail logged to the file specified,
         so we create a custom LogRecord and pass it to all the additional handlers (which will be all the file handlers)
         """
+        caller_frame = inspect.currentframe().f_back.f_back.f_back
         if len(self.logger.handlers):  # will be 0 if it's just the console output, so only do this if we actually have file loggers
             try:
                 for handler in self.logger.handlers:
-                    handler.handle(LogRecord("nxc", 20, "", kwargs, msg=text, args=args, exc_info=None))
+                    handler.handle(LogRecord("nxc", 20, pathname=caller_frame.f_code.co_filename, lineno=caller_frame.f_lineno, msg=text, args=args, exc_info=None))
             except Exception as e:
                 self.logger.fail(f"Issue while trying to custom print handler: {e}")
 
     def add_file_log(self, log_file=None):
-        file_formatter = TermEscapeCodeFormatter("%(asctime)s - %(levelname)s - %(message)s")
+        file_formatter = TermEscapeCodeFormatter("%(asctime)s | %(filename)s:%(lineno)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
         output_file = self.init_log_file() if log_file is None else log_file
         file_creation = False
 

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -5,6 +5,7 @@ import os.path
 import sys
 import re
 from nxc.console import nxc_console
+from nxc.paths import NXC_PATH
 from termcolor import colored
 from datetime import datetime
 from rich.text import Text
@@ -194,11 +195,10 @@ class NXCAdapter(logging.LoggerAdapter):
 
     @staticmethod
     def init_log_file():
-        newpath = os.path.expanduser("~/.nxc") + "/logs/" + datetime.now().strftime("%Y-%m-%d")
-        if not os.path.exists(newpath):
-            os.makedirs(newpath)
+        newpath = NXC_PATH + "/logs/" + datetime.now().strftime("%Y-%m-%d")
+        os.makedirs(newpath, exist_ok=True)
         return os.path.join(
-            os.path.expanduser("~/.nxc"),
+            NXC_PATH,
             "logs",
             datetime.now().strftime("%Y-%m-%d"),
             f"log_{datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.log",


### PR DESCRIPTION
This PR will fix missing display (and probably other custom log messages) from not appearing in the file log, see #388.

@Marshall-Hallenbeck originally there was a filter to not log debug messages to the file, which prevented the logging of "display" messages. Any idea why this was the case? I did not find a case where this could cause problems (which doesn't mean there isn't)

Before&After:
![image](https://github.com/user-attachments/assets/44d27ce3-66ad-45d3-9e58-089dbcfd4de3)
![image](https://github.com/user-attachments/assets/327206fd-2380-404b-89b7-51e6e8e06fc6)

Added file&linenumber to debug log, as recommended by @Dfte:
![image](https://github.com/user-attachments/assets/13d02de7-afd3-43f1-89fe-f423aa103b52)

