### PR TITLE
Fix left handside indent from exec output

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,12 +4,14 @@ name: Lint Python code with ruff
 on:
   push:
   workflow_dispatch:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+      github.event_name == 'push' || github.event.review.state == 'APPROVED' || github.event_name == 'workflow_dispatch'
 
     steps:
       - uses: actions/checkout@v4

--- a/nxc/modules/recent_files.py
+++ b/nxc/modules/recent_files.py
@@ -18,7 +18,7 @@ class NXCModule:
 
     def on_admin_login(self, context, connection):
         lnks = []
-        for directory in connection.conn.listPath("C$",  "Users\\*"):
+        for directory in connection.conn.listPath("C$", "Users\\*"):
             if directory.get_longname() not in self.false_positive and directory.is_directory():
                 context.log.highlight(f"C:\\{directory.get_longname()}")
                 recent_files_dir = f"Users\\{directory.get_longname()}\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\"

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -818,9 +818,8 @@ class smb(connection):
             if (self.args.execute or self.args.ps_execute):
                 self.logger.success(f"Executed command via {current_method}")
                 if output:
-                    output_lines = StringIO(output).readlines()
-                    for line in output_lines:
-                        self.logger.highlight(line.strip())
+                    for line in output.split("\n"):
+                        self.logger.highlight(line)
             return output
         else:
             self.logger.fail(f"Execute command failed with {current_method}")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -2,7 +2,6 @@ import ntpath
 import binascii
 import os
 import re
-from io import StringIO
 from Cryptodome.Hash import MD4
 
 from impacket.smbconnection import SMBConnection, SessionError


### PR DESCRIPTION
## Description

When retrieving output from `.execute()` the output is first cleaned `.rstrip`, which correctly removes trailing spaces/indents:
https://github.com/Pennyw0rth/NetExec/blob/6fcfb8d0314465a58bef8690ab5bac181c9e2453/nxc/protocols/smb.py#L811
However, before logging it to the console the output is `.strip()` again, which now also removed leading spaces/indents. This destroys formatting from the powershell output. As we already stripped it with `.rstrip` we can just remove the duplicate strip (we also don't need that StringIOstuff).

Also changed the linting pipeline to trigger on code reviews, so that not linted PRs are pushed to main.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Against a Windows Server in Goad

## Screenshots (if appropriate):
Before&After example of the Command `Get-WindowsFeature`, which uses indents to separate categories:
![image](https://github.com/user-attachments/assets/2baceb5d-cdc4-4902-b5d3-e783d614be38)
![image](https://github.com/user-attachments/assets/e28ae38c-c63c-45e7-9c24-15cc03a91f6b)
