### PR TITLE
Ruff fixed LDAP protocol 

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -591,7 +591,7 @@ class ldap(connection):
                     if str(attribute["type"]) == "distinguishedName":
                         answers.append(str("(memberOf:1.2.840.113556.1.4.1941:=" + attribute["vals"][0] + ")"))
             if len(answers) == 0:
-                self.logger.debug(f"No groups with default privileged RID were found. Assuming user is not a Domain Administrator.")
+                self.logger.debug("No groups with default privileged RID were found. Assuming user is not a Domain Administrator.")
                 return
 
             # 3. get member of these groups


### PR DESCRIPTION
## Description

Fixed f-string without any placeholders on ldap.py line 594


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
