### PR TITLE
Add baseDN flag to ldap

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1246,6 +1246,7 @@ class ldap(connection):
         try:
             self.logger.debug(f"Search Filter={searchFilter}")
             resp = self.ldapConnection.search(
+                searchBase=self.baseDN,
                 searchFilter=searchFilter,
                 attributes=[
                     "sAMAccountName",
@@ -1373,6 +1374,7 @@ class ldap(connection):
         self.logger.display("Getting GMSA Passwords")
         search_filter = "(objectClass=msDS-GroupManagedServiceAccount)"
         gmsa_accounts = self.ldapConnection.search(
+            searchBase=self.baseDN,
             searchFilter=search_filter,
             attributes=[
                 "sAMAccountName",
@@ -1380,7 +1382,6 @@ class ldap(connection):
                 "msDS-GroupMSAMembership",
             ],
             sizeLimit=0,
-            searchBase=self.baseDN,
         )
         if gmsa_accounts:
             self.logger.debug(f"Total of records returned {len(gmsa_accounts):d}")
@@ -1426,10 +1427,10 @@ class ldap(connection):
                 # getting the gmsa account
                 search_filter = "(objectClass=msDS-GroupManagedServiceAccount)"
                 gmsa_accounts = self.ldapConnection.search(
+                    searchBase=self.baseDN,
                     searchFilter=search_filter,
                     attributes=["sAMAccountName"],
                     sizeLimit=0,
-                    searchBase=self.baseDN,
                 )
                 if gmsa_accounts:
                     self.logger.debug(f"Total of records returned {len(gmsa_accounts):d}")
@@ -1456,10 +1457,10 @@ class ldap(connection):
                 # getting the gmsa account
                 search_filter = "(objectClass=msDS-GroupManagedServiceAccount)"
                 gmsa_accounts = self.ldapConnection.search(
+                    searchBase=self.baseDN,
                     searchFilter=search_filter,
                     attributes=["sAMAccountName"],
                     sizeLimit=0,
-                    searchBase=self.baseDN,
                 )
                 if gmsa_accounts:
                     self.logger.debug(f"Total of records returned {len(gmsa_accounts):d}")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -255,6 +255,7 @@ class ldap(connection):
 
     def enum_host_info(self):
         self.target, self.targetDomain, self.baseDN = self.get_ldap_info(self.host)
+        self.baseDN = self.args.base_dn if self.args.base_dn else self.baseDN   # Allow overwriting baseDN from args
         self.hostname = self.target
         self.remoteName = self.target
         self.domain = self.targetDomain
@@ -697,6 +698,7 @@ class ldap(connection):
                 # Microsoft Active Directory set an hard limit of 1000 entries returned by any search
                 paged_search_control = ldapasn1_impacket.SimplePagedResultsControl(criticality=True, size=1000)
                 return self.ldapConnection.search(
+                    searchBase=self.baseDN,
                     searchFilter=searchFilter,
                     attributes=attributes,
                     sizeLimit=sizeLimit,

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -15,7 +15,8 @@ def proto_args(parser, parents):
     egroup.add_argument("--asreproast", help="Output AS_REP response to crack with hashcat to file")
     egroup.add_argument("--kerberoasting", help="Output TGS ticket to crack with hashcat to file")
 
-    vgroup = ldap_parser.add_argument_group("Retrieve useful information on the domain", "Options to to play with Kerberos")
+    vgroup = ldap_parser.add_argument_group("Retrieve useful information on the domain")
+    vgroup.add_argument("--base-dn", metavar="BASE_DN", dest="base_dn", type=str, default=None, help="base DN for search queries")
     vgroup.add_argument("--query", nargs=2, help="Query LDAP with a custom filter and attributes")
     vgroup.add_argument("--find-delegation", action="store_true", help="Finds delegation relationships within an Active Directory domain. (Enabled Accounts only)")
     vgroup.add_argument("--trusted-for-delegation", action="store_true", help="Get the list of users and computers with flag TRUSTED_FOR_DELEGATION")


### PR DESCRIPTION
## Description
Following up on #500 this PR adds the ability to manually specify the baseDN for search requests. This enables finding object, that otherwise would not be found by the query. See https://github.com/Pennyw0rth/NetExec/pull/500#issuecomment-2517954528 and https://github.com/fortra/impacket/pull/1855.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manual testing is the best testing right...
Normal search queries still work as intended

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/8580a8c1-59c1-4bb8-be1b-d7db305736b8)
