### PR TITLE
Swap cert-pem to pem-cert to match pfx syntax

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -103,8 +103,8 @@ def gen_cli_args():
     certificate_group.add_argument("--pfx-cert", metavar="PFXCERT", help="Use certificate authentication from pfx file .pfx")
     certificate_group.add_argument("--pfx-base64", metavar="PFXB64", help="Use certificate authentication from pfx file encoded in base64")
     certificate_group.add_argument("--pfx-pass", metavar="PFXPASS", help="Password of the pfx certificate")
-    certificate_group.add_argument("--cert-pem", metavar="CERTPEM", help="Use certificate authentication from PEM file")
-    certificate_group.add_argument("--key-pem", metavar="KEYPEM", help="Private key for the PEM format")
+    certificate_group.add_argument("--pem-cert", metavar="PEMCERT", help="Use certificate authentication from PEM file")
+    certificate_group.add_argument("--pem-key", metavar="PEMKEY", help="Private key for the PEM format")
     
     server_group = std_parser.add_argument_group("Servers", "Options for nxc servers")
     server_group.add_argument("--server", choices={"http", "https"}, default="https", help="use the selected server")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -550,7 +550,7 @@ class connection:
                 self.logger.info("Successfully authenticated using Kerberos cache")
                 return True
 
-        if self.args.pfx_cert or self.args.pfx_base64 or self.args.cert_pem:
+        if self.args.pfx_cert or self.args.pfx_base64 or self.args.pem_cert:
             self.logger.debug("Trying to authenticate using Certificate pfx")
             if not self.args.username:
                 self.logger.fail("You must specify a username when using certificate authentication")

--- a/nxc/helpers/pfx.py
+++ b/nxc/helpers/pfx.py
@@ -496,8 +496,8 @@ def pfx_auth(self):
     if self.args.pfx_cert or self.args.pfx_base64:
         pfx = self.args.pfx_cert if self.args.pfx_cert else self.args.pfx_base64
         ini = myPKINIT.from_pfx(pfx, self.args.pfx_pass, dhparams, bool(self.args.pfx_base64))
-    elif self.args.cert_pem and self.args.key_pem:
-        ini = myPKINIT.from_pem(self.args.cert_pem, self.args.key_pem, dhparams)
+    elif self.args.pem_cert and self.args.pem_key:
+        ini = myPKINIT.from_pem(self.args.pem_cert, self.args.pem_key, dhparams)
     else:
         self.logger.fail("You must either specify a PFX file + optional password or a combination of Cert PEM file and Private key PEM file")
         return None


### PR DESCRIPTION
Replace `--cert-pem`/`--key-pem` with `--pem-cert`/`--pem-key` to match the syntax for pfx