### PR TITLE
switch default conn from smbv1 to smbv3

### DIFF
--- a/nxc/modules/enum_av.py
+++ b/nxc/modules/enum_av.py
@@ -84,10 +84,7 @@ class NXCModule:
                             prod_results = results.setdefault(product["name"], {})
                             prod_results.setdefault("pipes", []).append(pipe)
         except Exception as e:
-            if "STATUS_ACCESS_DENIED" in str(e):
-                context.log.fail("Error STATUS_ACCESS_DENIED while enumerating pipes, probably due to using SMBv1")
-            else:
-                context.log.fail(str(e))
+            context.log.fail(str(e))
 
     def dump_results(self, results, context):
         if not results:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -596,7 +596,6 @@ class smb(connection):
 
         :param no_smbv1: If True, it will not try to create a SMBv1 connection
         """
-
         # Initial negotiation
         if self.smbv3 is None:
             self.smbv3 = self.create_smbv3_conn()


### PR DESCRIPTION
## Description

As we all know, making connections with SMBv1 often causes errors like "**connection reset by peer**" or "**broken pipe**." This is why the `--no-smbv1` flag was added by @XiaoliChan 

Currently, the reason SMBv1 is checked in the first place is to determine the host info line smbv1: True/False. This is the only reason. However, if a connection with SMBv1 is successful, it will be used for all subsequent operations on the host (self.conn)

The idea: Why not use SMBv3 by default (and then fall back to SMBv1 if SMBv3 fails, essentially doing the opposite of what is done today) and perform a simple check for smbv1: True/False on the host without relying on self.conn (an independent check) 

This approach would make Netexec much more reliable i think 💪 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Against goad lab

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/ad68b631-3b64-442e-ae52-6aff081d736e)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas