### PR TITLE
Fix #514

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -384,7 +384,7 @@ class connection:
             if isfile(user):
                 with open(user) as user_file:
                     for line in user_file:
-                        if "\\" in line:
+                        if "\\" in line and len(line.split("\\")) == 2:
                             domain_single, username_single = line.split("\\")
                         else:
                             domain_single = self.args.domain if hasattr(self.args, "domain") and self.args.domain else self.domain


### PR DESCRIPTION
Small fix for #514 when a username in a wordlist has at least two backslashes, e.g. `user\\name`.
Before&After:
![image](https://github.com/user-attachments/assets/678877d2-2827-4971-8381-99f140ea0cc2)
