### PR TITLE
[SMB] Add --enum-shares options like in NFS protocol

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -905,11 +905,6 @@ class smb(connection):
 
 
     def dir(self):
-        # Seems defined by default, do we have to keep this check ?
-        if not self.args.share:
-            self.logger.error("You must define --share option")
-            return
-        
         search_path = ntpath.join(self.args.dir, "*")
         try: 
             contents = self.conn.listPath(self.args.share, search_path)

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -904,7 +904,7 @@ class smb(connection):
         return permissions
 
 
-    def dir(self):
+    def dir(self):  # noqa: A003
         search_path = ntpath.join(self.args.dir, "*")
         try: 
             contents = self.conn.listPath(self.args.share, search_path)

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -34,7 +34,7 @@ def proto_args(parser, parents):
 
     mapping_enum_group = smb_parser.add_argument_group("Mapping/Enumeration", "Options for Mapping/Enumerating")
     mapping_enum_group.add_argument("--shares", action="store_true", help="enumerate shares and access")
-    mapping_enum_group.add_argument("--enum-shares", nargs="?", type=int, const=3, help="Authenticate and enumerate exposed shares recursively (default depth: %(const)s)")
+    mapping_enum_group.add_argument("--dir", nargs="?", type=str, const="", help="List the content of a path (default path: '%(const)s')")
     mapping_enum_group.add_argument("--interfaces", action="store_true", help="enumerate network interfaces")
     mapping_enum_group.add_argument("--no-write-check", action="store_true", help="Skip write check on shares (avoid leaving traces when missing delete permissions)")
     mapping_enum_group.add_argument("--filter-shares", nargs="+", help="Filter share by access, option 'read' 'write' or 'read,write'")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -34,6 +34,7 @@ def proto_args(parser, parents):
 
     mapping_enum_group = smb_parser.add_argument_group("Mapping/Enumeration", "Options for Mapping/Enumerating")
     mapping_enum_group.add_argument("--shares", action="store_true", help="enumerate shares and access")
+    mapping_enum_group.add_argument("--enum-shares", nargs="?", type=int, const=3, help="Authenticate and enumerate exposed shares recursively (default depth: %(const)s)")
     mapping_enum_group.add_argument("--interfaces", action="store_true", help="enumerate network interfaces")
     mapping_enum_group.add_argument("--no-write-check", action="store_true", help="Skip write check on shares (avoid leaving traces when missing delete permissions)")
     mapping_enum_group.add_argument("--filter-shares", nargs="+", help="Filter share by access, option 'read' 'write' or 'read,write'")


### PR DESCRIPTION
This PR give the possibility to enum SMB shares like with NFS.

```
poetry run NetExec smb 192.168.56.11 -u Administrator -p  "<REDACTED>" --enum-shares 1 
```

![image](https://github.com/user-attachments/assets/e574d830-3df4-4cff-b64d-eba7fc2ef849)


