### PR TITLE
Fix veeam output

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,3 @@
----
-name: Pull request
-about: Update code to fix a bug or add an enhancement/feature
-title: ''
-labels: ''
-assignees: ''
-
----
 ## Description
 
 Please include a summary of the change and which issue is fixed, or what the enhancement does.

--- a/nxc/modules/veeam.py
+++ b/nxc/modules/veeam.py
@@ -142,7 +142,7 @@ class NXCModule:
             context.log.fail("Access denied! This is probably due to an AntiVirus software blocking the execution of the PowerShell script.")
 
         # Stripping whitespaces and newlines
-        output_stripped = [" ".join(line.split()) for line in output.split("\r\n") if line.strip()]
+        output_stripped = [line for line in output.replace("\r", "").split("\n") if line.strip()]
 
         # Error handling
         if "Can't connect to DB! Exiting..." in output_stripped or "No passwords found!" in output_stripped:
@@ -154,7 +154,8 @@ class NXCModule:
         try:
             for account in output_stripped:
                 user, password = account.split(" ", 1)
-                password = password.replace("WHITESPACE_ERROR", " ")
+                password = password.strip().replace("WHITESPACE_ERROR", " ")
+                user = user.strip()
                 context.log.highlight(f"{user}:{password}")
                 if " " in password:
                     context.log.fail(f'Password contains whitespaces! The password for user "{user}" is: "{password}"')


### PR DESCRIPTION
## Description
This will fix the output of the veeam module. Previously due to a logic bug credentials were all printed in one output line. This is fixed now.
Also updated the PR template to remove the weird header.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This has been tested on an assessment. Therefore, i can't provide screenshots.

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
