### PR TITLE
Catch ldap error if host is not reachable

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -3,6 +3,7 @@
 import hashlib
 import hmac
 import os
+from errno import EHOSTUNREACH
 from binascii import hexlify
 from datetime import datetime
 from re import sub, I
@@ -209,7 +210,11 @@ class ldap(connection):
             self.logger.debug(f"{e} on host {self.host}")
             return False
         except OSError as e:
-            self.logger.error(f"Error getting ldap info {e}")
+            if e.errno == EHOSTUNREACH:
+                self.logger.info(f"Error connecting to {self.host} - {e}")
+                return False
+            else:
+                self.logger.error(f"Error getting ldap info {e}")
 
         self.logger.debug(f"Target: {target}; target_domain: {target_domain}; base_dn: {base_dn}")
         self.target = target


### PR DESCRIPTION
## Description

The ldap protocol continues even if the host is unreachable. This is fixed now, so ldap does not continue executing if no host is found.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Against a non existing IP

## Screenshots (if appropriate):
Before&After:
![image](https://github.com/user-attachments/assets/3d70c2db-41f3-4e8b-89b5-951dcde7bb17)

