### PR TITLE
Silently handle connection timed out during LDAP scan

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -3,7 +3,7 @@
 import hashlib
 import hmac
 import os
-from errno import EHOSTUNREACH
+from errno import EHOSTUNREACH, ETIMEDOUT
 from binascii import hexlify
 from datetime import datetime
 from re import sub, I
@@ -211,7 +211,7 @@ class ldap(connection):
             self.logger.debug(f"{e} on host {self.host}")
             return False
         except OSError as e:
-            if e.errno == EHOSTUNREACH:
+            if e.errno in (EHOSTUNREACH, ETIMEDOUT):
                 self.logger.info(f"Error connecting to {self.host} - {e}")
                 return False
             else:


### PR DESCRIPTION
## Description
Silently handle connection timeouts when doing an LDAP scan on host(s). Before, the connection timeout would print an error to the screen, which would show for every single host not running LDAP. However, this most likely isn't helpful to the user as it means the hosts are probably not running an LDAP server. Now, this error is handled and ignored.

This could be caught with a separate `TimeoutError` exception (a subclass of OSError), but I decided against that to use the same message that a 'Host unreachable' error would use. Can definitely make the change if this would be the better way to do it though.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually:
`nxc ldap 10.10.10.10-20`

## Screenshots (if appropriate):
Before:
![NetExec-LDAP-Timeout-Before](https://github.com/user-attachments/assets/69442df4-dd9a-4913-a717-3afa6f0ce66e)

After:
![NetExec-LDAP-Timeout-After](https://github.com/user-attachments/assets/134768a8-b6fb-4373-9900-2b06c2624cd4)

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [N/A] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [N/A] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
