### PR TITLE
Remove firefox module in favour of --dpapi which includes firefox

### DIFF
--- a/nxc/modules/firefox.py
+++ b/nxc/modules/firefox.py
@@ -10,16 +10,23 @@ class NXCModule:
     """
 
     name = "firefox"
-    description = "Dump credentials from Firefox"
+    description = "[REMOVED] Dump credentials from Firefox"
     supported_protocols = ["smb"]
     opsec_safe = True  # Does the module touch disk?
     multiple_hosts = True  # Does it make sense to run this module on multiple hosts at a time?
 
     def options(self, context, module_options):
-        """COOKIES    Get also Firefox cookies"""
+        """
+        [REMOVED] use the --dpapi flag instead of the module firefox.
+
+        COOKIES    Get also Firefox cookies
+        """
         self.gather_cookies = "COOKIES" in module_options
 
     def on_admin_login(self, context, connection):
+        context.log.fail("[REMOVED] Use the --dpapi flag instead of the module firefox.")
+        return
+
         host = connection.host if not connection.kerberos else connection.hostname + "." + connection.domain
         domain = connection.domain
         username = connection.username

--- a/nxc/modules/group-mem.py
+++ b/nxc/modules/group-mem.py
@@ -11,7 +11,7 @@ class NXCModule:
     """
 
     name = "group-mem"
-    description = "Retrieves all the members within a Group"
+    description = "[REMOVED] Retrieves all the members within a Group"
     supported_protocols = ["ldap"]
     opsec_safe = True
     multiple_hosts = False


### PR DESCRIPTION
## Description

As the title says, we should probably remove the firefox module as it is included in `--dpapi`.
The reason why i stumbled across is, that it looks to me like the module is broken, while `--dpapi` spits out all firefox data. See Screenshots.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/ec549361-19da-409b-a260-b1d9cc98da48)
