### PR TITLE
Encode delegate/impersonate user name string as utf8 unicode, not latin1

### DIFF
--- a/nxc/protocols/smb/kerberos.py
+++ b/nxc/protocols/smb/kerberos.py
@@ -88,7 +88,7 @@ def kerberos_login_with_S4U(domain, hostname, username, password, nthash, lmhash
     client_name = Principal(impersonate, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
 
     s4u_byte_array = struct.pack("<I", constants.PrincipalNameType.NT_PRINCIPAL.value)
-    s4u_byte_array += b(impersonate) + b(domain) + b"Kerberos"
+    s4u_byte_array += impersonate.encode() + b(domain) + b"Kerberos"
 
     # Finally cksum is computed by calling the KERB_CHECKSUM_HMAC_MD5 hash
     # with the following three parameters: the session key of the TGT of


### PR DESCRIPTION
Since its possible (and completely fine) for user name to be non ascii string, encoding it to bytes with `latin1` (which `six` does) produces `UnicodeEncodeError`.

I'm not using `six` here at all, since project has python3.8 requirement.