### PR TITLE
Rename ambigous function

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1083,7 +1083,7 @@ class smb(connection):
             dc_ips.append(self.host)
         return dc_ips
 
-    def sessions(self):
+    def smb_sessions(self):
         try:
             sessions = get_netsession(
                 self.host,
@@ -1098,8 +1098,8 @@ class smb(connection):
                 if session.sesi10_cname.find(self.local_ip) == -1:
                     self.logger.highlight(f"{session.sesi10_cname:<25} User:{session.sesi10_username}")
             return sessions
-        except Exception:
-            pass
+        except Exception as e:
+            self.logger.debug(e)
 
     def disks(self):
         disks = []


### PR DESCRIPTION
## Description

It was never clear to me what `--sessions` exactly does. After digging into the MS Documentation it looks like this explicitely lists all **SMB** sessions. In order to properly distinguish it from options like `--qwinsta` (see #445) i would opt to rename it.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/37df083b-bc90-4b73-a107-0d02b6a79e1e)

## Checklist:
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
