### PR TITLE
fix trust relation for ldap

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -249,7 +249,7 @@ class ldap(connection):
             ntlm_info = parse_challenge(ntlm_challenge)
             self.server_os = ntlm_info["os_version"]
 
-        if not self.kdcHost and self.domain:
+        if not self.kdcHost and self.domain and self.domain == self.remoteName:
             result = self.resolver(self.domain)
             self.kdcHost = result["host"] if result else None
             self.logger.info(f"Resolved domain: {self.domain} with dns, kdcHost: {self.kdcHost}")


### PR DESCRIPTION
## Description

If targetdomain is not the same as domain, don't check the kdchost 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Against GOAD lab

![image](https://github.com/user-attachments/assets/cc64932b-a9b6-4f41-8af2-82d55eb5e23a)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas