### PR TITLE
fix connection issue with socks ldap

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -208,6 +208,7 @@ class ldap(connection):
         except OSError as e:
             self.logger.error(f"Error getting ldap info {e}")
 
+        self.logger.debug(f"Target: {target}; target_domain: {target_domain}; base_dn: {base_dn}")
         self.target = target
         self.targetDomain = target_domain
         self.baseDN = base_dn

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -206,7 +206,7 @@ class ldap(connection):
                     self.logger.debug("Exception:", exc_info=True)
                     self.logger.info(f"Skipping item, cannot process due to error {e}")
         except OSError as e:
-            self.logger.error(f"Error getting ldap info { str(e) }")
+            self.logger.error(f"Error getting ldap info {e}")
 
         self.target = target
         self.targetDomain = target_domain


### PR DESCRIPTION
## Description

Using proxychains, nxc is failing to make first ldap connection (because it's not auth so we pass via proxychains to 127.0.0.1 but ntlmrelayx doesn't relay the connection since it's unauth) but this pr fix the problem by ignoring the first ldap connection

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Against GOAD lab

## Screenshots (if appropriate):

Before
![2025-01-02_16-42](https://github.com/user-attachments/assets/1b6280c8-1563-45be-8ab5-fd9d1f410d4c)


After
![2025-01-02_16-51](https://github.com/user-attachments/assets/6861ca8d-b88c-48f8-b2ef-cdae962d03d7)

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have performed a self-review of my own code
