### PR TITLE
Add information if ntlm disabled

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -316,7 +316,8 @@ class smb(connection):
     def print_host_info(self):
         signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
         smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=["bold"]) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=["bold"])
-        self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.targetDomain}) ({signing}) ({smbv1})")
+        ntlm = colored(f"(NTLM:{not self.no_ntlm})", host_info_colors[2], attrs=["bold"]) if self.no_ntlm else ""
+        self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.targetDomain}) ({signing}) ({smbv1}) {ntlm}")
 
         if self.args.generate_hosts_file or self.args.generate_krb5_file:
             from impacket.dcerpc.v5 import nrpc, epm


### PR DESCRIPTION
## Description

This pull request includes a small change to the `nxc/protocols/smb.py` file. The change modifies the `print_host_info` method to include NTLM information in the host display output.

* [`nxc/protocols/smb.py`](diffhunk://#diff-03a263aab56e8880814c8a586230088900d62ab9c53b93744492f6fcd1bf7630L319-R320): Updated the `print_host_info` method to add NTLM status to the host information display.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/56c9a394-4ce2-485f-bc91-98f5042ab0b0)
