### PR TITLE
Fix #564

### DIFF
--- a/nxc/protocols/smb/passpol.py
+++ b/nxc/protocols/smb/passpol.py
@@ -23,7 +23,7 @@ def convert(low, high, lockout=False):
     time = ""
     tmp = 0
 
-    if low == 0 and hex(high) == "-0x80000000":
+    if low == 0 and high == -0x8000_0000 or low == 0 and high == -0x8000_0000_0000_0000:
         return "Not Set"
     if low == 0 and high == 0:
         return "None"
@@ -35,7 +35,7 @@ def convert(low, high, lockout=False):
             high = abs(high)
             low = abs(low)
 
-        tmp = low + (high) * 16**8  # convert to 64bit int
+        tmp = low + (high << 32)  # convert to 64bit int
         tmp *= 1e-7  # convert to seconds
     else:
         tmp = abs(high) * (1e-7)


### PR DESCRIPTION
## Description

When unsetting values like the Account lockout duration the value is stored as max 64-Bit integer (`-9223372036854775808`/`9223372036854775808`). However this is not checked in the current conversion in `def pass_pol` resulting in a wrong number (see #564)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Against GOAD

## Screenshots (if appropriate):
Before:
![image](https://github.com/user-attachments/assets/0f2b2cc0-55a8-469c-8c21-6ff20396a1d1)
After:
![image](https://github.com/user-attachments/assets/5d75955d-67e1-44e9-be4b-d441a7ceed14)
