### PR TITLE
ssh: allow for putting and getting files

### DIFF
--- a/nxc/protocols/ssh/proto_args.py
+++ b/nxc/protocols/ssh/proto_args.py
@@ -12,6 +12,10 @@ def proto_args(parser, parents):
     ssh_parser.add_argument("--get-output-tries", type=int, default=5, help="Number of times with sudo command tries to get results")
     sudo_check_method_arg.make_required.append(sudo_check_arg)
 
+    files_group = ssh_parser.add_argument_group("Files", "Options for remote file interaction")
+    files_group.add_argument("--put-file", action="append", nargs=2, metavar="FILE", help="Put a local file into remote target, ex: whoami.txt /tmp/whoami.txt")
+    files_group.add_argument("--get-file", action="append", nargs=2, metavar="FILE", help="Get a remote file, ex: /tmp/whoami.txt whoami.txt")
+
     cgroup = ssh_parser.add_argument_group("Command Execution", "Options for executing commands")
     cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target, map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -256,6 +256,8 @@ netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-check-method sudo-stdin --get-output-tries 10
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-check-method mkfifo
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-check-method mkfifo --get-output-tries 10
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --put-file TEST_NORMAL_FILE /tmp/test_file.txt --put-file TEST_NORMAL_FILE /tmp/test_file2.txt
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --get-file /tmp/test_file.txt /tmp/test_file.txt --get-file /tmp/test_file.txt /tmp/test_file2.txt
 ##### FTP- Default test passwords and random key; switch these out if you want correct authentication
 netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD
 netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --ls


### PR DESCRIPTION
## Description

Allows for getting and putting files using SSH. This is identical to the SMB get and put file feature. Uses Paramiko's SFTP implementation to transfer files between hosts.

This has similar use cases as the SMB feature, as you can now upload and download files to Linux computers more easily.

I can update the Netexec wikipedia to add an entry for this feature under the SSH protocol if it is accepted.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Manually as well as all SSH e2e tests.

Tested using Python 3.13.1 on Linux. Tested remotely against a Linux host and Windows 10 host.

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
