### PR TITLE
Fix Kerberos Login While Using --use-kcache

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -19,7 +19,6 @@ from nxc.protocols.ldap.laps import laps_search
 from nxc.helpers.pfx import pfx_auth
 
 from impacket.dcerpc.v5 import transport
-from impacket.krb5.ccache import CCache
 
 sem = BoundedSemaphore(1)
 global_failed_logins = 0
@@ -543,13 +542,11 @@ class connection:
             data.extend(parsed_data)
 
         if self.args.use_kcache:
-            ccache = CCache.parseFile()
             self.logger.debug("Trying to authenticate using Kerberos cache")
             with sem:
                 username = self.args.username[0] if len(self.args.username) else ""
                 password = self.args.password[0] if len(self.args.password) else ""
-                domain = self.args.domain if self.args.domain else ccache[0]
-                self.kerberos_login(domain, username, password, "", "", self.kdcHost, True)
+                self.kerberos_login(self.domain, username, password, "", "", self.kdcHost, True)
                 self.logger.info("Successfully authenticated using Kerberos cache")
                 return True
 

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -19,6 +19,7 @@ from nxc.protocols.ldap.laps import laps_search
 from nxc.helpers.pfx import pfx_auth
 
 from impacket.dcerpc.v5 import transport
+from impacket.krb5.ccache import CCache
 
 sem = BoundedSemaphore(1)
 global_failed_logins = 0
@@ -542,11 +543,13 @@ class connection:
             data.extend(parsed_data)
 
         if self.args.use_kcache:
+            ccache = CCache.parseFile()
             self.logger.debug("Trying to authenticate using Kerberos cache")
             with sem:
                 username = self.args.username[0] if len(self.args.username) else ""
                 password = self.args.password[0] if len(self.args.password) else ""
-                self.kerberos_login(self.domain, username, password, "", "", self.kdcHost, True)
+                domain = ccache[0]
+                self.kerberos_login(domain, username, password, "", "", self.kdcHost, True)
                 self.logger.info("Successfully authenticated using Kerberos cache")
                 return True
 

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -548,7 +548,7 @@ class connection:
             with sem:
                 username = self.args.username[0] if len(self.args.username) else ""
                 password = self.args.password[0] if len(self.args.password) else ""
-                domain = ccache[0]
+                domain = self.args.domain if self.args.domain else ccache[0]
                 self.kerberos_login(domain, username, password, "", "", self.kdcHost, True)
                 self.logger.info("Successfully authenticated using Kerberos cache")
                 return True

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -25,6 +25,7 @@ from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 from impacket.dcerpc.v5.epm import MSRPC_UUID_PORTMAP
 from impacket.dcerpc.v5.samr import SID_NAME_USE
 from impacket.dcerpc.v5.dtypes import MAXIMUM_ALLOWED
+from impacket.krb5.ccache import CCache
 from impacket.krb5.kerberosv5 import SessionKeyDecryptionError
 from impacket.krb5.types import KerberosException, Principal
 from impacket.krb5 import constants
@@ -246,7 +247,12 @@ class smb(connection):
                     self.hostname = self.host
                     self.targetDomain = self.host
 
-        self.domain = self.targetDomain if self.args.domain is None else self.args.domain
+        if self.args.domain:
+            self.domain = self.args.domain
+        elif self.args.use_kcache:  # Fixing domain trust, just pull the auth domain out of the ticket
+            self.domain = CCache.parseFile()[0]
+        else:
+            self.domain = self.targetDomain
 
         if self.args.local_auth:
             self.domain = self.hostname


### PR DESCRIPTION
## Description

On Last IppSec video (HTB-Ghost) and sometimes I encountered, Kerberos login fails while working with trusted domains or using --use-kcache.
It is only work with specify domain name which created ticket used on.
The reason for the error is that it does not receive the domain value from ccache, the target machine receives the domain value.

Now dont need to specify domain.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested on HTB-Ghost machine


## Screenshots (if appropriate):

Before
![image](https://github.com/user-attachments/assets/9b64abf2-40de-4d3c-9e0f-9aeff2912401)
![image](https://github.com/user-attachments/assets/058e74f4-b827-4edc-874f-da078b1dbaf2)


After
![image](https://github.com/user-attachments/assets/ae91690b-ab78-4527-abfd-98a358f59ad0)
![image](https://github.com/user-attachments/assets/276c9ee6-c637-4eec-8c4f-ff51226e926c)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
