### PR TITLE
fix 0x_df issue with hosts file

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -330,8 +330,8 @@ class smb(connection):
 
             if self.args.generate_hosts_file:
                 with open(self.args.generate_hosts_file, "a+") as host_file:
-                    host_file.write(f"{self.host}    {self.hostname} {self.hostname}.{self.targetDomain} {self.targetDomain if isdc else ''}\n")
-                    self.logger.debug(f"{self.host}    {self.hostname} {self.hostname}.{self.targetDomain} {self.targetDomain if isdc else ''}")
+                    host_file.write(f"{self.host}     {self.hostname}.{self.targetDomain} {self.targetDomain if isdc else ''} {self.hostname}\n")
+                    self.logger.debug(f"{self.host}    {self.hostname}.{self.targetDomain} {self.targetDomain if isdc else ''} {self.hostname}")
             elif self.args.generate_krb5_file and isdc:
                 with open(self.args.generate_krb5_file, "w+") as host_file:
                     data = f"""

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -330,8 +330,8 @@ class smb(connection):
 
             if self.args.generate_hosts_file:
                 with open(self.args.generate_hosts_file, "a+") as host_file:
-                    host_file.write(f"{self.host}     {self.hostname}.{self.targetDomain} {self.targetDomain if isdc else ''} {self.hostname}\n")
-                    self.logger.debug(f"{self.host}    {self.hostname}.{self.targetDomain} {self.targetDomain if isdc else ''} {self.hostname}")
+                    host_file.write(f"{self.host}     {self.hostname}.{self.targetDomain}{self.targetDomain if isdc else ''} {self.hostname}\n")
+                    self.logger.debug(f"{self.host}    {self.hostname}.{self.targetDomain}{self.targetDomain if isdc else ''} {self.hostname}")
             elif self.args.generate_krb5_file and isdc:
                 with open(self.args.generate_krb5_file, "w+") as host_file:
                     data = f"""


### PR DESCRIPTION
## Description

Fix https://x.com/0xdf_/status/1898386186361532467

https://www.ibm.com/docs/en/samfm/8.0.1?topic=spnego-algorithm-resolve-host-names

This pull request includes a small change to the `nxc/protocols/smb.py` file to modify the format of the host information being logged and written to a file.

* [`nxc/protocols/smb.py`](diffhunk://#diff-03a263aab56e8880814c8a586230088900d62ab9c53b93744492f6fcd1bf7630L333-R334): Changed the order and format of the host information in the `print_host_info` method to ensure the hostname is listed after the domain.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/ffa2558d-d681-478a-9a20-a83d30ad8773)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
