### PR TITLE
Fix ldap hash auth with signing enforced

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -549,7 +549,7 @@ class ldap(connection):
                     # We need to try SSL
                     self.logger.extra["protocol"] = "LDAPS"
                     self.logger.extra["port"] = "636"
-                    ldaps_url = f"{proto}://{self.target}"
+                    ldaps_url = f"ldaps://{self.target}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host}")
                     self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
                     self.ldap_connection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)


### PR DESCRIPTION
## Description

Due to a simple typo ldap hash authentication did not switch to LDAPS when signing is enforced.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Against GOAD with signing enforced and `-H`

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/d5297885-0136-4e47-af38-eb7116ea56a7)
