### PR TITLE
[SMB] Allow force to disable SMBv1

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -592,7 +592,7 @@ class smb(connection):
         no_smbv1 = self.args.no_smbv1 if self.args.no_smbv1 else no_smbv1
 
         # Initial negotiation
-        if self.smbv1 is None:
+        if not no_smbv1 and self.smbv1 is None:
             self.smbv1 = self.create_smbv1_conn()
             if self.smbv1:
                 return True

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -16,7 +16,7 @@ def proto_args(parser, parents):
     smb_parser.add_argument("--port", type=int, default=445, help="SMB port")
     smb_parser.add_argument("--share", metavar="SHARE", default="C$", help="specify a share")
     smb_parser.add_argument("--smb-server-port", default="445", help="specify a server port for SMB", type=int)
-    smb_parser.add_argument("--force-smbv2", action="store_true", help="Force to use SMBv2 in connection")
+    smb_parser.add_argument("--no-smbv1", action="store_true", help="Force to disable SMBv1 in connection")
     smb_parser.add_argument("--gen-relay-list", metavar="OUTPUT_FILE", help="outputs all hosts that don't require SMB signing to the specified file")
     smb_parser.add_argument("--smb-timeout", help="SMB connection timeout", type=int, default=2)
     smb_parser.add_argument("--laps", dest="laps", metavar="LAPS", type=str, help="LAPS authentification", nargs="?", const="administrator")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -16,6 +16,7 @@ def proto_args(parser, parents):
     smb_parser.add_argument("--port", type=int, default=445, help="SMB port")
     smb_parser.add_argument("--share", metavar="SHARE", default="C$", help="specify a share")
     smb_parser.add_argument("--smb-server-port", default="445", help="specify a server port for SMB", type=int)
+    smb_parser.add_argument("--force-smbv2", action="store_true", help="Force to use SMBv2 in connection")
     smb_parser.add_argument("--gen-relay-list", metavar="OUTPUT_FILE", help="outputs all hosts that don't require SMB signing to the specified file")
     smb_parser.add_argument("--smb-timeout", help="SMB connection timeout", type=int, default=2)
     smb_parser.add_argument("--laps", dest="laps", metavar="LAPS", type=str, help="LAPS authentification", nargs="?", const="administrator")

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -5,6 +5,7 @@ netexec smb TARGET_HOST --generate-hosts-file /tmp/hostsfile
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec {DNS} smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --shares
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --shares --no-smbv1
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --shares --filter-shares READ WRITE
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --pass-pol
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --disks


### PR DESCRIPTION
## Description
Allow force to disable smbv1 in smb connection

## Type of change
Please delete options that are not relevant.
- [√] Bug fix (non-breaking change which fixes an issue)
- [√] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
nxc smb 127.0.0.1 -u a -p a --no-smbv1 --shares

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/8fabbab9-0424-4aa3-93cc-2434e9adbfa4)

## Checklist:

- [√] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [√] I have added or updated the tests/e2e_commands.txt file if necessary
- [√] New and existing e2e tests pass locally with my changes
- [√] My code follows the style guidelines of this project (should be covered by Ruff above)
- [×] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [√] I have performed a self-review of my own code
- [√] I have commented my code, particularly in hard-to-understand areas
- [×] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
