### PR TITLE
Fix user-desc.py

### DIFF
--- a/nxc/modules/user-desc.py
+++ b/nxc/modules/user-desc.py
@@ -71,7 +71,7 @@ class NXCModule:
         Users can specify additional LDAP filters that are applied to the query.
         """
         self.context = context
-        self.create_log_file(connection.conn.getRemoteHost(), datetime.now().strftime("%Y%m%d_%H%M%S"))
+        self.create_log_file(connection.target, datetime.now().strftime("%Y%m%d_%H%M%S"))
         context.log.info(f"Starting LDAP search with search filter '{self.search_filter}'")
 
         try:


### PR DESCRIPTION
Greetings,

## Description
Since LDAP module seems to not use SMB anymore (#508), we can't rely on the `getRemoteHost()` function of the SMB connection object that we previously had.

Here is the result without this fix:
```bash
$ poetry run NetExec ldap 10.2.10.40 -u 'administrator' -p 'AZERTY*qsdfg' -d 'sccm.lab' -M user-desc
LDAP        10.2.10.40      389    DC               [*] Windows 10 / Server 2019 Build 17763 (name:DC) (domain:sccm.lab)
LDAP        10.2.10.40      389    DC               [+] sccm.lab\administrator:AZERTY*qsdfg (admin)
[01:14:00] ERROR    Exception while calling proto_flow() on target 10.2.10.40: 'NoneType' object has no attribute 'getRemoteHost'                 connection.py:174
                    ╭──────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────╮
                    │ /workspace/NetExec/nxc/connection.py:166 in __init__                                                                      │
                    │                                                                                                                           │
                    │   163 │   │   self.logger.info(f"Socket info: host={self.host}, hostname={self.hostname},                                 │
                    │       kerberos={self.kerberos}, ipv6={self.is_ipv6}, link-local                                                           │
                    │       ipv6={self.is_link_local_ipv6}")                                                                                    │
                    │   164 │   │                                                                                                               │
                    │   165 │   │   try:                                                                                                        │
                    │ ❱ 166 │   │   │   self.proto_flow()                                                                                       │
                    │   167 │   │   except Exception as e:                                                                                      │
                    │   168 │   │   │   if "ERROR_DEPENDENT_SERVICES_RUNNING" in str(e):                                                        │
                    │   169 │   │   │   │   self.logger.error(f"Exception while calling proto_flow() on target                                  │
                    │       {target}: {e}")                                                                                                     │
                    │                                                                                                                           │
                    │ /workspace/NetExec/nxc/connection.py:237 in proto_flow                                                                    │
                    │                                                                                                                           │
                    │   234 │   │   │   │   if hasattr(self.args, "module") and self.args.module:                                               │
                    │   235 │   │   │   │   │   self.load_modules()                                                                             │
                    │   236 │   │   │   │   │   self.logger.debug("Calling modules")                                                            │
                    │ ❱ 237 │   │   │   │   │   self.call_modules()                                                                             │
                    │   238 │   │   │   │   else:                                                                                               │
                    │   239 │   │   │   │   │   self.logger.debug("Calling command arguments")                                                  │
                    │   240 │   │   │   │   │   self.call_cmd_args()                                                                            │
                    │                                                                                                                           │
                    │ /workspace/NetExec/nxc/connection.py:292 in call_modules                                                                  │
                    │                                                                                                                           │
                    │   289 │   │   │                                                                                                           │
                    │   290 │   │   │   if hasattr(module, "on_login"):                                                                         │
                    │   291 │   │   │   │   self.logger.debug(f"Module {module.name} has on_login method")                                      │
                    │ ❱ 292 │   │   │   │   module.on_login(context, self)                                                                      │
                    │   293 │   │   │                                                                                                           │
                    │   294 │   │   │   if self.admin_privs and hasattr(module, "on_admin_login"):                                              │
                    │   295 │   │   │   │   self.logger.debug(f"Module {module.name} has on_admin_login method")                                │
                    │                                                                                                                           │
                    │ /workspace/NetExec/nxc/modules/user-desc.py:74 in on_login                                                                │
                    │                                                                                                                           │
                    │    71 │   │   Users can specify additional LDAP filters that are applied to the query.                                    │
                    │    72 │   │   """                                                                                                         │
                    │    73 │   │   self.context = context                                                                                      │
                    │ ❱  74 │   │   self.create_log_file(connection.conn.getRemoteHost(),                                                       │
                    │       datetime.now().strftime("%Y%m%d_%H%M%S"))                                                                           │
                    │    75 │   │   context.log.info(f"Starting LDAP search with search filter                                                  │
                    │       '{self.search_filter}'")                                                                                            │
                    │    76 │   │                                                                                                               │
                    │    77 │   │   try:                                                                                                        │
                    ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                    AttributeError: 'NoneType' object has no attribute 'getRemoteHost'
```

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## How Has This Been Tested?
On the DC machine of GOAD SCCM:
```bash
$ poetry run NetExec ldap 10.2.10.40-42 -u 'administrator' -p 'AZERTY*qsdfg' -d 'sccm.lab' -M user-desc
LDAP        10.2.10.40      389    DC               [*] Windows 10 / Server 2019 Build 17763 (name:DC) (domain:sccm.lab)
LDAP        10.2.10.40      389    DC               [+] sccm.lab\administrator:AZERTY*qsdfg (admin)
USER-DESC   10.2.10.40      389    DC               User: krbtgt - Description: Key Distribution Center Service Account
USER-DESC   10.2.10.40      389    DC               Saved 14 user descriptions to /root/.nxc/logs/UserDesc-DC.sccm.lab-20241231_010909.log
```

If you are using poetry, you can easily run tests via:
`poetry run python tests/e2e_tests.py -t $TARGET -u $USER -p $PASSWORD`
There are additional options like `--errors` to display ALL errors (some may not be failures), `--poetry` (output will include the poetry run prepended), `--line-num $START-$END $SINGLE` for only running a subset

## Screenshots (if appropriate):
Screenshots are always nice to have and can give a visual representation of the change.
If appropriate include before and after screenshot(s) to show which results are to be expected.

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] My code follows the style guidelines of this project (should be covered by Ruff above)
- [ ] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
