### PR TITLE
Add regsecretdump technique

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1545,7 +1545,7 @@ class smb(connection):
     @requires_admin
     def sam(self):
         try:
-            self.enable_remoteops(regsecret=self.args.sam == "regdump")
+            self.enable_remoteops(regsecret=(self.args.sam == "regdump"))
             host_id = self.db.get_hosts(filter_term=self.host)[0][0]
 
             def add_sam_hash(sam_hash, host_id):
@@ -1806,7 +1806,7 @@ class smb(connection):
     @requires_admin
     def lsa(self):
         try:
-            self.enable_remoteops(regsecret=self.args.lsa == "regdump")
+            self.enable_remoteops(regsecret=(self.args.lsa == "regdump"))
 
             def add_lsa_secret(secret):
                 add_lsa_secret.secrets += 1

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1552,7 +1552,7 @@ class smb(connection):
     @requires_admin
     def sam(self):
         try:
-            self.enable_remoteops(regsecret=True if self.args.sam == "regdump" else False)
+            self.enable_remoteops(regsecret=self.args.sam == "regdump")
             host_id = self.db.get_hosts(filter_term=self.host)[0][0]
 
             def add_sam_hash(sam_hash, host_id):
@@ -1813,7 +1813,7 @@ class smb(connection):
     @requires_admin
     def lsa(self):
         try:
-            self.enable_remoteops(regsecret=True if self.args.lsa == "regdump" else False)
+            self.enable_remoteops(regsecret=self.args.lsa == "regdump")
 
             def add_lsa_secret(secret):
                 add_lsa_secret.secrets += 1
@@ -1843,6 +1843,7 @@ class smb(connection):
                     LSA = LSASecrets(
                         SECURITYFileName,
                         self.bootkey,
+                        self.remote_ops,
                         isRemote=True,
                         perSecretCallback=lambda secret_type, secret: add_lsa_secret(secret),
                     )

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -25,8 +25,8 @@ def proto_args(parser, parents):
     self_delegate_arg.make_required = [delegate_arg]
 
     cred_gathering_group = smb_parser.add_argument_group("Credential Gathering", "Options for gathering credentials")
-    cred_gathering_group.add_argument("--sam", action="store_true", help="dump SAM hashes from target systems")
-    cred_gathering_group.add_argument("--lsa", action="store_true", help="dump LSA secrets from target systems")
+    cred_gathering_group.add_argument("--sam", choices={"regdump", "secdump"}, nargs="?", const="regdump", help="dump SAM hashes from target systems")
+    cred_gathering_group.add_argument("--lsa", choices={"regdump", "secdump"}, nargs="?", const="regdump", help="dump LSA secrets from target systems")
     cred_gathering_group.add_argument("--ntds", choices={"vss", "drsuapi"}, nargs="?", const="drsuapi", help="dump the NTDS.dit from target DCs using the specifed method")
     cred_gathering_group.add_argument("--dpapi", choices={"cookies", "nosystem"}, nargs="*", help="dump DPAPI secrets from target systems, can dump cookies if you add 'cookies', will not dump SYSTEM dpapi if you add nosystem")
     cred_gathering_group.add_argument("--sccm", choices={"wmi", "disk"}, nargs="?", const="disk", help="dump SCCM secrets from target systems")

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,7 +865,7 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "impacket"
-version = "0.13.0.dev0+20250220.93348.6315ebd5"
+version = "0.13.0.dev0+20250314.172046.8b4566b1"
 description = "Network protocols Constructors and Dissectors"
 optional = false
 python-versions = "*"
@@ -890,7 +890,7 @@ six = "*"
 type = "git"
 url = "https://github.com/fortra/impacket.git"
 reference = "HEAD"
-resolved_reference = "6315ebd5388cf5bf52a809b8101f18d49c6a0ef7"
+resolved_reference = "8b4566b12fc79acb520d045dbae8f13446a9d4d7"
 
 [[package]]
 name = "iniconfig"


### PR DESCRIPTION
## Description

No more file write on disk when dumping SAM and LSA following the new addition in impacket https://github.com/fortra/impacket/pull/1898 from @laxa 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/c3624766-6b3c-4359-ae7e-baded97dd837)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
