### PR TITLE
schtask_as - Delete task when there is an error

### DIFF
--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -166,7 +166,7 @@ class TSCH_EXEC:
         self.__outputBuffer = data
 
     def get_end_boundary(self):
-        # Get current date and time
+        # Get current date and time + 5 minutes
         end_boundary = datetime.now() + timedelta(minutes=5)
 
         # Format it to match the format in the XML: "YYYY-MM-DDTHH:MM:SS.ssssss"

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -91,7 +91,7 @@ class NXCModule:
         except Exception as e:
             if "SCHED_S_TASK_HAS_NOT_RUN" in str(e):
                 self.logger.fail("Task was not run, seems like the specified user has no active session on the target")
-                #exec_method.deleteartifact()
+                exec_method.deleteartifact()
 
 class TSCH_EXEC:
     def __init__(self, target, share_name, username, password, domain, user, cmd, file, task, location, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None):

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -91,7 +91,7 @@ class NXCModule:
         except Exception as e:
             if "SCHED_S_TASK_HAS_NOT_RUN" in str(e):
                 self.logger.fail("Task was not run, seems like the specified user has no active session on the target")
-                exec_method.deleteartifact()
+                #exec_method.deleteartifact()
 
 class TSCH_EXEC:
     def __init__(self, target, share_name, username, password, domain, user, cmd, file, task, location, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None):
@@ -266,6 +266,8 @@ class TSCH_EXEC:
                 tsch.hSchRpcDelete(dce, f"\\{tmpName}")
             if "SCHED_S_TASK_HAS_NOT_RUN" in str(e):
                 tsch.hSchRpcDelete(dce, f"\\{tmpName}")
+            if "ERROR_ALREADY_EXISTS" in str(e):
+                self.logger.fail(f"Schtask_as: Create schedule task failed: {e}")
             else:
                 self.logger.fail(f"Schtask_as: Create schedule task failed: {e}")
                 tsch.hSchRpcDelete(dce, f"\\{tmpName}")

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -273,7 +273,7 @@ class TSCH_EXEC:
                 tsch.hSchRpcDelete(dce, f"\\{tmpName}")
             return
         else:
-            taskCreated = True    
+            taskCreated = True
         self.logger.info(f"Running task \\{tmpName}")
         tsch.hSchRpcRun(dce, f"\\{tmpName}") 
         done = False

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -278,9 +278,6 @@ class TSCH_EXEC:
                     tsch.hSchRpcDelete(dce, f"\\{self.task}")
             return
 
-        self.logger.info(f"Running task \\{self.task}")
-        tsch.hSchRpcRun(dce, f"\\{self.task}")
-
         done = False
         while not done:
             self.logger.debug(f"Calling SchRpcGetLastRunInfo for \\{self.task}")

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -95,6 +95,7 @@ class NXCModule:
             else:
                 self.logger.fail(f"Failed to execute command: {e}")
 
+
 class TSCH_EXEC:
     def __init__(self, target, share_name, username, password, domain, user, cmd, file, task, location, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None):
         self.__target = target
@@ -156,7 +157,7 @@ class TSCH_EXEC:
         self.logger.display(f"Deleting task \\{tmpName}")
         tsch.hSchRpcDelete(dce, f"\\{tmpName}")
         dce.disconnect()
-    
+
     def execute(self, command, output=False):
         self.__retOutput = output
         self.execute_handler(command)
@@ -245,7 +246,6 @@ class TSCH_EXEC:
         xml = self.gen_xml(command, fileless)
 
         self.logger.info(f"Task XML: {xml}")
-        taskCreated = False
         self.logger.info(f"Creating task \\{tmpName}")
         try:
             # windows server 2003 has no MSRPC_UUID_TSCHS, if it bind, it will return abstract_syntax_not_supported
@@ -270,10 +270,10 @@ class TSCH_EXEC:
                 self.logger.fail(f"Schtask_as: Create schedule task failed: {e}")
                 tsch.hSchRpcDelete(dce, f"\\{tmpName}")
             return
-        else:
-            taskCreated = True
+
         self.logger.info(f"Running task \\{tmpName}")
-        tsch.hSchRpcRun(dce, f"\\{tmpName}") 
+        tsch.hSchRpcRun(dce, f"\\{tmpName}")
+
         done = False
         while not done:
             self.logger.debug(f"Calling SchRpcGetLastRunInfo for \\{tmpName}")
@@ -285,10 +285,6 @@ class TSCH_EXEC:
 
         self.logger.info(f"Deleting task \\{tmpName}")
         tsch.hSchRpcDelete(dce, f"\\{tmpName}")
-        taskCreated = False
-
-        if taskCreated is True:
-            tsch.hSchRpcDelete(dce, f"\\{tmpName}")
 
         if self.__retOutput:
             if fileless:

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -151,9 +151,6 @@ class TSCH_EXEC:
                 self.logger.fail(str(e))
             return
 
-        self.logger.info(f"Running task \\{tmpName}")
-        tsch.hSchRpcRun(dce, f"\\{tmpName}")
-
         done = False
         while not done:
             self.logger.debug(f"Calling SchRpcGetLastRunInfo for \\{tmpName}")

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -4,6 +4,7 @@ from impacket.dcerpc.v5.dtypes import NULL
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from nxc.helpers.misc import gen_random_string
 from time import sleep
+from datetime import datetime, timedelta
 
 
 class TSCH_EXEC:
@@ -60,17 +61,20 @@ class TSCH_EXEC:
     def output_callback(self, data):
         self.__outputBuffer = data
 
+    def get_end_boundary(self):
+        # Get current date and time + 5 minutes
+        end_boundary = datetime.now() + timedelta(minutes=5)
+
+        # Format it to match the format in the XML: "YYYY-MM-DDTHH:MM:SS.ssssss"
+        return end_boundary.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+
     def gen_xml(self, command, fileless=False):
-        xml = """<?xml version="1.0" encoding="UTF-16"?>
+        xml = f"""<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <Triggers>
-    <CalendarTrigger>
-      <StartBoundary>2015-07-15T20:35:13.2757294</StartBoundary>
-      <Enabled>true</Enabled>
-      <ScheduleByDay>
-        <DaysInterval>1</DaysInterval>
-      </ScheduleByDay>
-    </CalendarTrigger>
+    <RegistrationTrigger>
+      <EndBoundary>{self.get_end_boundary()}</EndBoundary>
+    </RegistrationTrigger>
   </Triggers>
   <Principals>
     <Principal id="LocalSystem">

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -138,7 +138,6 @@ class TSCH_EXEC:
         xml = self.gen_xml(command, fileless)
 
         self.logger.debug(f"Task XML: {xml}")
-        taskCreated = False
         self.logger.info(f"Creating task \\{tmpName}")
         try:
             # windows server 2003 has no MSRPC_UUID_TSCHS, if it bind, it will return abstract_syntax_not_supported
@@ -151,8 +150,6 @@ class TSCH_EXEC:
             else:
                 self.logger.fail(str(e))
             return
-        else:
-            taskCreated = True
 
         self.logger.info(f"Running task \\{tmpName}")
         tsch.hSchRpcRun(dce, f"\\{tmpName}")
@@ -168,10 +165,6 @@ class TSCH_EXEC:
 
         self.logger.info(f"Deleting task \\{tmpName}")
         tsch.hSchRpcDelete(dce, f"\\{tmpName}")
-        taskCreated = False
-
-        if taskCreated is True:
-            tsch.hSchRpcDelete(dce, f"\\{tmpName}")
 
         if self.__retOutput:
             if fileless:


### PR DESCRIPTION
---
name: schtask_as - Delete task when there is an error
about: Addition to module to delete created task when an error occurs. 
---
## Description

A few months after an engagement, a client contacted me an informed me that some tasks created by "schtask_as" were still present. This was due to some errors during the test that prevented the ability to execute schtask_as, such as the target user not having a session on the host.
This led me to find out that in this scenario, the task is still created and will trigger the next time the user logs into that host. 

**Example - creating task "LabTest3" where the target user doesn't have a session pre-fix:**
![1](https://github.com/user-attachments/assets/4c2e27b6-2f8e-4b28-bf26-63118171dc36)
The attack stops but the task remains on the host
![2](https://github.com/user-attachments/assets/a1ab5941-7274-40de-829b-7b6327c116e3)
![3](https://github.com/user-attachments/assets/c2f03a29-121c-4d2f-8566-cc0d9cefe15d)

Attempting the same command again, this time we get the error that the task already exists.
![image](https://github.com/user-attachments/assets/fc78955f-b0b5-4cf9-a4a6-2aba0b481865)

**Creating task "FixTest00" when a user doesn't have a session post-fix:**
![4](https://github.com/user-attachments/assets/876c950f-a3ca-4c87-92cc-e88f0e05bd44)
"FixTest00" was removed from the host.
![image](https://github.com/user-attachments/assets/ce34c52c-f45e-4cee-8b8f-d89c39822bbd)
![image](https://github.com/user-attachments/assets/59fd0bed-64fe-49c8-87f3-f0f54f2b78ed)

**Successful use of the module**
![image](https://github.com/user-attachments/assets/643b8bad-7720-4313-9d42-2ec09a24dc2d)

With the following changes, most errors will delete the created task. The only error that does not delete a task is when the task name already exists, to prevent deleting legitimate tasks.




## Checklist:

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [X] My code follows the style guidelines of this project (should be covered by Ruff above)
- [X] I have performed a self-review of my own code
 
