### PR TITLE
Remove smb from ldap proto

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -14,8 +14,6 @@ from Cryptodome.Hash import MD4
 from OpenSSL.SSL import SysCallError
 from bloodhound.ad.authentication import ADAuthentication
 from bloodhound.ad.domain import AD
-from impacket.dcerpc.v5.epm import MSRPC_UUID_PORTMAP
-from impacket.dcerpc.v5.rpcrt import DCERPCException, RPC_C_AUTHN_GSS_NEGOTIATE
 from impacket.dcerpc.v5.samr import (
     UF_ACCOUNTDISABLE,
     UF_DONT_REQUIRE_PREAUTH,
@@ -23,7 +21,6 @@ from impacket.dcerpc.v5.samr import (
     UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION,
     UF_SERVER_TRUST_ACCOUNT,
 )
-from impacket.dcerpc.v5.transport import DCERPCTransportFactory
 from impacket.krb5 import constants
 from impacket.krb5.kerberosv5 import getKerberosTGS, SessionKeyDecryptionError
 from impacket.krb5.types import Principal, KerberosException
@@ -31,7 +28,7 @@ from impacket.ldap import ldap as ldap_impacket
 from impacket.ldap import ldaptypes
 from impacket.ldap import ldapasn1 as ldapasn1_impacket
 from impacket.ldap.ldap import LDAPFilterSyntaxError
-from impacket.smbconnection import SMBConnection, SessionError
+from impacket.smbconnection import SessionError
 from impacket.ntlm import getNTLMSSPType1
 
 from nxc.config import process_secret, host_info_colors
@@ -238,13 +235,13 @@ class ldap(connection):
 
         ntlm_challenge = None
         bindRequest = ldapasn1_impacket.BindRequest()
-        bindRequest['version'] = 3
-        bindRequest['name'] = ""
+        bindRequest["version"] = 3
+        bindRequest["name"] = ""
         negotiate = getNTLMSSPType1()
-        bindRequest['authentication']['sicilyNegotiate'] = negotiate.getData()
+        bindRequest["authentication"]["sicilyNegotiate"] = negotiate.getData()
         try:
-            response = self.ldap_connection.sendReceive(bindRequest)[0]['protocolOp']
-            ntlm_challenge = bytes(response['bindResponse']['matchedDN'])
+            response = self.ldap_connection.sendReceive(bindRequest)[0]["protocolOp"]
+            ntlm_challenge = bytes(response["bindResponse"]["matchedDN"])
         except Exception as e:
             self.logger.debug(f"Failed to get target {self.host} ntlm challenge, error: {e!s}")
 

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -229,7 +229,7 @@ class ldap(connection):
 
     def enum_host_info(self):
         self.baseDN = self.args.base_dn if self.args.base_dn else self.baseDN   # Allow overwriting baseDN from args
-        self.hostname = self.target
+        self.hostname = self.target.split(".")[0].upper()
         self.remoteName = self.target
         self.domain = self.targetDomain
 
@@ -260,7 +260,7 @@ class ldap(connection):
         self.logger.debug("Printing host info for LDAP")
         self.logger.extra["protocol"] = "LDAP" if str(self.port) == "389" else "LDAPS"
         self.logger.extra["port"] = self.port
-        self.logger.extra["hostname"] = self.target.split(".")[0].upper()
+        self.logger.extra["hostname"] = self.hostname
         self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain})")
 
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -134,7 +134,7 @@ class ldap(connection):
         self.server_os = None
         self.os_arch = 0
         self.hash = None
-        self.ldapConnection = None
+        self.ldap_connection = None
         self.lmhash = ""
         self.nthash = ""
         self.baseDN = ""
@@ -302,8 +302,8 @@ class ldap(connection):
             proto = "ldaps" if (self.args.gmsa or self.port == 636) else "ldap"
             ldap_url = f"{proto}://{self.target}"
             self.logger.info(f"Connecting to {ldap_url} - {self.baseDN} - {self.host} [1]")
-            self.ldapConnection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
-            self.ldapConnection.kerberosLogin(username, password, domain, self.lmhash, self.nthash, aesKey, kdcHost=kdcHost, useCache=useCache)
+            self.ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
+            self.ldap_connection.kerberosLogin(username, password, domain, self.lmhash, self.nthash, aesKey, kdcHost=kdcHost, useCache=useCache)
             if self.username == "":
                 self.username = self.get_ldap_username()
 
@@ -347,8 +347,8 @@ class ldap(connection):
                     self.logger.extra["port"] = "636"
                     ldaps_url = f"ldaps://{self.target}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host} [2]")
-                    self.ldapConnection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
-                    self.ldapConnection.kerberosLogin(username, password, domain, self.lmhash, self.nthash, aesKey, kdcHost=kdcHost, useCache=useCache)
+                    self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
+                    self.ldap_connection.kerberosLogin(username, password, domain, self.lmhash, self.nthash, aesKey, kdcHost=kdcHost, useCache=useCache)
                     if self.username == "":
                         self.username = self.get_ldap_username()
 
@@ -404,8 +404,8 @@ class ldap(connection):
             proto = "ldaps" if (self.args.gmsa or self.port == 636) else "ldap"
             ldap_url = f"{proto}://{self.target}"
             self.logger.info(f"Connecting to {ldap_url} - {self.baseDN} - {self.host} [3]")
-            self.ldapConnection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
-            self.ldapConnection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
+            self.ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
+            self.ldap_connection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
             self.check_if_admin()
 
             # Prepare success credential text
@@ -425,8 +425,8 @@ class ldap(connection):
                     self.logger.extra["port"] = "636"
                     ldaps_url = f"ldaps://{self.target}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host} [4]")
-                    self.ldapConnection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
-                    self.ldapConnection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
+                    self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
+                    self.ldap_connection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
                     self.check_if_admin()
 
                     # Prepare success credential text
@@ -490,8 +490,8 @@ class ldap(connection):
             proto = "ldaps" if (self.args.gmsa or self.port == 636) else "ldap"
             ldaps_url = f"{proto}://{self.target}"
             self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host}")
-            self.ldapConnection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
-            self.ldapConnection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
+            self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
+            self.ldap_connection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
             self.check_if_admin()
 
             # Prepare success credential text
@@ -511,8 +511,8 @@ class ldap(connection):
                     self.logger.extra["port"] = "636"
                     ldaps_url = f"{proto}://{self.target}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host}")
-                    self.ldapConnection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
-                    self.ldapConnection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
+                    self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
+                    self.ldap_connection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
                     self.check_if_admin()
 
                     # Prepare success credential text
@@ -605,12 +605,12 @@ class ldap(connection):
 
     def search(self, searchFilter, attributes, sizeLimit=0) -> list:
         try:
-            if self.ldapConnection:
+            if self.ldap_connection:
                 self.logger.debug(f"Search Filter={searchFilter}")
 
                 # Microsoft Active Directory set an hard limit of 1000 entries returned by any search
                 paged_search_control = ldapasn1_impacket.SimplePagedResultsControl(criticality=True, size=1000)
-                return self.ldapConnection.search(
+                return self.ldap_connection.search(
                     searchBase=self.baseDN,
                     searchFilter=searchFilter,
                     attributes=attributes,
@@ -1158,7 +1158,7 @@ class ldap(connection):
         searchFilter = "(userAccountControl:1.2.840.113556.1.4.803:=32)"
         try:
             self.logger.debug(f"Search Filter={searchFilter}")
-            resp = self.ldapConnection.search(
+            resp = self.ldap_connection.search(
                 searchBase=self.baseDN,
                 searchFilter=searchFilter,
                 attributes=[
@@ -1286,7 +1286,7 @@ class ldap(connection):
     def gmsa(self):
         self.logger.display("Getting GMSA Passwords")
         search_filter = "(objectClass=msDS-GroupManagedServiceAccount)"
-        gmsa_accounts = self.ldapConnection.search(
+        gmsa_accounts = self.ldap_connection.search(
             searchBase=self.baseDN,
             searchFilter=search_filter,
             attributes=[
@@ -1339,7 +1339,7 @@ class ldap(connection):
             else:
                 # getting the gmsa account
                 search_filter = "(objectClass=msDS-GroupManagedServiceAccount)"
-                gmsa_accounts = self.ldapConnection.search(
+                gmsa_accounts = self.ldap_connection.search(
                     searchBase=self.baseDN,
                     searchFilter=search_filter,
                     attributes=["sAMAccountName"],
@@ -1369,7 +1369,7 @@ class ldap(connection):
                 gmsa_pass = gmsa[1]
                 # getting the gmsa account
                 search_filter = "(objectClass=msDS-GroupManagedServiceAccount)"
-                gmsa_accounts = self.ldapConnection.search(
+                gmsa_accounts = self.ldap_connection.search(
                     searchBase=self.baseDN,
                     searchFilter=search_filter,
                     attributes=["sAMAccountName"],

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -5,7 +5,6 @@ def proto_args(parser, parents):
     ldap_parser = parser.add_parser("ldap", help="own stuff using LDAP", parents=parents, formatter_class=DisplayDefaultsNotNone)
     ldap_parser.add_argument("-H", "--hash", metavar="HASH", dest="hash", nargs="+", default=[], help="NTLM hash(es) or file(s) containing NTLM hashes")
     ldap_parser.add_argument("--port", type=int, default=389, help="LDAP port")
-    ldap_parser.add_argument("--no-smb", action="store_true", help="No smb connection")
 
     dgroup = ldap_parser.add_mutually_exclusive_group()
     dgroup.add_argument("-d", metavar="DOMAIN", dest="domain", type=str, default=None, help="domain to authenticate to")


### PR DESCRIPTION
## Description

Actually, ldap proto is using SMB to get host information. Using the PR of @XiaoliChan #245 I've added only the interesting part to avoid any breaking change but removing smb.

## Type of change
Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Against GOAD lab

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/b251d540-ac09-424b-87b2-4d56f20dbb3a)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
