### PR TITLE
Speed improvements and bug fixes

### DIFF
--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -3,7 +3,6 @@ from logging import LogRecord
 from logging.handlers import RotatingFileHandler
 import os.path
 import sys
-import re
 from nxc.console import nxc_console
 from nxc.paths import NXC_PATH
 from termcolor import colored
@@ -174,7 +173,7 @@ class NXCAdapter(logging.LoggerAdapter):
                 self.logger.fail(f"Issue while trying to custom print handler: {e}")
 
     def add_file_log(self, log_file=None):
-        file_formatter = TermEscapeCodeFormatter("%(asctime)s | %(filename)s:%(lineno)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+        file_formatter = logging.Formatter("%(asctime)s | %(filename)s:%(lineno)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
         output_file = self.init_log_file() if log_file is None else log_file
         file_creation = False
 
@@ -204,18 +203,6 @@ class NXCAdapter(logging.LoggerAdapter):
             datetime.now().strftime("%Y-%m-%d"),
             f"log_{datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.log",
         )
-
-
-class TermEscapeCodeFormatter(logging.Formatter):
-    """A class to strip the escape codes for logging to files"""
-
-    def __init__(self, fmt=None, datefmt=None, style="%", validate=True):
-        super().__init__(fmt, datefmt, style, validate)
-
-    def format(self, record):  # noqa: A003
-        escape_re = re.compile(r"\x1b\[[0-9;]*m")
-        record.msg = re.sub(escape_re, "", str(record.msg))
-        return super().format(record)
 
 
 # initialize the logger for all of nxc - this is imported everywhere

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -43,7 +43,7 @@ def create_temp_logger(caller_frame, formatted_text, args, kwargs):
     temp_logger = logging.getLogger("temp")
     formatter = logging.Formatter("%(message)s", datefmt="[%X]")
     handler = SmartDebugRichHandler(formatter=formatter)
-    handler.handle(LogRecord(temp_logger.name, logging.INFO, caller_frame.f_code.co_filename, caller_frame.f_lineno, formatted_text, args, kwargs, caller_frame=caller_frame))
+    handler.handle(LogRecord(temp_logger.name, logging.INFO, caller_frame.f_code.co_filename, caller_frame.f_lineno, formatted_text, args, None, caller_frame=caller_frame))
 
 
 class SmartDebugRichHandler(RichHandler):
@@ -56,9 +56,6 @@ class SmartDebugRichHandler(RichHandler):
 
     def emit(self, record):
         """Overrides the emit method of the RichHandler class so we can set the proper pathname and lineno"""
-        # for some reason in RDP, the exc_text is None which leads to a KeyError in Python logging
-        record.exc_text = record.getMessage() if record.exc_text is None else record.exc_text
-
         if hasattr(record, "caller_frame"):
             frame_info = inspect.getframeinfo(record.caller_frame)
             record.pathname = frame_info.filename

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -554,8 +554,11 @@ class smb(connection):
         except OSError as e:
             if "Connection reset by peer" in str(e):
                 self.logger.info(f"SMBv1 might be disabled on {self.host}")
-            if "timed out" in str(e):
+            elif "timed out" in str(e):
                 self.is_timeouted = True
+                self.logger.debug(f"Timeout creating SMBv1 connection to {self.host}")
+            else:
+                self.logger.info(f"Error creating SMBv1 connection to {self.host}: {e}")
             return False
         except NetBIOSError:
             self.logger.info(f"SMBv1 disabled on {self.host}")
@@ -576,15 +579,7 @@ class smb(connection):
                 timeout=self.args.smb_timeout,
             )
             self.smbv1 = False
-        except OSError as e:
-            # This should not happen anymore!!!
-            if str(e).find("Too many open files") != -1:
-                if not self.logger:
-                    print("DEBUG ERROR: logger not set, please open an issue on github: " + str(self) + str(self.logger))
-                    self.proto_logger()
-                self.logger.fail(f"SMBv3 connection error on {self.host}: {e}")
-            return False
-        except (Exception, NetBIOSTimeout) as e:
+        except (Exception, NetBIOSTimeout, OSError) as e:
             self.logger.info(f"Error creating SMBv3 connection to {self.host}: {e}")
             return False
         return True

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -846,7 +846,7 @@ class smb(connection):
             self.logger.debug(f"domain: {self.domain}")
             user_id = self.db.get_user(self.domain.upper(), self.username)[0][0]
         except IndexError as e:
-            if self.kerberos:
+            if self.kerberos or self.username == "":
                 pass
             else:
                 self.logger.fail(f"IndexError: {e!s}")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -948,10 +948,9 @@ class smb(connection):
             self.logger.highlight(f"{name:<15} {','.join(perms):<15} {remark}")
         return permissions
 
-
     def dir(self):  # noqa: A003
         search_path = ntpath.join(self.args.dir, "*")
-        try: 
+        try:
             contents = self.conn.listPath(self.args.share, search_path)
         except SessionError as e:
             error = get_error_string(e)
@@ -960,7 +959,7 @@ class smb(connection):
                 color="magenta" if error in smb_error_status else "red",
             )
             return
-        
+
         if not contents:
             return
 
@@ -969,7 +968,6 @@ class smb(connection):
         for content in contents:
             full_path = ntpath.join(self.args.dir, content.get_longname())
             self.logger.highlight(f"{'d' if content.is_directory() else 'f'}{'rw-' if content.is_readonly() > 0 else 'r--':<8}{content.get_filesize():<15}{ctime(float(content.get_mtime_epoch())):<30}{full_path:<45}")
-
 
     @requires_admin
     def interfaces(self):


### PR DESCRIPTION
## Description
There are several bug fixes and improvements that have been done:
- Improved Scanning speed
- Bug fixes in the logging, so we don't log messages 2x when running debug mode
- Small fix so we don't display an index error when scanning with null session, e.g. `-u ''`
- Removed outdated code

### Improvement to scanning speed
We always tried smbv1 and smbv3 when scanning a subnet. In #317 i removed an unnecessary step where we would always try smbv1 against a host where we already know it's gonna be smbv3. With this change we now also don't try smbv3 when the connection for smbv1 times out, as the host is not responding -> it is likely down. This reduces time to scan per subnet from ~5s down to ~3s -> nearly 40% speed improvement for subnet scanning 🎉 
![image](https://github.com/user-attachments/assets/82b05325-5acf-4c70-bfd1-438ce398dd14)

### Fixing duplicate logging message
Before&After:
![image](https://github.com/user-attachments/assets/f9805c2a-c504-44c7-9694-36b6b3dd95c8)

