### PR TITLE
new module: ldap > dump-computers

### DIFF
--- a/nxc/modules/dump-computers.py
+++ b/nxc/modules/dump-computers.py
@@ -1,0 +1,87 @@
+from nxc.logger import nxc_logger
+from impacket.ldap.ldap import LDAPSearchError
+from impacket.ldap.ldapasn1 import SearchResultEntry
+
+class NXCModule:
+
+    name = "dump-computers"
+    description = "Dumps all computers in the domain"
+    supported_protocols = ["ldap"]
+    opsec_safe = True
+    multiple_hosts = False
+
+    def options(self, context, module_options):
+        """
+        dump-computers: Specify dump-computers to call the module
+        Usage:
+        
+        >prints fqdn and version
+        nxc ldap $DC-IP -u Username -p Password -M dump-computers
+        
+        >prints only netbios name
+        nxc ldap $DC-IP -u Username -p Password -M dump-computers -o NETBIOS=True
+        
+        >prints fqdn and version, output to file
+        nxc ldap $DC-IP -u Username -p Password -M dump-computers -o OUTPUT=<location>
+        
+        >prints only netbios name, output to file
+        nxc ldap $DC-IP -u Username -p Password -M dump-computers -o OUTPUT=<location> -o NETBIOS=True
+        
+        """
+        self.output_file = None
+        self.netbios_only = False
+        
+        if "OUTPUT" in module_options:
+            self.output_file = module_options["OUTPUT"]
+        if "NETBIOS" in module_options and module_options["NETBIOS"].lower() == "true":
+            self.netbios_only = True
+
+    def on_login(self, context, connection):
+        search_filter = "(objectCategory=computer)"
+        
+        try:
+            context.log.debug(f"Search Filter={search_filter}")
+            resp = connection.ldap_connection.search(searchFilter=search_filter, attributes=["dNSHostName", "operatingSystem"], sizeLimit=0)
+        except LDAPSearchError as e:
+            if e.getErrorString().find("sizeLimitExceeded") >= 0:
+                context.log.debug("sizeLimitExceeded exception caught, giving up and processing the data received")
+                resp = e.getAnswers()
+            else:
+                nxc_logger.debug(e)
+                return False
+
+        answers = []
+        context.log.debug(f"Total no. of records returned: {len(resp)}")
+        for item in resp:
+            if isinstance(item, SearchResultEntry) is not True:
+                continue
+            dns_host_name = ""
+            operating_system = ""
+            try:
+                for attribute in item["attributes"]:
+                    if str(attribute["type"]) == "dNSHostName":
+                        dns_host_name = str(attribute["vals"][0])
+                    elif str(attribute["type"]) == "operatingSystem":
+                        operating_system = attribute["vals"][0]
+                if dns_host_name:
+                    netbios_name = dns_host_name.split(".")[0]
+                    answer = netbios_name if self.netbios_only else f"{dns_host_name} ({operating_system})"
+                    answers.append(answer)
+            except Exception as e:
+                context.log.debug("Exception:", exc_info=True)
+                context.log.debug(f"Skipping item, cannot process due to error {e}")
+        
+        if len(answers) > 0:
+            context.log.success("Found the following computers: ")
+            for answer in answers:
+                context.log.highlight(answer)
+            
+            if self.output_file:
+                try:
+                    with open(self.output_file, "w") as f:
+                        f.write("\n".join(answers) + "\n")
+                    context.log.success(f"Results saved to {self.output_file}")
+                except Exception as e:
+                    context.log.error(f"Failed to write to file {self.output_file}: {e}")
+        else:
+            context.log.success("No computers found in the domain.")


### PR DESCRIPTION
## Description

i'm doing a lot of local infrastructure and active directory pentests. during my engagements, i always needing all computers of a domain. so i can first eliminate active directory then scan complete infrastructure with nessus. i was pulling bloodhound data then manipulating text so i retrieve domain computers. it's working, but, why can't i do it with precious netexec? that's why i created dump-computers module. 

_it's my first pr so please forgive my mistakes._

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
i tested it with a dummy domain, domain controller and two clients.

## Screenshots (if appropriate):
![dc1](https://github.com/user-attachments/assets/559bc371-2844-4fef-8d7d-522934486699)
![dc2](https://github.com/user-attachments/assets/df6a2702-8158-457e-9e90-ce304c78c8eb)
![dco1](https://github.com/user-attachments/assets/53166251-1702-4ad0-8817-71494ba487b7)
![dco2](https://github.com/user-attachments/assets/6b9d2049-83d3-4d5b-8e32-c8f9e6a8748f)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
