### PR TITLE
Change error to fail message

### DIFF
--- a/nxc/modules/mssql_coerce.py
+++ b/nxc/modules/mssql_coerce.py
@@ -75,5 +75,5 @@ class NXCModule:
                 result = self.mssql_conn.sql_query(command)
                 self.context.log.debug(f"Executing command: {command}, Command result: {result}")
             except Exception as e:
-                self.context.log.error(f"Failed to execute command: {command}, Error: {e}")
+                self.context.log.fail(f"Failed to execute command: {command}, Error: {e}")
         self.context.log.display("Commands executed successfully, check the listener for results")


### PR DESCRIPTION
Error messages should only be used when logic breaks, not when commands fail. Looks a lot better imo:
![image](https://github.com/user-attachments/assets/c7c70249-1be6-4c66-8aa7-f4e45d009e26)
