### PR TITLE
Fix RDP '--nla-screenshot' option

### DIFF
--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -379,16 +379,16 @@ class rdp(connection):
                 self.auth = NTLMCredential(secret="", username="", domain="", stype=asyauthSecret.PASS)
                 self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
                 await self.connect_rdp()
-                await asyncio.sleep(int(self.args.screentime))
-
-                if self.conn is not None and self.conn.desktop_buffer_has_data is True:
-                    buffer = self.conn.get_desktop_buffer(VIDEO_FORMAT.PIL)
-                    filename = os.path.expanduser(f"~/.nxc/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png")
-                    buffer.save(filename, "png")
-                    self.logger.highlight(f"NLA Screenshot saved {filename}")
-                    return
             except Exception:
-                pass
+                return
+
+            await asyncio.sleep(int(self.args.screentime))
+            if self.conn is not None and self.conn.desktop_buffer_has_data is True:
+                buffer = self.conn.get_desktop_buffer(VIDEO_FORMAT.PIL)
+                filename = os.path.expanduser(f"~/.nxc/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png")
+                buffer.save(filename, "png")
+                self.logger.highlight(f"NLA Screenshot saved {filename}")
+                return
 
     def nla_screenshot(self):
         if not self.nla:

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -373,18 +373,22 @@ class rdp(connection):
         asyncio.run(self.screen())
 
     async def nla_screen(self):
-        # Otherwise it crash
-        self.iosettings.supported_protocols = None
-        self.auth = NTLMCredential(secret="", username="", domain="", stype=asyauthSecret.PASS)
-        self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
-        await self.connect_rdp()
-        await asyncio.sleep(int(self.args.screentime))
+        for proto in self.protoflags_nla:
+            try:
+                self.iosettings.supported_protocols = proto
+                self.auth = NTLMCredential(secret="", username="", domain="", stype=asyauthSecret.PASS)
+                self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
+                await self.connect_rdp()
+                await asyncio.sleep(int(self.args.screentime))
 
-        if self.conn is not None and self.conn.desktop_buffer_has_data is True:
-            buffer = self.conn.get_desktop_buffer(VIDEO_FORMAT.PIL)
-            filename = os.path.expanduser(f"~/.nxc/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png")
-            buffer.save(filename, "png")
-            self.logger.highlight(f"NLA Screenshot saved {filename}")
+                if self.conn is not None and self.conn.desktop_buffer_has_data is True:
+                    buffer = self.conn.get_desktop_buffer(VIDEO_FORMAT.PIL)
+                    filename = os.path.expanduser(f"~/.nxc/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png")
+                    buffer.save(filename, "png")
+                    self.logger.highlight(f"NLA Screenshot saved {filename}")
+                    return
+            except Exception:
+                pass
 
     def nla_screenshot(self):
         if not self.nla:

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -22,6 +22,8 @@ from asyauth.common.credentials.kerberos import KerberosCredential
 from asyauth.common.constants import asyauthSecret
 from asysocks.unicomm.common.target import UniTarget, UniProto
 
+from nxc.paths import NXC_PATH
+
 
 class rdp(connection):
     def __init__(self, args, db, host):
@@ -166,6 +168,7 @@ class rdp(connection):
         return True
 
     def check_nla(self):
+        self.logger.debug(f"Checking NLA for {self.host}")
         for proto in self.protoflags_nla:
             try:
                 self.iosettings.supported_protocols = proto
@@ -381,13 +384,14 @@ class rdp(connection):
                 self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
 
                 await self.connect_rdp()
-            except Exception:
+            except Exception as e:
+                self.logger.debug(f"Failed to connect for nla_screenshot with {proto} {e}")
                 return
 
             await asyncio.sleep(int(self.args.screentime))
             if self.conn is not None and self.conn.desktop_buffer_has_data is True:
                 buffer = self.conn.get_desktop_buffer(VIDEO_FORMAT.PIL)
-                filename = os.path.expanduser(f"~/.nxc/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png")
+                filename = os.path.expanduser(f"{NXC_PATH}/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png")
                 buffer.save(filename, "png")
                 self.logger.highlight(f"NLA Screenshot saved {filename}")
                 return

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -373,11 +373,13 @@ class rdp(connection):
         asyncio.run(self.screen())
 
     async def nla_screen(self):
+        self.auth = NTLMCredential(secret="", username="", domain="", stype=asyauthSecret.PASS)
+
         for proto in self.protoflags_nla:
             try:
                 self.iosettings.supported_protocols = proto
-                self.auth = NTLMCredential(secret="", username="", domain="", stype=asyauthSecret.PASS)
                 self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
+
                 await self.connect_rdp()
             except Exception:
                 return


### PR DESCRIPTION
## Description

On recent target, I received this error while using the `--nla-screenshot` option of the RDP protocol:
```
[19:13:38] ERROR    Exception while calling proto_flow() on target 10.X.X.X:        connection.py:174
                    CredSSP - Server sent an error! Code: 0xc000006d
```

Trying a bunch of protoflags seems to solve the issue, mimicking what was done on the `check_nla()` function:
```
# nxc rdp 10.X.X.X --nla-screenshot
RDP         10.X.X.X      3389   MECM             [*] Windows 10 or Windows Server 2016 Build 17763 (name:MECM) (domain:sccm.lab) (nla:False)
RDP         10.X.X.X      3389   MECM             NLA Screenshot saved /root/.nxc/screenshots/MECM_10.X.X.X_2024-12-10_193035.png
```

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
```
# nxc rdp 10.X.X.X --nla-screenshot
RDP         10.X.X.X      3389   MECM             [*] Windows 10 or Windows Server 2016 Build 17763 (name:MECM) (domain:sccm.lab) (nla:False)
RDP         10.X.X.X      3389   MECM             NLA Screenshot saved /root/.nxc/screenshots/MECM_10.X.X.X_2024-12-10_193035.png
```

## Screenshots (if appropriate):
N/A

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] I have performed a self-review of my own code
