### PR TITLE
fix trust relation for smb

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -296,9 +296,10 @@ class smb(connection):
             self.logger.debug(f"Error logging off system: {e}")
 
         # DCOM connection with kerberos needed
-        self.remoteName = self.host if not self.kerberos else f"{self.hostname}.{self.domain}"
+        self.remoteName = self.host if not self.kerberos else f"{self.hostname}.{self.targetDomain}"
 
-        if not self.kdcHost and self.domain:
+        # using kdcHost is buggy on impacket when using trust relation between ad so we kdcHost must stay to none if targetdomain is not equal to domain
+        if not self.kdcHost and self.domain and self.domain == self.targetDomain:
             result = self.resolver(self.domain)
             self.kdcHost = result["host"] if result else None
             self.logger.info(f"Resolved domain: {self.domain} with dns, kdcHost: {self.kdcHost}")


### PR DESCRIPTION
## Description

This PR fix the trust relation between two AD (it was broken)

The fix is very simple, `self.remoteName` need to be equal to `{self.hostname}.{self.targetDomain}` and not `{self.hostname}.{self.domain}` as your domain is not the same as your target domain (since it's a trust)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested against GOAD lab

![image](https://github.com/user-attachments/assets/4a8bfee7-4634-402d-8d51-14a1651a223a)

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
