### PR TITLE
Fix maq module if MAQ not set

### DIFF
--- a/nxc/modules/hyperv-host.py
+++ b/nxc/modules/hyperv-host.py
@@ -22,7 +22,7 @@ class NXCModule:
     def on_admin_login(self, context, connection):
         self.context = context
 
-        path = "SOFTWARE\Microsoft\Virtual Machine\Guest\Parameters"
+        path = "SOFTWARE\\Microsoft\\Virtual Machine\\Guest\\Parameters"
         key = "HostName"
 
         try:

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -1,3 +1,5 @@
+from pyasn1.error import PyAsn1Error
+
 
 class NXCModule:
     """
@@ -21,9 +23,10 @@ class NXCModule:
     multiple_hosts = False
 
     def on_login(self, context, connection):
-        result = []
         context.log.display("Getting the MachineAccountQuota")
-        searchFilter = "(objectClass=*)"
-        attributes = ["ms-DS-MachineAccountQuota"]
-        result = connection.search(searchFilter, attributes)
-        context.log.highlight("MachineAccountQuota: %d" % result[0]["attributes"][0]["vals"][0])
+        result = connection.search("(objectClass=*)", ["ms-DS-MachineAccountQuota"])
+        try:
+            maq = result[0]["attributes"][0]["vals"][0]
+            context.log.highlight(f"MachineAccountQuota: {maq}")
+        except PyAsn1Error:
+            context.log.highlight("MachineAccountQuota: <not set>")


### PR DESCRIPTION
If the ms-DS-MachineAccountQuota is not set in the domain policy the maq module throws an error while decoding the ldap result, see #421.

This is fixed now:
![image](https://github.com/user-attachments/assets/362ac613-4dd2-42a8-aba3-715ac654b8f1)

Also fixed a string not being escaped properly, which got highlighted by python 3.12.