### PR TITLE
Fix: privileged groups SID not found error

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -591,6 +591,7 @@ class ldap(connection):
                     if str(attribute["type"]) == "distinguishedName":
                         answers.append(str("(memberOf:1.2.840.113556.1.4.1941:=" + attribute["vals"][0] + ")"))
             if len(answers) == 0:
+                self.logger.debug(f"No groups with default privileged RID were found. Assuming user is not a Domain Administrator.")
                 return
 
             # 3. get member of these groups

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -590,6 +590,8 @@ class ldap(connection):
                 for attribute in item["attributes"]:
                     if str(attribute["type"]) == "distinguishedName":
                         answers.append(str("(memberOf:1.2.840.113556.1.4.1941:=" + attribute["vals"][0] + ")"))
+            if len(answers) == 0:
+                return
 
             # 3. get member of these groups
             search_filter = "(&(objectCategory=user)(sAMAccountName=" + self.username + ")(|" + "".join(answers) + "))"


### PR DESCRIPTION
## Description

After encountering this error:
![1](https://github.com/user-attachments/assets/e9765c92-e085-4a71-b859-ee122620ce2c)
[...]
![2](https://github.com/user-attachments/assets/bdb86cb4-1216-4ab6-9aac-3dbb0f27f2cc)
I realized the piece of code in ldap.py that checks if the user making the request is part of an admin group has no failsafe in case it doesn't find the privileged groups' CN names and errors out when it tries to get the members of these groups. This happened in my case since the privileged groups had been deleted and recreated with a different RID/group SID.

I just added a single condition which is no privileged groups found = you're not an admin. This could probably be improved by checking specific ACLs against the domain but I'm leaving someone with more ~~time~~ knowledge than me do it.

Cheers,
