### PR TITLE
FIX `a bytes-like object is required, not str` in `nxc/protocols/smb.py`

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -258,6 +258,9 @@ class smb(connection):
         except KeyError:
             self.logger.debug("Error getting server information...")
 
+        if isinstance(self.server_os.lower(), bytes):
+            self.server_os = self.server_os.decode("utf-8")
+            
         if "Windows 6.1" in self.server_os and self.server_os_build == 0 and self.os_arch == 0:
             self.server_os = "Unix - Samba"
         elif self.server_os_build == 0 and self.os_arch == 0:
@@ -265,9 +268,6 @@ class smb(connection):
         self.logger.debug(f"Server OS: {self.server_os} {self.server_os_major}.{self.server_os_minor} build {self.server_os_build}")
 
         self.logger.extra["hostname"] = self.hostname
-
-        if isinstance(self.server_os.lower(), bytes):
-            self.server_os = self.server_os.decode("utf-8")
 
         try:
             self.signing = self.conn.isSigningRequired() if self.smbv1 else self.conn._SMBConnection._Connection["RequireSigning"]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/614aab9d-b5b7-429d-bd14-595a03c53a68)

I fixed a bug by moving a portion of the code higher up.