### PR TITLE
Add Error handling for loading users into registry

### DIFF
--- a/nxc/modules/putty.py
+++ b/nxc/modules/putty.py
@@ -69,19 +69,23 @@ class NXCModule:
     def load_missing_users(self, unloaded_user_objects):
         """Load missing users into registry to access their registry keys."""
         for user_object in unloaded_user_objects:
-            # Extract profile Path of NTUSER.DAT
-            reg_handle = rrp.hOpenLocalMachine(self.rrp._RemoteOperations__rrp)["phKey"]
-            key_handle = rrp.hBaseRegOpenKey(self.rrp._RemoteOperations__rrp, reg_handle, f"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{user_object}")["phkResult"]
-            user_profile_path = rrp.hBaseRegQueryValue(self.rrp._RemoteOperations__rrp, key_handle, "ProfileImagePath")[1].split("\x00")[:-1][0]
-            rrp.hBaseRegCloseKey(self.rrp._RemoteOperations__rrp, key_handle)
+            try:
+                # Extract profile Path of NTUSER.DAT
+                reg_handle = rrp.hOpenLocalMachine(self.rrp._RemoteOperations__rrp)["phKey"]
+                key_handle = rrp.hBaseRegOpenKey(self.rrp._RemoteOperations__rrp, reg_handle, f"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{user_object}")["phkResult"]
+                user_profile_path = rrp.hBaseRegQueryValue(self.rrp._RemoteOperations__rrp, key_handle, "ProfileImagePath")[1].split("\x00")[:-1][0]
+                rrp.hBaseRegCloseKey(self.rrp._RemoteOperations__rrp, key_handle)
 
-            # Load Profile
-            reg_handle = rrp.hOpenUsers(self.rrp._RemoteOperations__rrp)["phKey"]
-            key_handle = rrp.hBaseRegOpenKey(self.rrp._RemoteOperations__rrp, reg_handle, "")["phkResult"]
+                # Load Profile
+                reg_handle = rrp.hOpenUsers(self.rrp._RemoteOperations__rrp)["phKey"]
+                key_handle = rrp.hBaseRegOpenKey(self.rrp._RemoteOperations__rrp, reg_handle, "")["phkResult"]
 
-            self.context.log.debug(f"LOAD USER INTO REGISTRY: {user_object}")
-            rrp.hBaseRegLoadKey(self.rrp._RemoteOperations__rrp, key_handle, user_object, f"{user_profile_path}\\NTUSER.DAT")
-            rrp.hBaseRegCloseKey(self.rrp._RemoteOperations__rrp, key_handle)
+                self.context.log.debug(f"LOAD USER INTO REGISTRY: {user_object}")
+                rrp.hBaseRegLoadKey(self.rrp._RemoteOperations__rrp, key_handle, user_object, f"{user_profile_path}\\NTUSER.DAT")
+                rrp.hBaseRegCloseKey(self.rrp._RemoteOperations__rrp, key_handle)
+            except rrp.DCERPCSessionError as e:
+                self.context.log.fail(f"Error loading user {user_object} into registry: {e}")
+                self.context.log.debug(traceback.format_exc())
 
     def unload_missing_users(self, unloaded_user_objects):
         """If some user were not logged in at the beginning we unload them from registry."""
@@ -92,7 +96,7 @@ class NXCModule:
             self.context.log.debug(f"UNLOAD USER FROM REGISTRY: {user_object}")
             try:
                 rrp.hBaseRegUnLoadKey(self.rrp._RemoteOperations__rrp, key_handle, user_object)
-            except Exception as e:
+            except rrp.DCERPCSessionError as e:
                 self.context.log.fail(f"Error unloading user {user_object} in registry: {e}")
                 self.context.log.debug(traceback.format_exc())
         rrp.hBaseRegCloseKey(self.rrp._RemoteOperations__rrp, key_handle)


### PR DESCRIPTION
## Description

As reported in #618 sometimes the putty module fails to load the registry content from the NTUSER.DAT into the registry. This is now handled properly for each user, so that not the whole module crashes if a single user fails to be loaded.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Against GOAD with a custom raised exception internally 

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c99352fb-9230-4c63-b8bf-2cb9b9c31d0d)
