### PR TITLE
remove pywerview from spec

### DIFF
--- a/netexec.spec
+++ b/netexec.spec
@@ -48,7 +48,6 @@ a = Analysis(
         'nxc.helpers.ntlm_parser',
         'paramiko',
         'pypsrp.client',
-        'pywerview.cli.helpers',
         'pylnk3',
         'pypykatz',
         'pyNfsClient',


### PR DESCRIPTION
## Description

See my remark at https://github.com/Pennyw0rth/NetExec/commit/25e7529a7c16e3d6084b88d0b5e6af957e4fddf5#commitcomment-154665882

Following pywerview removal in #579, pywerview reference should also be removed from the spec to avoid dependency error while building static binary with pyinstaller.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## How Has This Been Tested?

As testing is doubting, I absolutely did not test it.

## Screenshots (if appropriate):

N/A

## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] My code follows the style guidelines of this project (should be covered by Ruff above)
- [ ] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
