### PR TITLE
Fix module loading for ssh, vnc and ftp

### DIFF
--- a/nxc/protocols/ftp.py
+++ b/nxc/protocols/ftp.py
@@ -25,7 +25,13 @@ class ftp(connection):
     def proto_flow(self):
         self.proto_logger()
         if self.create_conn_obj() and self.enum_host_info() and self.print_host_info() and self.login():
-            pass
+            if hasattr(self.args, "module") and self.args.module:
+                self.load_modules()
+                self.logger.debug("Calling modules")
+                self.call_modules()
+            else:
+                self.logger.debug("Calling command arguments")
+                self.call_cmd_args()
 
     def enum_host_info(self):
         welcome = self.conn.getwelcome()

--- a/nxc/protocols/ssh.py
+++ b/nxc/protocols/ssh.py
@@ -33,8 +33,11 @@ class ssh(connection):
                 return
             if self.login():
                 if hasattr(self.args, "module") and self.args.module:
+                    self.load_modules()
+                    self.logger.debug("Calling modules")
                     self.call_modules()
                 else:
+                    self.logger.debug("Calling command arguments")
                     self.call_cmd_args()
                 self.conn.close()
 

--- a/nxc/protocols/vnc.py
+++ b/nxc/protocols/vnc.py
@@ -31,8 +31,11 @@ class vnc(connection):
             self.print_host_info()
             if self.login():
                 if hasattr(self.args, "module") and self.args.module:
+                    self.load_modules()
+                    self.logger.debug("Calling modules")
                     self.call_modules()
                 else:
+                    self.logger.debug("Calling command arguments")
                     self.call_cmd_args()
 
     def proto_logger(self):


### PR DESCRIPTION
Before as some protocols implemented `proto_flow` themselves but did not properly load modules. This is fixed now

Fixes #443 