### PR TITLE
fix pfx auth on non dc

### DIFF
--- a/nxc/helpers/pfx.py
+++ b/nxc/helpers/pfx.py
@@ -509,7 +509,7 @@ def pfx_auth(self):
     req = ini.build_asreq(self.domain, username)
     self.logger.info("Requesting TGT")
 
-    sock = KerberosClientSocket(KerberosTarget(self.domain))
+    sock = KerberosClientSocket(KerberosTarget(self.kdcHost))
     try:
         res = sock.sendrecv(req)
     except Exception as e:

--- a/nxc/helpers/pfx.py
+++ b/nxc/helpers/pfx.py
@@ -509,7 +509,7 @@ def pfx_auth(self):
     req = ini.build_asreq(self.domain, username)
     self.logger.info("Requesting TGT")
 
-    sock = KerberosClientSocket(KerberosTarget(self.host))
+    sock = KerberosClientSocket(KerberosTarget(self.domain))
     try:
         res = sock.sendrecv(req)
     except Exception as e:
@@ -527,7 +527,7 @@ def pfx_auth(self):
     creds = ccache.getCredential(principal)
     if creds is not None:
         tgt = creds.toTGT()
-        dumper = GETPAC(username, self.domain, self.host, key, tgt)
+        dumper = GETPAC(username, self.domain, self.domain, key, tgt)
         nthash = dumper.dump()
         if not self.kerberos:
             self.hash_login(self.domain, username, nthash)

--- a/nxc/helpers/pfx.py
+++ b/nxc/helpers/pfx.py
@@ -527,7 +527,7 @@ def pfx_auth(self):
     creds = ccache.getCredential(principal)
     if creds is not None:
         tgt = creds.toTGT()
-        dumper = GETPAC(username, self.domain, self.domain, key, tgt)
+        dumper = GETPAC(username, self.domain, self.kdcHost, key, tgt)
         nthash = dumper.dump()
         if not self.kerberos:
             self.hash_login(self.domain, username, nthash)


### PR DESCRIPTION
## Description

To convert pfx to ccache you need to contact the DC, this commit fix certificat auth on non dc server

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Against GOAD

## Screenshots (if appropriate):

Before:
![image](https://github.com/user-attachments/assets/c3541a6d-0be5-49c8-9d20-fb7ab2c40eaf)


After:
![image](https://github.com/user-attachments/assets/064775e8-d373-4a3c-a8b9-6fe395a372e3)

![image](https://github.com/user-attachments/assets/c36fc13e-767e-4f8f-90b5-69156c7466cb)



## Checklist:

- [x] I have performed a self-review of my own code