### PR TITLE
Fix runasppl.py

### DIFF
--- a/nxc/modules/runasppl.py
+++ b/nxc/modules/runasppl.py
@@ -17,7 +17,7 @@ class NXCModule:
         command = r"reg query HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa\ /v RunAsPPL"
         context.log.debug(f"Executing command: {command}")
         p = connection.execute(command, True)
-        if "The system was unable to find the specified registry key or value" in p:
+        if not p or "The system was unable to find the specified registry key or value" in p:
             context.log.debug("Unable to find RunAsPPL Registry Key")
         else:
             context.log.highlight(p)


### PR DESCRIPTION
`execute()` method of `smb` class returns False if an error occurred. https://github.com/Pennyw0rth/NetExec/blob/main/nxc/protocols/smb.py#L766

If so, the current code fails as `False` is not iterable.

![image](https://github.com/user-attachments/assets/ab0646c4-b737-4b81-ad70-b8f708c82510)

![image](https://github.com/user-attachments/assets/c162fe6e-e595-4c08-a387-909575944df1)


This fix will check if `p` is not `False` before checking the error message in `p`