### PR TITLE
smb: Prevent infinite loops handling an unknown error retrieving command output

### DIFF
--- a/nxc/protocols/smb/mmcexec.py
+++ b/nxc/protocols/smb/mmcexec.py
@@ -249,7 +249,7 @@ class MMCEXEC:
             self.__outputBuffer = ""
             return
 
-        tries = 0
+        tries = 1
         # Give the command a bit of time to execute before we try to read the output, 0.4 seconds was good in testing
         sleep(0.4)
         while True:
@@ -258,7 +258,7 @@ class MMCEXEC:
                 self.__smbconnection.getFile(self.__share, self.__output, self.output_callback)
                 break
             except Exception as e:
-                if tries > self.__tries:
+                if tries >= self.__tries:
                     self.logger.fail("MMCEXEC: Could not retrieve output file, it may have been detected by AV. Please increase the number of tries with the option '--get-output-tries'. If it is still failing, try the 'wmi' protocol or another exec method")
                     break
                 if "STATUS_BAD_NETWORK_NAME" in str(e):
@@ -270,15 +270,17 @@ class MMCEXEC:
                 # When executing powershell and the command is still running, we get a sharing violation
                 # We can use that information to wait longer than if the file is not found (probably av or something)
                 if "STATUS_SHARING_VIOLATION" in str(e):
-                    self.logger.info(f"File {self.__share}\\{self.__output} is still in use with {self.__tries - tries} left, retrying...")
+                    self.logger.info(f"File {self.__share}\\{self.__output} is still in use with {self.__tries - tries} tries left, retrying...")
                     tries += 1
                     sleep(1)
                 elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
-                    self.logger.info(f"File {self.__share}\\{self.__output} not found with {self.__tries - tries} left, deducting 10 tries and retrying...")
+                    self.logger.info(f"File {self.__share}\\{self.__output} not found with {self.__tries - tries} tries left, deducting 10 tries and retrying...")
                     tries += 10
                     sleep(1)
                 else:
-                    self.logger.debug(str(e))
+                    self.logger.debug(f"Exception when trying to read output file: {e!s}. {self.__tries - tries} tries left, retrying...")
+                    tries += 1
+                    sleep(1)
 
         try:
             self.logger.debug(f"Deleting file {self.__share}\\{self.__output}")

--- a/nxc/protocols/smb/smbexec.py
+++ b/nxc/protocols/smb/smbexec.py
@@ -141,16 +141,14 @@ class SMBEXEC:
             self.__outputBuffer = ""
             return
 
-        # TODO: It looks like the service is hanging anyway until the command is finished, so all this timeout logic is likely not needed
-        # Still adding this for now to keep the structure similar until we can confirm the above
-        tries = 0
+        tries = 1
         while True:
             try:
                 self.logger.info(f"Attempting to read {self.__share}\\{self.__output}")
                 self.__smbconnection.getFile(self.__share, self.__output, self.output_callback)
                 break
             except Exception as e:
-                if tries > self.__tries:
+                if tries >= self.__tries:
                     self.logger.fail("SMBEXEC: Could not retrieve output file, it may have been detected by AV. Please increase the number of tries with the option '--get-output-tries'. If it is still failing, try the 'wmi' protocol or another exec method")
                     break
                 if "STATUS_BAD_NETWORK_NAME" in str(e):
@@ -162,15 +160,17 @@ class SMBEXEC:
                 # When executing powershell and the command is still running, we get a sharing violation
                 # We can use that information to wait longer than if the file is not found (probably av or something)
                 if "STATUS_SHARING_VIOLATION" in str(e):
-                    self.logger.info(f"File {self.__share}\\{self.__output} is still in use with {self.__tries - tries} left, retrying...")
+                    self.logger.info(f"File {self.__share}\\{self.__output} is still in use with {self.__tries - tries} tries left, retrying...")
                     tries += 1
                     sleep(1)
                 elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
-                    self.logger.info(f"File {self.__share}\\{self.__output} not found with {self.__tries - tries} left, deducting 10 tries and retrying...")
+                    self.logger.info(f"File {self.__share}\\{self.__output} not found with {self.__tries - tries} tries left, deducting 10 tries and retrying...")
                     tries += 10
                     sleep(1)
                 else:
-                    self.logger.debug(str(e))
+                    self.logger.debug(f"Exception when trying to read output file: {e!s}. {self.__tries - tries} tries left, retrying...")
+                    tries += 1
+                    sleep(1)
 
         try:
             self.logger.debug(f"Deleting file {self.__share}\\{self.__output}")

--- a/nxc/protocols/smb/wmiexec.py
+++ b/nxc/protocols/smb/wmiexec.py
@@ -140,7 +140,7 @@ class WMIEXEC:
             self.__outputBuffer = ""
             return
 
-        tries = 0
+        tries = 1
         # Give the command a bit of time to execute before we try to read the output, 0.4 seconds was good in testing
         sleep(0.4)
         while True:
@@ -149,7 +149,7 @@ class WMIEXEC:
                 self.__smbconnection.getFile(self.__share, self.__output, self.output_callback)
                 break
             except Exception as e:
-                if tries > self.__tries:
+                if tries >= self.__tries:
                     self.logger.fail("wmiexec: Could not retrieve output file, it may have been detected by AV. If it is still failing, try the 'wmi' protocol or another exec method")
                     break
                 elif "STATUS_BAD_NETWORK_NAME" in str(e):
@@ -161,15 +161,17 @@ class WMIEXEC:
                 # When executing powershell and the command is still running, we get a sharing violation
                 # We can use that information to wait longer than if the file is not found (probably av or something)
                 elif "STATUS_SHARING_VIOLATION" in str(e):
-                    self.logger.info(f"File {self.__share}\\{self.__output} is still in use with {self.__tries - tries} left, retrying...")
+                    self.logger.info(f"File {self.__share}\\{self.__output} is still in use with {self.__tries - tries} tries left, retrying...")
                     sleep(1)
                     tries += 1
                 elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
-                    self.logger.info(f"File {self.__share}\\{self.__output} not found with {self.__tries - tries} left, deducting 10 tries and retrying...")
+                    self.logger.info(f"File {self.__share}\\{self.__output} not found with {self.__tries - tries} tries left, deducting 10 tries and retrying...")
                     tries += 10
                     sleep(1)
                 else:
-                    self.logger.debug(f"Exception when trying to read output file: {e}")
+                    self.logger.debug(f"Exception when trying to read output file: {e!s}. {self.__tries - tries} tries left, retrying...")
+                    tries += 1
+                    sleep(1)
 
         try:
             self.logger.debug(f"Deleting file {self.__share}\\{self.__output}")


### PR DESCRIPTION
## Description
When an error like 'Broken pipe' occurs while trying to read the output file from a command, the number of tries is not incremented, causing an infinite loop fetching the output file (if this error keeps happening). Now, the number of tries is incremented in this case. Also, the debug messages were slightly improved to be more clear when failing to retrieve output.

I also changed back the `tries` logic to what it was before this commit: https://github.com/Pennyw0rth/NetExec/commit/4ffcc83bcc02cbb7e87fb34f7213df5268c23189. The reason for this is that if, for example, `self.__tries` is 20, the output will now be retrieved for 20 tries instead of 22. I didn't change this, but I think a better option for `get_output_tries` could be to set the defaults 10 times higher instead of multiplying it by 10 in `cli.py`, Then the user would have full control over how many tries are done.

Last, I removed the TODO comment above smbexec's loop, as Windows will wait for the service for 30 seconds before timing out. Therefore, the output logic is necessary if command runs for more than 30 seconds. [Reference](https://winprotocoldoc.z19.web.core.windows.net/MS-SCMR/%5bMS-SCMR%5d.pdf#%5B%7B%22num%22:343,%22gen%22:0%7D,%7B%22name%22:%22XYZ%22%7D,69,130,0%5D). 

In the near future, I would love to refactor the exec method code to use class inheritance to remove duplicating logic. This is just a small start to it. 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Mostly manual. However, I was able to replicate the infinite loop by hitting a `Broken pipe` error. The easiest way I found to replicate this was to just kill the smb server with the command. E.g.
`nxc smb IP -u admin -p admin -x 'net stop /y lanmanserver' --exec-method smbexec`

## Screenshots (if appropriate):

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [N/A] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [N/A] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
