### PR TITLE
oened in bloodhoundCE uses a new tag

### DIFF
--- a/nxc/helpers/bloodhound.py
+++ b/nxc/helpers/bloodhound.py
@@ -74,8 +74,8 @@ def _add_with_domain(user_info, domain, tx, logger):
         logger.fail("Account not found in the BloodHound database.")
         return
     if result[0]["c"].get("owned") in (False, None):
-        logger.debug(f"MATCH (c:{account_type} {{name:'{user_owned}'}}) SET c.owned=True RETURN c.name AS name")
-        result = tx.run(f"MATCH (c:{account_type} {{name:'{user_owned}'}}) SET c.owned=True RETURN c.name AS name").data()[0]
+        logger.debug(f"MATCH (c:{account_type} {{name:'{user_owned}'}}) SET c.system_tags='owned' RETURN c.name AS name")
+        result = tx.run(f"MATCH (c:{account_type} {{name:'{user_owned}'}}) SET c.system_tags='owned' c.name AS name").data()[0]
         logger.highlight(f"Node {result['name']} successfully set as owned in BloodHound")
 
 
@@ -96,6 +96,6 @@ def _add_without_domain(user_info, tx, logger):
         logger.fail(f"Multiple accounts found with the name '{user_info['username']}' in the BloodHound database. Please specify the FQDN ex:domain.local")
         return
     elif result[0]["c"].get("owned") in (False, None):
-        logger.debug(f"MATCH (c:{account_type} {{name:'{result[0]['c']['name']}'}}) SET c.owned=True RETURN c.name AS name")
-        result = tx.run(f"MATCH (c:{account_type} {{name:'{result[0]['c']['name']}'}}) SET c.owned=True RETURN c.name AS name").data()[0]
+        logger.debug(f"MATCH (c:{account_type} {{name:'{result[0]['c']['name']}'}}) SET c.system_tags='owned' RETURN c.name AS name")
+        result = tx.run(f"MATCH (c:{account_type} {{name:'{result[0]['c']['name']}'}}) SET c.system_tags='owned' c.name AS name").data()[0]
         logger.highlight(f"Node {result['name']} successfully set as owned in BloodHound")


### PR DESCRIPTION
## Description

NetExec can update in bloodhoundCE users an computers "owned", in the old way the tag to add in neo4j was:
`c.owned=True`
But now the new tag is:
`c.system_tags='owned`

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
In my own tests.

## Screenshots (if appropriate):
No scrrenshots

## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] My code follows the style guidelines of this project (should be covered by Ruff above)
- [ ] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
