### PR TITLE
Fix nmap XML parser when looking for ftp service

### DIFF
--- a/nxc/parsers/nmap.py
+++ b/nxc/parsers/nmap.py
@@ -3,7 +3,7 @@ from nxc.logger import nxc_logger
 
 # right now we are only referencing the port numbers, not the service name, but this should be sufficient for 99% cases
 protocol_dict = {
-    "Ftp": {"ports": [21], "services": ["Ftp"]},
+    "ftp": {"ports": [21], "services": ["ftp"]},
     "ssh": {"ports": [22, 2222], "services": ["ssh"]},
     "smb": {"ports": [139, 445], "services": ["netbios-ssn", "microsoft-ds"]},
     "ldap": {"ports": [389, 636], "services": ["ldap", "ldaps"]},

--- a/nxc/parsers/nmap.py
+++ b/nxc/parsers/nmap.py
@@ -11,6 +11,8 @@ protocol_dict = {
     "rdp": {"ports": [3389], "services": ["ms-wbt-server"]},
     "winrm": {"ports": [5985, 5986], "services": ["wsman"]},
     "vnc": {"ports": [5900, 5901, 5902, 5903, 5904, 5905, 5906], "services": ["vnc"]},
+    "wmi": {"ports": [135], "services": ["msrpc"]},
+    "nfs": {"ports": [2049], "services": ["nfs"]},
 }
 
 


### PR DESCRIPTION
Looks like it was broken in: https://github.com/Pennyw0rth/NetExec/commit/14be9d5b0e7636e850909eb6b2b27d8132a0eec1

```
$ netexec ftp nmap_ftp.xml
Traceback (most recent call last):
  File "/usr/bin/netexec", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3/dist-packages/nxc/netexec.py", line 117, in main
    targets.extend(parse_nmap_xml(target, args.protocol))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/nxc/parsers/nmap.py", line 23, in parse_nmap_xml
    if port in protocol_dict[protocol]["ports"]:
               ~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'ftp'
```