### PR TITLE
Make --version switch universal so help2man will work properly

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -27,6 +27,7 @@ def gen_cli_args():
     
     generic_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
     generic_group = generic_parser.add_argument_group("Generic", "Generic options for nxc across protocols")
+    generic_group.add_argument("--version", action="store_true", help="Display nxc version")
     generic_group.add_argument("-t", "--threads", type=int, dest="threads", default=256, help="set how many concurrent threads to use")
     generic_group.add_argument("--timeout", default=None, type=int, help="max timeout in seconds of each thread")
     generic_group.add_argument("--jitter", metavar="INTERVAL", type=str, help="sets a random delay between each authentication")
@@ -69,8 +70,6 @@ def gen_cli_args():
         parents=[generic_parser, output_parser, dns_parser]
     )
 
-    parser.add_argument("--version", action="store_true", help="Display nxc version")
-
     # we do module arg parsing here so we can reference the module_list attribute below
     module_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
     mgroup = module_parser.add_argument_group("Modules", "Options for nxc modules")
@@ -82,7 +81,7 @@ def gen_cli_args():
     subparsers = parser.add_subparsers(title="Available Protocols", dest="protocol")
 
     std_parser = argparse.ArgumentParser(add_help=False, parents=[generic_parser, output_parser, dns_parser], formatter_class=DisplayDefaultsNotNone)
-    std_parser.add_argument("target", nargs="+" if not (module_parser.parse_known_args()[0].list_modules or module_parser.parse_known_args()[0].show_module_options) else "*", type=str, help="the target IP(s), range(s), CIDR(s), hostname(s), FQDN(s), file(s) containing a list of targets, NMap XML or .Nessus file(s)")
+    std_parser.add_argument("target", nargs="+" if not (module_parser.parse_known_args()[0].list_modules or module_parser.parse_known_args()[0].show_module_options or generic_parser.parse_known_args()[0].version) else "*", type=str, help="the target IP(s), range(s), CIDR(s), hostname(s), FQDN(s), file(s) containing a list of targets, NMap XML or .Nessus file(s)")
     credential_group = std_parser.add_argument_group("Authentication", "Options for authenticating")
     credential_group.add_argument("-u", "--username", metavar="USERNAME", dest="username", nargs="+", default=[], help="username(s) or file(s) containing usernames")
     credential_group.add_argument("-p", "--password", metavar="PASSWORD", dest="password", nargs="+", default=[], help="password(s) or file(s) containing passwords")


### PR DESCRIPTION
Ensure that the `--version` switch is available in all modes so that `help2man` processing will function properly.
* Moves the `--version` switch into generic_parser
* Adds `--version` to the conditions that will suppress the requirement for `target` positional argument

**Motivation:** The netexec package (on Kali in this case) does not include man pages. The existence of man pages is required to enable the use of the `apropos` command. The `apropos` command is used when a user is trying to think of what command they need for what they are trying to do. For example:
```bash
# apropos smb brute force
brutespray (8)       - Python bruteforce tool
netexec (1)          - The network execution tool
patator (1)          - multi-purpose brute-forcer
smbmap (1)           - SMB enumeration tool

# apropos wmi query
netexec (1)          - The network execution tool
```

To ensure that users are more easily able to find and adopt netexec, the project should include man pages even if the `--help` pages are exhaustive. To minimize the overhead of generating man pages, the tool `help2man` can be used to convert the various already existing `--help` pages into actual man pages. The `help2man` tool works best when each program section (i.e., `netexec`, `netexec ftp`, `netexec ldap`, etc.) accepts both `--help` and `--version`. This change puts the `--version` switch into the universal "Generic" argument group and ensures that the `target` positional argument is not required when the `--version` switch is used.