### PR TITLE
Updated exe files while putting for evasion

### DIFF
--- a/nxc/modules/handlekatz.py
+++ b/nxc/modules/handlekatz.py
@@ -5,7 +5,7 @@
 import base64
 import re
 import sys
-
+from datetime import datetime
 from nxc.helpers.bloodhound import add_user_bh
 from pypykatz.pypykatz import pypykatz
 
@@ -34,6 +34,10 @@ class NXCModule:
         self.handlekatz_path = "/tmp/"
         self.dir_result = self.handlekatz_path
         self.useembeded = True
+        current_time = datetime.now()
+        time_string = current_time.strftime("%Y%m%d%H%M%S")
+        padding = time_string.encode()
+        self.handlekatz_embeded = self.handlekatz_embeded + padding
 
         if "HANDLEKATZ_PATH" in module_options:
             self.handlekatz_path = module_options["HANDLEKATZ_PATH"]

--- a/nxc/modules/handlekatz.py
+++ b/nxc/modules/handlekatz.py
@@ -34,10 +34,8 @@ class NXCModule:
         self.handlekatz_path = "/tmp/"
         self.dir_result = self.handlekatz_path
         self.useembeded = True
-        current_time = datetime.now()
-        time_string = current_time.strftime("%Y%m%d%H%M%S")
-        padding = time_string.encode()
-        self.handlekatz_embeded = self.handlekatz_embeded + padding
+        # Add some random binary data to defeat AVs which check the file hash
+        self.handlekatz_embeded += datetime.now().strftime("%Y%m%d%H%M%S").encode()
 
         if "HANDLEKATZ_PATH" in module_options:
             self.handlekatz_path = module_options["HANDLEKATZ_PATH"]

--- a/nxc/modules/impersonate.py
+++ b/nxc/modules/impersonate.py
@@ -6,7 +6,7 @@
 from base64 import b64decode
 from os import path
 import sys
-
+from datetime import datetime
 from nxc.paths import DATA_PATH
 
 
@@ -29,8 +29,15 @@ class NXCModule:
         self.impersonate = "Impersonate.exe"
         self.useembeded = True
         self.token = self.cmd = ""
+        current_time = datetime.now()
+        time_string = current_time.strftime("%Y%m%d%H%M%S")
+
         with open(path.join(DATA_PATH, ("impersonate_module/impersonate.bs64"))) as impersonate_file:
             self.impersonate_embedded = b64decode(impersonate_file.read())
+        
+        padding = time_string.encode()
+        self.impersonate_embedded = self.impersonate_embedded + padding
+
         if "EXEC" in module_options:
             self.cmd = module_options["EXEC"]
 

--- a/nxc/modules/impersonate.py
+++ b/nxc/modules/impersonate.py
@@ -29,14 +29,12 @@ class NXCModule:
         self.impersonate = "Impersonate.exe"
         self.useembeded = True
         self.token = self.cmd = ""
-        current_time = datetime.now()
-        time_string = current_time.strftime("%Y%m%d%H%M%S")
 
         with open(path.join(DATA_PATH, ("impersonate_module/impersonate.bs64"))) as impersonate_file:
             self.impersonate_embedded = b64decode(impersonate_file.read())
-        
-        padding = time_string.encode()
-        self.impersonate_embedded = self.impersonate_embedded + padding
+
+        # Add some random binary data to defeat AVs which check the file hash
+        self.impersonate_embedded += datetime.now().strftime("%Y%m%d%H%M%S").encode()
 
         if "EXEC" in module_options:
             self.cmd = module_options["EXEC"]

--- a/nxc/modules/nanodump.py
+++ b/nxc/modules/nanodump.py
@@ -51,6 +51,11 @@ class NXCModule:
         self.nano = "nano.exe"
         self.nano_path = ""
         self.useembeded = True
+        current_time = datetime.now()
+        time_string = current_time.strftime("%Y%m%d%H%M%S")
+        padding = time_string.encode()
+        self.nano_embedded64 = self.nano_embedded64 + padding
+        self.nano_embedded32 = self.nano_embedded32 + padding
 
         if "NANO_PATH" in module_options:
             self.nano_path = module_options["NANO_PATH"]

--- a/nxc/modules/nanodump.py
+++ b/nxc/modules/nanodump.py
@@ -51,11 +51,10 @@ class NXCModule:
         self.nano = "nano.exe"
         self.nano_path = ""
         self.useembeded = True
-        current_time = datetime.now()
-        time_string = current_time.strftime("%Y%m%d%H%M%S")
-        padding = time_string.encode()
-        self.nano_embedded64 = self.nano_embedded64 + padding
-        self.nano_embedded32 = self.nano_embedded32 + padding
+        # Add some random binary data to defeat AVs which check the file hash
+        padding = datetime.now().strftime("%Y%m%d%H%M%S").encode()
+        self.nano_embedded64 += padding
+        self.nano_embedded32 += padding
 
         if "NANO_PATH" in module_options:
             self.nano_path = module_options["NANO_PATH"]

--- a/nxc/modules/pi.py
+++ b/nxc/modules/pi.py
@@ -25,14 +25,12 @@ class NXCModule:
         self.pi = "pi.exe"
         self.useembeded = True
         self.pid = self.cmd = ""
-        current_time = datetime.now()
-        time_string = current_time.strftime("%Y%m%d%H%M%S")
         
         with open(join(DATA_PATH, ("pi_module/pi.bs64"))) as pi_file:
             self.pi_embedded = b64decode(pi_file.read())
 
-        padding = time_string.encode()
-        self.pi_embedded = self.pi_embedded + padding
+        # Add some random binary data to defeat AVs which check the file hash
+        self.pi_embedded += datetime.now().strftime("%Y%m%d%H%M%S").encode()
         
         if "EXEC" in module_options:
             self.cmd = module_options["EXEC"]

--- a/nxc/modules/pi.py
+++ b/nxc/modules/pi.py
@@ -1,7 +1,7 @@
 from base64 import b64decode
 from sys import exit
 from os.path import abspath, join, isfile
-
+from datetime import datetime
 from nxc.paths import DATA_PATH, TMP_PATH
 
 
@@ -25,9 +25,15 @@ class NXCModule:
         self.pi = "pi.exe"
         self.useembeded = True
         self.pid = self.cmd = ""
+        current_time = datetime.now()
+        time_string = current_time.strftime("%Y%m%d%H%M%S")
+        
         with open(join(DATA_PATH, ("pi_module/pi.bs64"))) as pi_file:
             self.pi_embedded = b64decode(pi_file.read())
 
+        padding = time_string.encode()
+        self.pi_embedded = self.pi_embedded + padding
+        
         if "EXEC" in module_options:
             self.cmd = module_options["EXEC"]
 

--- a/nxc/modules/procdump.py
+++ b/nxc/modules/procdump.py
@@ -36,10 +36,8 @@ class NXCModule:
         self.procdump_path = abspath(TMP_PATH)
         self.dir_result = self.procdump_path
         self.useembeded = True
-        current_time = datetime.now()
-        time_string = current_time.strftime("%Y%m%d%H%M%S")
-        padding = time_string.encode()
-        self.procdump_embeded = self.procdump_embeded + padding
+        # Add some random binary data to defeat AVs which check the file hash
+        self.procdump_embeded += datetime.now().strftime("%Y%m%d%H%M%S").encode()
 
         if "PROCDUMP_PATH" in module_options:
             self.procdump_path = module_options["PROCDUMP_PATH"]

--- a/nxc/modules/procdump.py
+++ b/nxc/modules/procdump.py
@@ -9,6 +9,7 @@ import pypykatz
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.paths import TMP_PATH
 from os.path import abspath, join
+from datetime import datetime
 
 
 class NXCModule:
@@ -35,6 +36,10 @@ class NXCModule:
         self.procdump_path = abspath(TMP_PATH)
         self.dir_result = self.procdump_path
         self.useembeded = True
+        current_time = datetime.now()
+        time_string = current_time.strftime("%Y%m%d%H%M%S")
+        padding = time_string.encode()
+        self.procdump_embeded = self.procdump_embeded + padding
 
         if "PROCDUMP_PATH" in module_options:
             self.procdump_path = module_options["PROCDUMP_PATH"]


### PR DESCRIPTION
## Description

This update is to change the hash value when uploading exe files in nxc/data (impersonate, pi). The hash changes depending on time by adding the time value as bytes. Although it has little effect in real life tests, it will be useful in bypassing bad and misconfigured EDRs.


## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested on my local lab and GOAD

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/1eff8e93-bca4-434c-bbbf-4ec44f475528)
![image](https://github.com/user-attachments/assets/8df05054-7b33-4f02-aec9-7d0fc762dd86)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
