### PR TITLE
Allow for empty domains

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -241,7 +241,7 @@ class smb(connection):
                     self.hostname = self.host
                     self.targetDomain = self.host
 
-        self.domain = self.targetDomain if not self.args.domain else self.args.domain
+        self.domain = self.targetDomain if self.args.domain is None else self.args.domain
 
         if self.args.local_auth:
             self.domain = self.hostname


### PR DESCRIPTION
This arg overrides the default behavior, which sets domain=hostname if not set. Useful in rare ocasions where a truly empty domain is required.

## Description

On rare occasions, you may come across a host that requires an empty string for the domain. Most commonly, this happens when using netexec in combination with a relayed ntlmrelayx.py session. Current behavior is to set the domain to the target hostname if it is not supplied, or set to an empty string with `-d ''`. This overrides any attempts to automatically set it, and sets it to `""`.

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Local testing against a host running responder, with `nxc smb TARGET_IP --null-domain -u '' -p''`. 

Used in the wild with ntlmrelayx.py session with `proxychains4 nxc smb TARGET_IP --null_domain -u '' -p ''`

## Screenshots (if appropriate):

ntlmrelayx.py socks connection that prompted this change

![image](https://github.com/user-attachments/assets/d3935bc3-1a7f-419c-a56f-e6758922a4d1)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
