### PR TITLE
Fix spec file

### DIFF
--- a/netexec.spec
+++ b/netexec.spec
@@ -20,6 +20,7 @@ a = Analysis(
         'aardwolf.commons.target',
         'aardwolf.protocol.x224.constants',
         'impacket.examples.secretsdump',
+        'impacket.examples.regsecrets',
         'impacket.dcerpc.v5.lsat',
         'impacket.dcerpc.v5.transport',
         'impacket.dcerpc.v5.lsad',


### PR DESCRIPTION
## Description

Include the `regsecrets` import in the spec file to fix the smb protocol in the native binary.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually build&tested on kali

## Screenshots (if appropriate):
Before:
![image](https://github.com/user-attachments/assets/ae04b51b-63ca-4c70-91ff-6d5b0709bf02)

After:
![image](https://github.com/user-attachments/assets/0c63dc28-badc-4e15-9669-832aa0da65cf)
