### PR TITLE
ldap-checker.py false positive fixed

### DIFF
--- a/nxc/modules/ldap-checker.py
+++ b/nxc/modules/ldap-checker.py
@@ -142,7 +142,7 @@ class NXCModule:
                     # because LDAP server signing requirements are not enforced
             except Exception as e:
                 context.log.debug(str(e))
-                return False
+                return None
               
 
         # Run trough all our code blocks to determine LDAP signing and channel binding settings.

--- a/nxc/modules/ldap-checker.py
+++ b/nxc/modules/ldap-checker.py
@@ -126,7 +126,7 @@ class NXCModule:
                 _, err = await ldapsClientConn.connect()
                 if err is not None:
                     context.log.fail(str(err))
-                    return False
+                    return None
                 
                 _, err = await ldapsClientConn.bind()
                 if err is not None:


### PR DESCRIPTION
run_ldap return code changed from False to None when errors are found to avoid false positives such as when connection fails.