### PR TITLE
Increase plaintext&hash login speeds

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -482,6 +482,7 @@ class connection:
             value = jitter[0] if jitter[0] == jitter[1] else random.choice(range(jitter[0], jitter[1]))
             self.logger.debug(f"Throttle authentications: sleeping {value} second(s)")
             sleep(value)
+        
 
         with sem:
             if cred_type == "plaintext":

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -482,7 +482,6 @@ class connection:
             value = jitter[0] if jitter[0] == jitter[1] else random.choice(range(jitter[0], jitter[1]))
             self.logger.debug(f"Throttle authentications: sleeping {value} second(s)")
             sleep(value)
-        
 
         with sem:
             if cred_type == "plaintext":

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -303,7 +303,7 @@ class smb(connection):
             self.logger.info(f"Resolved domain: {self.domain} with dns, kdcHost: {self.kdcHost}")
 
         # If we want to authenticate we should create another connection object, because we already logged in
-        if self.args.username or self.args.cred_id or self.kerberos:
+        if self.args.username or self.args.cred_id or self.kerberos or self.args.use_kcache:
             self.create_conn_obj()
 
     def print_host_info(self):

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -313,8 +313,6 @@ class smb(connection):
         return True
 
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
-        # Re-connect since we logged off
-        self.create_conn_obj()
         self.logger.debug(f"KDC set to: {kdcHost}")
         lmhash = ""
         nthash = ""
@@ -373,6 +371,7 @@ class smb(connection):
             if self.args.continue_on_success and self.signing:
                 with contextlib.suppress(Exception):
                     self.conn.logoff()
+                self.create_conn_obj()
             return True
         except SessionKeyDecryptionError:
             # success for now, since it's a vulnerability - previously was an error

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -302,6 +302,10 @@ class smb(connection):
             self.kdcHost = result["host"] if result else None
             self.logger.info(f"Resolved domain: {self.domain} with dns, kdcHost: {self.kdcHost}")
 
+        # If we want to authenticate we should create another connection object, because we already logged in
+        if self.args.username or self.args.cred_id or self.kerberos:
+            self.create_conn_obj()
+
     def print_host_info(self):
         signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
         smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=["bold"]) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=["bold"])


### PR DESCRIPTION
This PR removes unnecessary recreation of connection initialization when a login has failed, we can just reuse that smb connection. As we don't need it with kerberos (and it would be a bit more complicated) it is not changed.

Also `create_conn_obj()` now checks if we already tested smbv1 and will choose the version accordingly for further connections, to eliminate the amount of connections.

This results in double the speed when testing credentials:
Before (tested with a wordlist containing ~3,6k lines):
![image](https://github.com/user-attachments/assets/fd50e309-f0db-4926-a404-a7fb2f55926a)
After:
![image](https://github.com/user-attachments/assets/835017c7-948b-4dfd-832f-238c159a8e0d)
