### PR TITLE
Bugfixes for py3.13

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
         #python-version: ["3.8", "3.9", "3.10", "3.11"] # for binary builds we only need one version
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-zipapps.yml
+++ b/.github/workflows/build-zipapps.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: NetExec set up python on ${{ matrix.os }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
           cache: poetry
           cache-dependency-path: poetry.lock
       - name: Install dependencies with dev group

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -80,7 +80,7 @@ def no_debug(func):
 
 
 class NXCAdapter(logging.LoggerAdapter):
-    def __init__(self, extra=None):
+    def __init__(self, extra=None, merge_extra=False):
         logging.basicConfig(
             format="%(message)s",
             datefmt="[%X]",
@@ -93,6 +93,7 @@ class NXCAdapter(logging.LoggerAdapter):
         )
         self.logger = logging.getLogger("nxc")
         self.extra = extra
+        self.merge_extra = merge_extra
         self.output_file = None
 
         logging.getLogger("impacket").disabled = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -893,7 +893,7 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "impacket"
-version = "0.13.0.dev0+20241125.162952.ea27e8b2"
+version = "0.13.0.dev0+20250220.93348.6315ebd5"
 description = "Network protocols Constructors and Dissectors"
 optional = false
 python-versions = "*"
@@ -917,7 +917,7 @@ six = "*"
 type = "git"
 url = "https://github.com/fortra/impacket.git"
 reference = "HEAD"
-resolved_reference = "ea27e8b2dfedf57370d2f65c5053a2b8eeb8ca9d"
+resolved_reference = "6315ebd5388cf5bf52a809b8101f18d49c6a0ef7"
 
 [[package]]
 name = "iniconfig"
@@ -1870,7 +1870,7 @@ develop = false
 type = "git"
 url = "https://github.com/Pennyw0rth/NfsClient"
 reference = "HEAD"
-resolved_reference = "a94a3254b279dc49395caecf27ec097a71eea91b"
+resolved_reference = "0fa1c048394f601d565c6301880da84912b8245a"
 
 [[package]]
 name = "pyopenssl"


### PR DESCRIPTION
## Description

Kali just updated the default python version to 3.13. This PR has the following bug fixes addressing py3.13 and other issues:
- Fixing a logging issue cause by the introduction of the new logging parameter "[merge_extra](https://docs.python.org/3/library/logging.html#logging.LoggerAdapter)"
- Update PyNfsClient to enable py3.13 compatibility
- Update impacket as https://github.com/fortra/impacket/pull/1897 was merged
- Update GitHub workflows to use python 3.13

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
e2e tests and manually tests against GOAD

## Screenshots (if appropriate):
Debug logging issue with py3.13:
![image](https://github.com/user-attachments/assets/b9e8e300-3b2d-42ed-b357-437142c0fa56)
Bug fix for the PyNfsClient with py3.13 (Before&After):
![image](https://github.com/user-attachments/assets/5cdea1e7-c0e3-4593-8c31-11774dd32057)
