### PR TITLE
fix(nfs): check if status is 13 and print out permission denied for share

### DIFF
--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -224,7 +224,15 @@ class nfs(connection):
             for share, network in zip(shares, networks):
                 try:
                     mount_info = self.mount.mnt(share, self.auth)
-                    contents = self.list_dir(mount_info["mountinfo"]["fhandle"], share, self.args.enum_shares)
+                    self.logger.debug(f"Mounted {share} - {mount_info}")
+                    if mount_info["status"] != 0:  # noqa: SIM102
+                        if mount_info["status"] == 13:
+                            self.logger.fail(f"{share} - Permission Denied")
+                            continue
+                        # check for other error codes here
+                        
+                    fhandle = mount_info["mountinfo"]["fhandle"]
+                    contents = self.list_dir(fhandle, share, self.args.enum_shares)
 
                     self.logger.success(share)
                     if contents:

--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -170,6 +170,10 @@ class nfs(connection):
             for share, network in zip(shares, networks):
                 try:
                     mnt_info = self.mount.mnt(share, self.auth)
+                    self.logger.debug(f"Mounted {share} - {mnt_info}")
+                    if mnt_info["status"] != 0:
+                        self.logger.fail(f"Error mounting share {share}: {NFSSTAT3[mnt_info['status']]}")
+                        continue
                     file_handle = mnt_info["mountinfo"]["fhandle"]
 
                     info = self.nfs3.fsstat(file_handle, self.auth)
@@ -225,12 +229,10 @@ class nfs(connection):
                 try:
                     mount_info = self.mount.mnt(share, self.auth)
                     self.logger.debug(f"Mounted {share} - {mount_info}")
-                    if mount_info["status"] != 0:  # noqa: SIM102
-                        if mount_info["status"] == 13:
-                            self.logger.fail(f"{share} - Permission Denied")
-                            continue
-                        # check for other error codes here
-                        
+                    if mount_info["status"] != 0:
+                        self.logger.fail(f"Error mounting share {share}: {NFSSTAT3[mount_info['status']]}")
+                        continue
+
                     fhandle = mount_info["mountinfo"]["fhandle"]
                     contents = self.list_dir(fhandle, share, self.args.enum_shares)
 


### PR DESCRIPTION
---
name: Fix for NFS shares that return status 13 - Permission Denied
about: check for status 13 return and output Permission Denied in output instead of TypeError (since the expected data structure is None
title: 'fix: check if status is 13 and print out permission denied for share'
labels: 'bug-fix'
assignees: 'Marshall-Hallenbeck'

---
## Description

When listing shares for NFS, if status 13 is returned, the current code tries to reference mount info where that data structure is None, causing a TypeError

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Rerun `nxc nfs $ip --enum-shares` against the host

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/85328d0f-741b-4b9b-8664-ec7e6554682a)
