### PR TITLE
update dploot to 3.1.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -678,13 +678,13 @@ wmi = ["wmi (>=1.5.1)"]
 
 [[package]]
 name = "dploot"
-version = "3.0.3"
+version = "3.1.0"
 description = "DPAPI looting remotely in Python"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 files = [
-    {file = "dploot-3.0.3-py3-none-any.whl", hash = "sha256:8d0a2c90e77594b4a7f5b4cee64f71b38d295da27151b5c4f5a0584a7d00ff3b"},
-    {file = "dploot-3.0.3.tar.gz", hash = "sha256:301b8ef5a9c27bcc030feef6a51fdb16b579a40984216636a4a4af3d24ead324"},
+    {file = "dploot-3.1.0-py3-none-any.whl", hash = "sha256:9fb89c4332f407700929290f147703c79e253d14a505649174c9d761415fddfe"},
+    {file = "dploot-3.1.0.tar.gz", hash = "sha256:0e531a12481b0c741be41574988f2a8d3046a66457edb3faecc64ee20f88d6e2"},
 ]
 
 [package.dependencies]
@@ -2510,4 +2510,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.0"
-content-hash = "6d49bd57d29f45512946dc1ddcaa667cdcb4ae6393cbc2524a6fab06f13802ab"
+content-hash = "6a4e460ce87103f0a4f9eeddbf78d48cd9e8dc6092457187f2deef26b0ccdfc4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ argcomplete = "^3.1.4"
 asyauth = ">=0.0.20"
 beautifulsoup4 = ">=4.11,<5"
 bloodhound = "^1.8.0"
-dploot = "^3.0.3"
+dploot = "^3.1.0"
 dsinternals = "^1.2.4"
 impacket =  { git = "https://github.com/fortra/impacket.git" }
 jwt = ">=1.3.1"


### PR DESCRIPTION
## Description

Update of dploot to 3.1.0. This adds chromium v20 cookies decryption (no code modification needed), and dpapi masterkey hash full support (actually it was already supported but I added a recent bug fix) required to update #379 

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## How Has This Been Tested?
:wink: 

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/66f04fd4-95ac-499e-8683-c9b5e1def4e5)
It's nxc with new dploot release allowing to dump new chromium cookies

## Checklist:

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [X] I have added or updated the tests/e2e_commands.txt file if necessary
- [X] New and existing e2e tests pass locally with my changes
- [X] My code follows the style guidelines of this project (should be covered by Ruff above)
- [X] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
