### PR TITLE
[smb] Always delete service when using smbexec

### DIFF
--- a/nxc/protocols/smb/smbexec.py
+++ b/nxc/protocols/smb/smbexec.py
@@ -127,9 +127,13 @@ class SMBEXEC:
         except Exception:
             pass
 
-        self.logger.debug(f"Remote service {self.__serviceName} deleted.")
-        scmr.hRDeleteService(self.__scmr, service)
-        scmr.hRCloseServiceHandle(self.__scmr, service)
+        try:
+            self.logger.debug(f"Remote service {self.__serviceName} deleted.")
+            scmr.hRDeleteService(self.__scmr, service)
+            scmr.hRCloseServiceHandle(self.__scmr, service)
+        except Exception:
+            pass
+
         self.get_output_remote()
 
     def get_output_remote(self):

--- a/nxc/protocols/smb/smbexec.py
+++ b/nxc/protocols/smb/smbexec.py
@@ -124,13 +124,12 @@ class SMBEXEC:
         try:
             self.logger.debug(f"Remote service {self.__serviceName} started.")
             scmr.hRStartServiceW(self.__scmr, service)
-
-            self.logger.debug(f"Remote service {self.__serviceName} deleted.")
-            scmr.hRDeleteService(self.__scmr, service)
-            scmr.hRCloseServiceHandle(self.__scmr, service)
         except Exception:
             pass
 
+        self.logger.debug(f"Remote service {self.__serviceName} deleted.")
+        scmr.hRDeleteService(self.__scmr, service)
+        scmr.hRCloseServiceHandle(self.__scmr, service)
         self.get_output_remote()
 
     def get_output_remote(self):


### PR DESCRIPTION
## Description
When using the `smbexec` method, the service isn't always cleaned up. Usually, it seems to be cleaned up by itself without needing to invoke `scmr.hRDeleteService`. However, `scmr.hRStartServiceW` seems to always throw the following exception: `SCMR SessionError: code: 0x41d - ERROR_SERVICE_REQUEST_TIMEOUT`. Therefore, when the output from a command is attempting to be retrieved and fails (e.g. a command that takes a long time, like winpeas.exe), the service won't be cleaned up.

To solve this, I just moved the delete methods out of the `try/except`. This is how it's done for [impacket-smbexec](https://github.com/fortra/impacket/blob/ea242af1c79cc6d8e29fb7c3fca450528b73f379/examples/smbexec.py#L298) and was originally how it was done for NetExec until https://github.com/Pennyw0rth/NetExec/commit/be5b5433385fa9c95885adff255535af56123948 (I'm unsure why this was changed).

This also led me to discover that the [TODO above `get_output_remote`](https://github.com/Pennyw0rth/NetExec/blob/c904f3aa813f36f56b61d1021d32f6b527b20d0a/nxc/protocols/smb/smbexec.py#L141) doesn't seem to be correct as the service appears to time out after 30 seconds, making the timeout logic in this function necessary.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
`netexec smb <IP> -u user -p pass -X "Start-Sleep -Seconds 60" --exec-method smbexec`
- Note that it can be any command that takes a while. In this case, after about ~30 seconds (once `scmr.hRStartServiceW` times out), `self.get_output_remote` will be called. If you interrupt the command during this time, the service will never be deleted. I'm not sure why it is deleted if this command finishes to completion and `scmr.hRDeleteService` is never called explicitly, but that may be Windows handling it internally.

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
