### PR TITLE
Release v1.3.0

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -22,7 +22,7 @@ def gen_cli_args():
     except ValueError:
         VERSION = importlib.metadata.version("netexec")
         COMMIT = ""
-    CODENAME = "ItsAlwaysDNS"
+    CODENAME = "NeedForSpeed"
     nxc_logger.debug(f"NXC VERSION: {VERSION} - {CODENAME} - {COMMIT}")
     
     generic_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netexec"
-version = "1.2.0"
+version = "1.3.0"
 description = "The Network Execution tool"
 authors = [
     "Marshall Hallenbeck <marshall.hallenbeck@gmail.com>",


### PR DESCRIPTION
Speaking for itself (not sure why there is the wrong version number...):
![image](https://github.com/user-attachments/assets/b0e27873-534c-4a51-8255-0604f7a0a5a3)
