### PR TITLE
Fixed issue with --options flag

### DIFF
--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -173,6 +173,9 @@ def main():
         for module in args.module:
             nxc_logger.display(f"{module} module options:\n{modules[module]['options']}")
         exit(0)
+    elif args.show_module_options:
+        nxc_logger.error(f"--options requires -M/--module")
+        exit(1)
     elif args.module:
         # Check the modules for sanity before loading the protocol
         nxc_logger.debug(f"Modules to be Loaded for sanity check: {args.module}, {type(args.module)}")


### PR DESCRIPTION
Fixed issue with --options flag where the program would still run with 0 targets if the options flag was specified

![image](https://github.com/user-attachments/assets/f1fdfd34-06cf-4d65-87db-6ea1fe1b99d5)

The program only checked the case for ` args.module and args.show_module_options:` but not for `args.show_module_options`

Fixed issue:
![image](https://github.com/user-attachments/assets/3dca7c8b-2c68-4637-b1c2-ecd79816727a)
