### PR TITLE
Improve test suite

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -215,7 +215,7 @@ class connection:
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
         return
 
-    def plaintext_login(self, domain, username, password):
+    def plaintext_login(self, username, password):
         return
 
     def hash_login(self, domain, username, ntlm_hash):

--- a/nxc/protocols/nfs/proto_args.py
+++ b/nxc/protocols/nfs/proto_args.py
@@ -1,5 +1,5 @@
 def proto_args(parser, parents):
-    nfs_parser = parser.add_parser("nfs", help="NFS", parents=parents)
+    nfs_parser = parser.add_parser("nfs", help="own stuff using NFS", parents=parents)
     nfs_parser.add_argument("--port", type=int, default=111, help="NFS portmapper port (default: %(default)s)")
     nfs_parser.add_argument("--nfs-timeout", type=int, default=30, help="NFS connection timeout (default: %(default)ss)")
 

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -249,7 +249,7 @@ netexec ftp TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce
 netexec ftp TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce --continue-on-success
 netexec ftp TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE
 ##### NFS
-netexec nfs TARGETHOST -u "" -p "" --shares
-netexec nfs TARGETHOST -u "" -p "" --enum-shares
-netexec nfs TARGETHOST -u "" -p "" --get-file /NFStest/test/test.txt ../test.txt
-netexec nfs TARGETHOST -u "" -p "" --put-file ../test.txt /NFStest/test
+netexec nfs TARGET_HOST -u "" -p "" --shares
+netexec nfs TARGET_HOST -u "" -p "" --enum-shares
+netexec nfs TARGET_HOST -u "" -p "" --get-file /NFStest/test/test.txt ../test.txt
+netexec nfs TARGET_HOST -u "" -p "" --put-file ../test.txt /NFStest/test


### PR DESCRIPTION
A few test suite improvements and removed the `domain` attribute from the `connection.plaintext()` function. Now protocols which do not implement authentication, such as nfs, don't crash if the user still supplies credentials:

Before&After:
![image](https://github.com/user-attachments/assets/04fc4b32-4147-409f-b3cf-89b644281b4a)
