### PR TITLE
Bugfix: file extension filter of spiderplus was misleading/broken

### DIFF
--- a/nxc/modules/spider_plus.py
+++ b/nxc/modules/spider_plus.py
@@ -286,6 +286,8 @@ class SMBSpiderPlus:
         # Check file extension filter.
         _, file_extension = splitext(file_path)
         if file_extension:
+            if file_extension.startswith(".") and len(file_extension) > 1:
+                file_extension = file_extension[1:]
             self.stats["file_exts"].add(file_extension.lower())
             if file_extension.lower() in self.exclude_exts:
                 self.logger.info(f'The file "{file_path}" has an excluded extension.')


### PR DESCRIPTION
Hi, this PR aims to fix the file extension filter of the SMB spider_plus module.
Both the default filters and potential user input are given without a dot in the unwanted extensions: 
`` EXCLUDE_EXTS      Case-insensitive extension filter to exclude (Default: ico,lnk)``

However the `splitext` method from `os.path` keeps the dot from the file extention:
![image](https://github.com/user-attachments/assets/19d2330e-f3aa-47b9-9c40-c86e101b1b4c)

The fix only checks for a prepending dot and removes it, this issue could also be fixed by changing the options' readme as well as the default option list array by adding dots however I felt like passing for example ``-o EXCLUDE_EXTS=ico,lnk,pdf,dll`` feels much cleaner than ``EXCLUDE_EXTS=.ico,.lnk,.pdf,.dll``