### PR TITLE
Small cosmetic fix for ldap when using --no-smb

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -302,7 +302,7 @@ class ldap(connection):
     def print_host_info(self):
         self.logger.debug("Printing host info for LDAP")
         if self.args.no_smb:
-            self.logger.extra["protocol"] = "LDAP" if self.port == "389" else "LDAPS"
+            self.logger.extra["protocol"] = "LDAP" if self.port == 389 else "LDAPS"
             self.logger.extra["port"] = self.port
             self.logger.display(f'{self.baseDN} (Hostname: {self.hostname.split(".")[0]}) (domain: {self.domain})')
         else:


### PR DESCRIPTION
In ldap we checked the port against the string "389" before, but as it is an integer it evaluated to false (even when run against port 389) resulting in the logger displaying "LDAPS" instead of "LDAP).

![image](https://github.com/user-attachments/assets/c1b96416-6e69-4c65-b599-3d109581c4c6)
