### PR TITLE
Encode-decode subfolder for smb spider to avoid encode error in case non latin-1 symbols

### DIFF
--- a/nxc/protocols/smb/smbspider.py
+++ b/nxc/protocols/smb/smbspider.py
@@ -83,7 +83,7 @@ class SMBSpider:
 
         filelist = None
         try:
-            filelist = self.smbconnection.listPath(self.share, subfolder)
+            filelist = self.smbconnection.listPath(self.share, subfolder.encode('utf-8').decode('latin-1'))
             self.dir_list(filelist, subfolder)
             if depth == 0:
                 return


### PR DESCRIPTION
In case there is a folder with non latin-1 symbols (cyrillic lets say) smb spider will fail with following error
```
[17:00:56] ERROR    Exception while calling proto_flow() on target <ip-address>: 'latin-1' codec can't encode character '\u03b1' in position 60: ordinal not in range(256)                                          connection.py:174
```

Error itself comes from `impacket` which is used for smb connection during list directory step. Although its much easier (and faster) to fix it here.

In case characters are `latin-1` then no change to string will be done.