### PR TITLE
Fix hardcoded option

### DIFF
--- a/nxc/protocols/mssql/mssqlexec.py
+++ b/nxc/protocols/mssql/mssqlexec.py
@@ -48,7 +48,7 @@ class MSSQLEXEC:
 
     def backup_and_enable(self, option):
         try:
-            self.backuped_options[option] = self.is_option_enabled("show advanced options")
+            self.backuped_options[option] = self.is_option_enabled(option)
             if not self.backuped_options[option]:
                 self.logger.debug(f"Option '{option}' is disabled, attempting to enable it.")
                 query = f"EXEC master.dbo.sp_configure '{option}', 1;RECONFIGURE;"


### PR DESCRIPTION
When i reworked the automatic check for `show advanced options`/`xp_cmdshell` in #405 i forgot to switch back the hardcoded `"show advanced options"` to the passed option in the function.

This way only if `xp_cmdshell` is already enabled it is possible to execute commands