### PR TITLE
Refactored powershell_history module to fix case sensitivity

### DIFF
--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -36,8 +36,10 @@ class NXCModule:
                             buf = BytesIO()
                             connection.conn.getFile("C$", file_path, buf.write)
                             buf.seek(0)
-                            file_content = buf.read().decode("utf-8", errors="ignore").lower()                
-                            keywords = [keyword.upper() for keyword in self.sensitive_keywords if keyword in file_content]
+                            file_content = buf.read().decode("utf-8", errors="ignore")
+                            # Use temporary lowercase version for searching
+                            file_content_lower = file_content.lower()
+                            keywords = [keyword.upper() for keyword in self.sensitive_keywords if keyword.lower() in file_content_lower]
                             if len(keywords):
                                 context.log.highlight(f"C:\\{file_path} [ {' '.join(keywords)} ]")
                             else:

--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -37,9 +37,7 @@ class NXCModule:
                             connection.conn.getFile("C$", file_path, buf.write)
                             buf.seek(0)
                             file_content = buf.read().decode("utf-8", errors="ignore")
-                            # Use temporary lowercase version for searching
-                            file_content_lower = file_content.lower()
-                            keywords = [keyword.upper() for keyword in self.sensitive_keywords if keyword.lower() in file_content_lower]
+                            keywords = [keyword.upper() for keyword in self.sensitive_keywords if keyword.lower() in file_content.lower()]
                             if len(keywords):
                                 context.log.highlight(f"C:\\{file_path} [ {' '.join(keywords)} ]")
                             else:


### PR DESCRIPTION
## Description

This PR fixes #550 by using a temporary variable to preserve case sensitivity for matching keywords. 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested on HTB Absolute. 

## Screenshots (if appropriate):
![powershell_fix](https://github.com/user-attachments/assets/7494af1c-0488-4604-8ec0-f5abdca79ac2)

