### PR TITLE
modified the password used in pre2k.py for machine names longer than …

### DIFF
--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -94,7 +94,7 @@ class NXCModule:
     def get_tgt(self, context, username, domain, kdcHost, ccache_base_dir):
         try:
             userName = Principal(username, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-            password = username  # Password is the machine name in lowercase
+            password = username[:14]  # Password is the first 14 characters of the machine name in lowercase
             context.log.info(f"Getting TGT for {username}@{domain}")
 
             tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(


### PR DESCRIPTION
added a quick fix for truncating the password to a max of 14 characters for issue #610 