### PR TITLE
Update impersonate.py

### DIFF
--- a/nxc/modules/impersonate.py
+++ b/nxc/modules/impersonate.py
@@ -14,7 +14,7 @@ class NXCModule:
     name = "impersonate"
     description = "List and impersonate tokens to run command as locally logged on users"
     supported_protocols = ["smb"]
-    opsec_safe = True  # could be flagged
+    opsec_safe = False  
     multiple_hosts = True
 
     def options(self, context, module_options):


### PR DESCRIPTION
Hi!

This is not an opsec_safe module because there is explicit interaction with the disk. The module puts the Impersonate.exe file on disk.

Therefore opsec_safe should be set to False according to the naming logic. 