### PR TITLE
[smb] Always delete output file

### DIFF
--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -207,8 +207,10 @@ class TSCH_EXEC:
                         else:
                             self.logger.debug(str(e))
 
-                if self.__outputBuffer:
+                try:
                     self.logger.debug(f"Deleting file {self.__share}\\{self.__output_filename}")
                     smbConnection.deleteFile(self.__share, self.__output_filename)
+                except Exception:
+                    pass
 
         dce.disconnect()

--- a/nxc/protocols/smb/mmcexec.py
+++ b/nxc/protocols/smb/mmcexec.py
@@ -280,6 +280,8 @@ class MMCEXEC:
                 else:
                     self.logger.debug(str(e))
 
-        if self.__outputBuffer:
+        try:
             self.logger.debug(f"Deleting file {self.__share}\\{self.__output}")
             self.__smbconnection.deleteFile(self.__share, self.__output)
+        except Exception:
+            pass

--- a/nxc/protocols/smb/smbexec.py
+++ b/nxc/protocols/smb/smbexec.py
@@ -172,9 +172,11 @@ class SMBEXEC:
                 else:
                     self.logger.debug(str(e))
 
-        if self.__outputBuffer:
+        try:
             self.logger.debug(f"Deleting file {self.__share}\\{self.__output}")
             self.__smbconnection.deleteFile(self.__share, self.__output)
+        except Exception:
+            pass
 
     def execute_fileless(self, data):
         self.__output = gen_random_string(6)

--- a/nxc/protocols/smb/wmiexec.py
+++ b/nxc/protocols/smb/wmiexec.py
@@ -171,6 +171,8 @@ class WMIEXEC:
                 else:
                     self.logger.debug(f"Exception when trying to read output file: {e}")
 
-        if self.__outputBuffer:
+        try:
             self.logger.debug(f"Deleting file {self.__share}\\{self.__output}")
             self.__smbconnection.deleteFile(self.__share, self.__output)
+        except Exception:
+            pass


### PR DESCRIPTION
## Description

Always delete the output file when executing a command with SMB. If the output is empty, the file will now be deleted with this change. This was similarly added in [impacket-smbexec](https://github.com/fortra/impacket/blob/075f2b10a7a4056374a8c917f75e4419817cd6c7/examples/smbexec.py#L212) a while ago.

An example of a command's output being empty is the sleep command: `powershell -c "Start-Sleep 2"`.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
`netexec smb <IP> -u <user> -p <pass> -x 'powershell -c "Start-Sleep 2"' --exec-method <method>`
and verify no output file exists in `C:\`.

## Checklist:

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [X] I have added or updated the tests/e2e_commands.txt file if necessary
- [X] New and existing e2e tests pass locally with my changes
- [X] My code follows the style guidelines of this project (should be covered by Ruff above)
- [X] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
