### PR TITLE
ldap-checker.py Catch connection errors

### DIFF
--- a/nxc/modules/ldap-checker.py
+++ b/nxc/modules/ldap-checker.py
@@ -99,8 +99,8 @@ class NXCModule:
                 do_handshake_on_connect=False,
                 suppress_ragged_eofs=False,
             )
-            ssl_sock.connect((dcIp, 636))
             try:
+                ssl_sock.connect((dcIp, 636))
                 ssl_sock.do_handshake()
                 ssl_sock.close()
                 return True


### PR DESCRIPTION
Socket connection moved into the try/catch to catch connection errors.