### PR TITLE
New smb module : restricted admin

### DIFF
--- a/nxc/modules/restrictedadmin.py
+++ b/nxc/modules/restrictedadmin.py
@@ -1,3 +1,4 @@
+import sys
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 
@@ -21,43 +22,43 @@ class NXCModule:
         ACTION:     "read" or "enable" or "disable" 
         '''
         self.action = None
-        if not 'ACTION' in module_options:
-            self.action = 'read' # DEFAULT MODE
-        if 'ACTION' in module_options:
-            if module_options['ACTION'] == 'enable':
-                self.action = 'enable'
-            if module_options['ACTION'] == 'disable':
-                self.action = 'disable'
-            if module_options['ACTION'] == 'read':
-                self.action = 'read'
+        if "ACTION" not in module_options:
+            self.action = "read" # DEFAULT MODE
+        if "ACTION" in module_options:
+            if module_options["ACTION"] == "enable":
+                self.action = "enable"
+            if module_options["ACTION"] == "disable":
+                self.action = "disable"
+            if module_options["ACTION"] == "read":
+                self.action = "read"
 
     def on_admin_login(self, context, connection):
 
-        if self.action == 'read':
+        if self.action == "read":
             # READ MODE
             read = self.check_status(context, connection)
-            if read == 1 : 
-                context.log.fail(f'DisableRestrictedAdmin key is set to 0x{read}, PTH on RDP is not allowed.')
-            if read == 0 :
-                context.log.highlight(f'DisableRestrictedAdmin key is set to 0x{read}, PTH on RDP is allowed.')
+            if read == 1: 
+                context.log.fail(f"DisableRestrictedAdmin key is set to 0x{read}, PTH on RDP is not allowed.")
+            if read == 0:
+                context.log.highlight(f"DisableRestrictedAdmin key is set to 0x{read}, PTH on RDP is allowed.")
             if read != 0 and read != 1:
-                context.log.error('Error unknown value on regkey : %s' % str(read)) 
-        if self.action == 'enable':
+                context.log.error("Error unknown value on regkey : %s" % str(read)) 
+        if self.action == "enable":
             # ENABLE MODE
             enable = self.enable(context, connection)
-            if enable == True :
+            if enable is True:
                 if self.check_status(context, connection) == 0:
-                    context.log.highlight('Operation completed successfully.')
+                    context.log.highlight("Operation completed successfully.")
                 else:
-                    context.log.error('Error unknown value on regkey : %s' % str(read))
-        if self.action == 'disable':
+                    context.log.error("Error unknown value on regkey : %s" % str(read))
+        if self.action == "disable":
             # DISABLE MODE
             disable = self.disable(context, connection)
-            if disable == True :
+            if disable is True:
                 if self.check_status(context, connection) == 1:
-                    context.log.highlight('Operation completed successfully.')
+                    context.log.highlight("Operation completed successfully.")
                 else:
-                    context.log.error('Error unknown value on regkey : %s' % str(read))
+                    context.log.error("Error unknown value on regkey : %s" % str(read))
 
 
     def check_status(self, context, connection):
@@ -78,11 +79,11 @@ class NXCModule:
                 query = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "DisableRestrictedAdmin\x00")
                 return query[1]                
             except Exception as e:
-                context.log.error('RemoteOperations failed: %s' % str(e))
+                context.log.error("RemoteOperations failed: %s" % str(e))
                 sys.exit(1) 
 
         except Exception as e:
-                context.log.error('RemoteOperations failed: %s' % str(e))
+                context.log.error("RemoteOperations failed: %s" % str(e))
                 sys.exit(1)
 
         finally:
@@ -93,7 +94,7 @@ class NXCModule:
     def enable(self, context, connection):
         
         try:
-            remoteOps  = RemoteOperations(connection.conn, False)
+            remoteOps = RemoteOperations(connection.conn, False)
             remoteOps.enableRegistry()
 
             # HKLM Access
@@ -105,14 +106,14 @@ class NXCModule:
             keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, registry_path)["phkResult"]
 
             try:
-                query = rrp.hBaseRegSetValue(remoteOps._RemoteOperations__rrp, keyHandle, 'DisableRestrictedAdmin\x00', rrp.REG_DWORD, 0)
+                rrp.hBaseRegSetValue(remoteOps._RemoteOperations__rrp, keyHandle, "DisableRestrictedAdmin\x00", rrp.REG_DWORD, 0)
                 return True                
             except Exception as e:
-                context.log.error('RemoteOperations failed: %s' % str(e))
+                context.log.error("RemoteOperations failed: %s" % str(e))
                 sys.exit(1) 
 
         except Exception as e:
-                context.log.error('RemoteOperations failed: %s' % str(e))
+                context.log.error("RemoteOperations failed: %s" % str(e))
                 sys.exit(1)
 
         finally:
@@ -123,7 +124,7 @@ class NXCModule:
     def disable(self, context, connection):
         
         try:
-            remoteOps  = RemoteOperations(connection.conn, False)
+            remoteOps = RemoteOperations(connection.conn, False)
             remoteOps.enableRegistry()
 
             # HKLM Access
@@ -135,14 +136,14 @@ class NXCModule:
             keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, registry_path)["phkResult"]
 
             try:
-                query = rrp.hBaseRegSetValue(remoteOps._RemoteOperations__rrp, keyHandle, 'DisableRestrictedAdmin\x00', rrp.REG_DWORD, 1)
+                rrp.hBaseRegSetValue(remoteOps._RemoteOperations__rrp, keyHandle, "DisableRestrictedAdmin\x00", rrp.REG_DWORD, 1)
                 return True                
             except Exception as e:
-                context.log.error('RemoteOperations failed: %s' % str(e))
+                context.log.error("RemoteOperations failed: %s" % str(e))
                 sys.exit(1) 
 
         except Exception as e:
-                context.log.error('RemoteOperations failed: %s' % str(e))
+                context.log.error("RemoteOperations failed: %s" % str(e))
                 sys.exit(1)
 
         finally:

--- a/nxc/modules/restrictedadmin.py
+++ b/nxc/modules/restrictedadmin.py
@@ -1,0 +1,153 @@
+import logging
+
+from impacket.dcerpc.v5 import rrp
+from impacket.examples.secretsdump import RemoteOperations
+
+class NXCModule:
+    name = "restrictedadmin"
+    description = "Perform actions (enable/disable) on DisableRestrictedAdmin reg key"
+    supported_protocols = ["smb"]
+    opsec_safe = True
+    multiple_hosts = True
+
+    def __init__(self, context=None, module_options=None):
+        self.context = context
+        self.module_options = module_options
+    
+    def options(self, context, module_options):
+        '''
+        Mode read See the value of the registry key and deduce if PTH is is possible or not
+        Mode enable Set value to 0, that will enable the security option "RestricedAdmin" and allow PTH on RDP
+        Mode disable Set value to 1, PTH will be no longer possible
+
+        ACTION:     "read" or "enable" or "disable" 
+        '''
+        self.action = None
+        if not 'ACTION' in module_options:
+            self.action = 'read' # DEFAULT MODE
+        if 'ACTION' in module_options:
+            if module_options['ACTION'] == 'enable':
+                self.action = 'enable'
+            if module_options['ACTION'] == 'disable':
+                self.action = 'disable'
+            if module_options['ACTION'] == 'read':
+                self.action = 'read'
+
+    def on_admin_login(self, context, connection):
+
+
+        if self.action == 'read':
+            # READ MODE
+            read = self.check_status(context, connection)
+            if read == 1 : 
+                context.log.fail(f'DisableRestrictedAdmin key is set to 0x{read}, PTH on RDP is not allowed.')
+            if read == 0 :
+                context.log.highlight(f'DisableRestrictedAdmin key is set to 0x{read}, PTH on RDP is allowed.')
+            if read != 0 and read != 1:
+                context.log.error('Error unknown value on regkey : %s' % str(read)) 
+        if self.action == 'enable':
+            # ENABLE MODE
+            enable = self.enable(context, connection)
+            if enable == True :
+                if self.check_status(context, connection) == 0:
+                    context.log.highlight('Operation complete successfully.')
+                else:
+                    context.log.error('Error unknown value on regkey : %s' % str(read))
+        if self.action == 'disable':
+            # DISABLE MODE
+            disable = self.disable(context, connection)
+            if disable == True :
+                if self.check_status(context, connection) == 1:
+                    context.log.highlight('Operation complete successfully.')
+                else:
+                    context.log.error('Error unknown value on regkey : %s' % str(read))
+
+
+    def check_status(self, context, connection):
+        
+        try:
+            remoteOps  = RemoteOperations(connection.conn, False)
+            remoteOps.enableRegistry()
+
+            # HKLM Access
+            ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
+            regHandle = ans["phKey"]
+
+            # registry path AND open registry
+            registry_path = f"System\\CurrentControlSet\\Control\\Lsa"
+            keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, registry_path)["phkResult"]
+
+            try:
+                query = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "DisableRestrictedAdmin\x00")
+                return query[1]                
+            except Exception as e:
+                context.log.error('RemoteOperations failed: %s' % str(e))
+                sys.exit(1) 
+
+        except Exception as e:
+                context.log.error('RemoteOperations failed: %s' % str(e))
+                sys.exit(1)
+
+        finally:
+            # CLODE HANDLE
+            rrp.hBaseRegCloseKey(remoteOps._RemoteOperations__rrp, keyHandle)
+
+    
+    def enable(self, context, connection):
+        
+        try:
+            remoteOps  = RemoteOperations(connection.conn, False)
+            remoteOps.enableRegistry()
+
+            # HKLM Access
+            ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
+            regHandle = ans["phKey"]
+
+            # registry path AND open registry
+            registry_path = f"System\\CurrentControlSet\\Control\\Lsa"
+            keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, registry_path)["phkResult"]
+
+            try:
+                query = rrp.hBaseRegSetValue(remoteOps._RemoteOperations__rrp, keyHandle, 'DisableRestrictedAdmin\x00', rrp.REG_DWORD, 0)
+                return True                
+            except Exception as e:
+                context.log.error('RemoteOperations failed: %s' % str(e))
+                sys.exit(1) 
+
+        except Exception as e:
+                context.log.error('RemoteOperations failed: %s' % str(e))
+                sys.exit(1)
+
+        finally:
+            # CLODE HANDLE
+            rrp.hBaseRegCloseKey(remoteOps._RemoteOperations__rrp, keyHandle)
+
+    
+    def disable(self, context, connection):
+        
+        try:
+            remoteOps  = RemoteOperations(connection.conn, False)
+            remoteOps.enableRegistry()
+
+            # HKLM Access
+            ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
+            regHandle = ans["phKey"]
+
+            # registry path AND open registry
+            registry_path = f"System\\CurrentControlSet\\Control\\Lsa"
+            keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, registry_path)["phkResult"]
+
+            try:
+                query = rrp.hBaseRegSetValue(remoteOps._RemoteOperations__rrp, keyHandle, 'DisableRestrictedAdmin\x00', rrp.REG_DWORD, 1)
+                return True                
+            except Exception as e:
+                context.log.error('RemoteOperations failed: %s' % str(e))
+                sys.exit(1) 
+
+        except Exception as e:
+                context.log.error('RemoteOperations failed: %s' % str(e))
+                sys.exit(1)
+
+        finally:
+            # CLODE HANDLE
+            rrp.hBaseRegCloseKey(remoteOps._RemoteOperations__rrp, keyHandle)

--- a/nxc/modules/restrictedadmin.py
+++ b/nxc/modules/restrictedadmin.py
@@ -1,5 +1,3 @@
-import logging
-
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 
@@ -35,7 +33,6 @@ class NXCModule:
 
     def on_admin_login(self, context, connection):
 
-
         if self.action == 'read':
             # READ MODE
             read = self.check_status(context, connection)
@@ -50,7 +47,7 @@ class NXCModule:
             enable = self.enable(context, connection)
             if enable == True :
                 if self.check_status(context, connection) == 0:
-                    context.log.highlight('Operation complete successfully.')
+                    context.log.highlight('Operation completed successfully.')
                 else:
                     context.log.error('Error unknown value on regkey : %s' % str(read))
         if self.action == 'disable':
@@ -58,7 +55,7 @@ class NXCModule:
             disable = self.disable(context, connection)
             if disable == True :
                 if self.check_status(context, connection) == 1:
-                    context.log.highlight('Operation complete successfully.')
+                    context.log.highlight('Operation completed successfully.')
                 else:
                     context.log.error('Error unknown value on regkey : %s' % str(read))
 
@@ -74,7 +71,7 @@ class NXCModule:
             regHandle = ans["phKey"]
 
             # registry path AND open registry
-            registry_path = f"System\\CurrentControlSet\\Control\\Lsa"
+            registry_path = "System\\CurrentControlSet\\Control\\Lsa"
             keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, registry_path)["phkResult"]
 
             try:
@@ -104,7 +101,7 @@ class NXCModule:
             regHandle = ans["phKey"]
 
             # registry path AND open registry
-            registry_path = f"System\\CurrentControlSet\\Control\\Lsa"
+            registry_path = "System\\CurrentControlSet\\Control\\Lsa"
             keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, registry_path)["phkResult"]
 
             try:
@@ -134,7 +131,7 @@ class NXCModule:
             regHandle = ans["phKey"]
 
             # registry path AND open registry
-            registry_path = f"System\\CurrentControlSet\\Control\\Lsa"
+            registry_path = "System\\CurrentControlSet\\Control\\Lsa"
             keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, registry_path)["phkResult"]
 
             try:


### PR DESCRIPTION
## Description

Hello,
I am proposing a small module for SMB. This module is designed to perform three main actions on a registry key: "DisableRestrictedAdmin".

This key manages Windows "Restricted Admin" protection. If this protection is enabled, it is possible to perform Pass-The-Hash (PTH) on the RDP protocol, particularly with xfreerdp, as Windows uses the NTLM hash for authentication.

This idea comes from my tool [pyRestrictedAdmin](https://github.com/Anh4ckin3/pyRestrictedAdmin)

modes:
- [x] read : See the value of the registry key and deduce if PTH is is possible or not
- [x] disable : Set value to 1, PTH will be no longer possible
- [x] enable : Set value to 0, that will enable the security option "RestricedAdmin" and allow PTH on RDP

## How Has This Been Tested?

I tested this module in an Active Directory lab environment, specifically on Windows Server 2022 machines:
```
OS Name:                   Microsoft Windows Server 2022 Standard Evaluation  
OS Version:                10.0.20348 N/A Build 20348  
```

To test, if you are using Poetry, you can proceed as follows:

- Read mode (default): `poetry run nxc smb IP -u USER -p '<PASS>' -M restrictedadmin`
- Disable mode: `poetry run nxc smb IP -u USER -p '<PASS>' -M restrictedadmin -o ACTION=disable`
- Enable mode: `poetry run nxc smb IP -u USER -p 'PASS' -M restrictedadmin -o ACTION=enable`

## Screenshots (if appropriate):
- Read mode (default):
![image](https://github.com/user-attachments/assets/6d8fbffe-9f95-4fd4-830c-509a09a5df46)


- Enable mode : 
![image](https://github.com/user-attachments/assets/dca414cb-ec10-449e-8dc4-43372db288f2)


- Disable mode : 
![image](https://github.com/user-attachments/assets/205be66d-7d8d-45e3-831a-df65fb9f3a91)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
