### PR TITLE
Fix NFS issues when share is not listable

### DIFF
--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -590,6 +590,10 @@ class nfs(connection):
         self.logger.debug(f"Trying root escape on shares: {shares}")
         for share in shares:
             mount_info = self.mount.mnt(share, self.auth)
+            if mount_info["status"] != 0:
+                self.logger.debug(f"Root escape: can't list directory {share}: {NFSSTAT3[mount_info['status']]}")
+                self.mount.umnt(self.auth)
+                continue
             mount_fh = mount_info["mountinfo"]["fhandle"]
             try:
                 possible_root_fhs = self.get_root_handles(mount_fh)

--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -116,7 +116,7 @@ class nfs(connection):
             self.port = self.mnt_port
             self.proto_logger()
         except Exception as e:
-            self.logger.fail(f"Error during Initialization: {e}")
+            self.logger.info(f"Error during Initialization: {e}")
             return False
         return True
 


### PR DESCRIPTION
## Description

- Fixes a bug reported by @Marshall-Hallenbeck on discord where NFS crashes on connection initialization when one of the shares is restricted to e.g. a different ip
- Mutes the error when the connection can't be established similar to smb, ldap etc.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Local NFS on kali

## Screenshots (if appropriate):
Before&After:
![image](https://github.com/user-attachments/assets/97fca9e7-7aff-45c2-a00a-4623aa9d9605)
