### PR TITLE
Fix lsass Dump Files Deleting Process When Dump Fail

### DIFF
--- a/nxc/modules/handlekatz.py
+++ b/nxc/modules/handlekatz.py
@@ -50,7 +50,7 @@ class NXCModule:
 
     def on_admin_login(self, context, connection):
         handlekatz_loc = self.handlekatz_path + self.handlekatz
-        
+
         if self.useembeded:
             try:
                 with open(handlekatz_loc, "wb") as handlekatz:

--- a/nxc/modules/handlekatz.py
+++ b/nxc/modules/handlekatz.py
@@ -97,12 +97,15 @@ class NXCModule:
             context.log.fail("Process lsass.exe error un dump, try with verbose")
             dump = False
 
-        if dump:
+        if not dump:
+            self.delete_handlekatz_binary(connection, context)
+            return
+        else:
             regex = r"([A-Za-z0-9-]*\.log)"
             matches = re.search(regex, str(p), re.MULTILINE)
             if not matches:
                 context.log.display("Error getting the lsass.dmp file name")
-                sys.exit(1)
+                return
 
             machine_name = matches.group()
             context.log.display(f"Copy {machine_name} to host")
@@ -115,7 +118,6 @@ class NXCModule:
                     context.log.fail(f"Error while get file: {e}")
 
             self.delete_handlekatz_binary()
-
             try:
                 connection.conn.deleteFile(self.share, self.tmp_share + machine_name)
                 context.log.success(f"Deleted lsass.dmp file on the {self.share} share")
@@ -179,9 +181,6 @@ class NXCModule:
                         add_user_bh(credz_bh, None, context.log, connection.config)
                 except Exception as e:
                     context.log.fail(f"Error opening dump file: {e}")
-
-        else:
-            self.delete_handlekatz_binary(connection, context)
 
     def delete_handlekatz_binary(self, connection, context):
         try:

--- a/nxc/modules/handlekatz.py
+++ b/nxc/modules/handlekatz.py
@@ -78,6 +78,7 @@ class NXCModule:
 
         if not p or p == "None":
             context.log.fail("Failed to execute command to get LSASS PID")
+            self.delete_handlekatz_binary(connection, context)
             return
         # we get a CSV string back from `tasklist`, so we grab the PID from it
         pid = p.split(",")[1][1:-1]
@@ -113,11 +114,7 @@ class NXCModule:
                 except Exception as e:
                     context.log.fail(f"Error while get file: {e}")
 
-            try:
-                connection.conn.deleteFile(self.share, self.tmp_share + self.handlekatz)
-                context.log.success(f"Deleted handlekatz file on the {self.share} share")
-            except Exception as e:
-                context.log.fail(f"[OPSEC] Error deleting handlekatz file on share {self.share}: {e}")
+            self.delete_handlekatz_binary()
 
             try:
                 connection.conn.deleteFile(self.share, self.tmp_share + machine_name)
@@ -182,3 +179,13 @@ class NXCModule:
                         add_user_bh(credz_bh, None, context.log, connection.config)
                 except Exception as e:
                     context.log.fail(f"Error opening dump file: {e}")
+
+        else:
+            self.delete_handlekatz_binary(connection, context)
+
+    def delete_handlekatz_binary(self, connection, context):
+        try:
+            connection.conn.deleteFile(self.share, self.tmp_share + self.handlekatz)
+            context.log.success(f"Deleted handlekatz file on the {self.share} share")
+        except Exception as e:
+            context.log.fail(f"[OPSEC] Error deleting handlekatz file on share {self.share}: {e}")

--- a/nxc/modules/nanodump.py
+++ b/nxc/modules/nanodump.py
@@ -254,7 +254,7 @@ class NXCModule:
                         add_user_bh(bh_creds, None, self.context.log, self.connection.config)
                 except Exception as e:
                     self.context.log.fail(f"Error opening dump file: {e}")
-    
+
     def delete_nanodump_binary(self):
         try:
             self.connection.execute(f"del {self.remote_tmp_dir + self.nano}")

--- a/nxc/modules/nanodump.py
+++ b/nxc/modules/nanodump.py
@@ -149,7 +149,10 @@ class NXCModule:
             self.context.log.fail("Process lsass.exe error on dump, try with verbose")
             dump = False
 
-        if dump:
+        if not dump:
+            self.delete_nanodump_binary()
+            return
+        else:
             self.context.log.display(f"Copying {nano_log_name} to host")
             filename = os.path.join(self.dir_result, f"{self.connection.hostname}_{self.connection.os_arch}_{self.connection.domain}.log")
             if self.context.protocol == "smb":
@@ -251,9 +254,6 @@ class NXCModule:
                         add_user_bh(bh_creds, None, self.context.log, self.connection.config)
                 except Exception as e:
                     self.context.log.fail(f"Error opening dump file: {e}")
-
-        else:
-            self.delete_nanodump_binary()
     
     def delete_nanodump_binary(self):
         try:

--- a/nxc/modules/nanodump.py
+++ b/nxc/modules/nanodump.py
@@ -252,6 +252,9 @@ class NXCModule:
                 except Exception as e:
                     self.context.log.fail(f"Error opening dump file: {e}")
 
+        else:
+            self.delete_nanodump_binary()
+    
     def delete_nanodump_binary(self):
         try:
             self.connection.execute(f"del {self.remote_tmp_dir + self.nano}")

--- a/nxc/modules/procdump.py
+++ b/nxc/modules/procdump.py
@@ -98,11 +98,7 @@ class NXCModule:
                 except Exception as e:
                     context.log.fail(f"Error while get file: {e}")
 
-            try:
-                connection.conn.deleteFile(self.share, self.tmp_share + self.procdump)
-                context.log.success(f"Deleted procdump file on the {self.share} share")
-            except Exception as e:
-                context.log.fail(f"Error deleting procdump file on share {self.share}: {e}")
+            self.delete_procdump_binary(connection, context)
 
             try:
                 connection.conn.deleteFile(self.share, self.tmp_share + machine_name)
@@ -154,8 +150,11 @@ class NXCModule:
                     context.log.fail("Error openning dump file", str(e))
 
         else:
-            try:
-                connection.conn.deleteFile(self.share, self.tmp_share + self.procdump)
-                context.log.success(f"Deleted procdump file on the {self.share} share")
-            except Exception as e:
-                context.log.fail(f"Error deleting procdump file on share {self.share}: {e}")
+            self.delete_procdump_binary(connection, context)
+
+    def delete_procdump_binary(self, connection, context):
+        try:
+            connection.conn.deleteFile(self.share, self.tmp_share + self.procdump)
+            context.log.success(f"Deleted procdump file on the {self.share} share")
+        except Exception as e:
+            context.log.fail(f"Error deleting procdump file on share {self.share}: {e}")

--- a/nxc/modules/procdump.py
+++ b/nxc/modules/procdump.py
@@ -4,7 +4,6 @@
 
 import base64
 import re
-import sys
 import pypykatz
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.paths import TMP_PATH
@@ -79,7 +78,10 @@ class NXCModule:
         else:
             context.log.fail("Process lsass.exe error un dump, try with verbose")
 
-        if dump:
+        if not dump:
+            self.delete_procdump_binary(connection, context)
+            return
+        else:
             regex = r"([A-Za-z0-9-]*.dmp)"
             matches = re.search(regex, str(p), re.MULTILINE)
             machine_name = ""
@@ -87,7 +89,7 @@ class NXCModule:
                 machine_name = matches.group()
             else:
                 context.log.display("Error getting the lsass.dmp file name")
-                sys.exit(1)
+                return
 
             context.log.display(f"Copy {machine_name} to host")
 
@@ -148,9 +150,6 @@ class NXCModule:
                         add_user_bh(credz_bh, None, context.log, connection.config)
                 except Exception as e:
                     context.log.fail("Error openning dump file", str(e))
-
-        else:
-            self.delete_procdump_binary(connection, context)
 
     def delete_procdump_binary(self, connection, context):
         try:

--- a/nxc/modules/procdump.py
+++ b/nxc/modules/procdump.py
@@ -152,3 +152,10 @@ class NXCModule:
                         add_user_bh(credz_bh, None, context.log, connection.config)
                 except Exception as e:
                     context.log.fail("Error openning dump file", str(e))
+
+        else:
+            try:
+                connection.conn.deleteFile(self.share, self.tmp_share + self.procdump)
+                context.log.success(f"Deleted procdump file on the {self.share} share")
+            except Exception as e:
+                context.log.fail(f"Error deleting procdump file on share {self.share}: {e}")


### PR DESCRIPTION
## Description

While lsass dumping fails on target, dump files are still on the target. This PR for delete the dump files if dumping fails. Encountered on handlekatz and procdump, but fixed on nanodump either.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested on my own lab and GOAD

## Screenshots (if appropriate):
Before Fix
![image](https://github.com/user-attachments/assets/d80bd161-98d9-4da9-92de-55ce6d25d9b3)
![image](https://github.com/user-attachments/assets/195dc2fa-edee-4a24-8812-ce6a3a3caf88)

After Fix
![image](https://github.com/user-attachments/assets/78f563ae-c082-4de1-bb86-496174569795)



## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
