### PR TITLE
Use host IP for DNS resolution in asreproast function if kdcHost not specified

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -259,7 +259,8 @@ class ldap(connection):
             ntlm_info = parse_challenge(ntlm_challenge)
             self.server_os = ntlm_info["os_version"]
 
-        if not self.kdcHost and self.domain and self.domain == self.remoteName:
+        # using kdcHost is buggy on impacket when using trust relation between ad so we kdcHost must stay to none if targetdomain is not equal to domain
+        if not self.kdcHost and self.domain and self.domain == self.targetDomain:
             result = self.resolver(self.domain)
             self.kdcHost = result["host"] if result else None
             self.logger.info(f"Resolved domain: {self.domain} with dns, kdcHost: {self.kdcHost}")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -806,10 +806,6 @@ class ldap(connection):
         if self.password == "" and self.nthash == "" and self.kerberos is False:
             return False
 
-        # If kdcHost isn't set, use the target IP for DNS resolution
-        if not self.kdcHost:
-            self.kdcHost = self.host
-
         # Building the search filter
         search_filter = "(&(UserAccountControl:1.2.840.113556.1.4.803:=%d)(!(UserAccountControl:1.2.840.113556.1.4.803:=%d))(!(objectCategory=computer)))" % (UF_DONT_REQUIRE_PREAUTH, UF_ACCOUNTDISABLE)
         attributes = [

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -805,6 +805,11 @@ class ldap(connection):
     def asreproast(self):
         if self.password == "" and self.nthash == "" and self.kerberos is False:
             return False
+
+        # If kdcHost isn't set, use the target IP for DNS resolution
+        if not self.kdcHost:
+            self.kdcHost = self.host
+
         # Building the search filter
         search_filter = "(&(UserAccountControl:1.2.840.113556.1.4.803:=%d)(!(UserAccountControl:1.2.840.113556.1.4.803:=%d))(!(objectCategory=computer)))" % (UF_DONT_REQUIRE_PREAUTH, UF_ACCOUNTDISABLE)
         attributes = [

--- a/nxc/protocols/ldap/kerberos.py
+++ b/nxc/protocols/ldap/kerberos.py
@@ -28,6 +28,7 @@ class KerberosAttacks:
         self.username = connection.username
         self.password = connection.password
         self.domain = connection.domain
+        self.host = connection.host
         self.targetDomain = connection.targetDomain
         self.hash = connection.hash
         self.lmhash = ""
@@ -222,6 +223,10 @@ class KerberosAttacks:
         seq_set_iter(req_body, "etype", supported_ciphers)
 
         message = encoder.encode(as_req)
+
+        # If kdcHost isn't set, use the target IP for DNS resolution
+        if not self.kdcHost:
+            self.kdcHost = self.host
 
         try:
             r = sendReceive(message, domain, self.kdcHost)


### PR DESCRIPTION
## Description
Fixes #592 by instructing the asreproast function to use the host IP for DNS resolution if not specified as a command-line arg with `--kdcHost`. 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested on HTB Rebound.

## Screenshots (if appropriate):
![ldap](https://github.com/user-attachments/assets/cd7a8c2e-3052-45c0-98f2-a15fd7e22888)

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)

