### PR TITLE
Catch rpc error nca_s_op_rng_error when method is not implemented

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1460,11 +1460,15 @@ class smb(connection):
 
         policy_handle = resp["PolicyHandle"]
 
-        resp = lsad.hLsarQueryInformationPolicy2(
-            dce,
-            policy_handle,
-            lsad.POLICY_INFORMATION_CLASS.PolicyAccountDomainInformation,
-        )
+        try:
+            resp = lsad.hLsarQueryInformationPolicy2(dce, policy_handle, lsad.POLICY_INFORMATION_CLASS.PolicyAccountDomainInformation)
+        except lsad.DCERPCException as e:
+            if e.error_string == "nca_s_op_rng_error":
+                self.logger.fail("RPC lookup failed: RPC method not implemented")
+            else:
+                self.logger.fail(f"Error querying policy information: {e}")
+            return entries
+
         domain_sid = resp["PolicyInformation"]["PolicyAccountDomainInfo"]["DomainSid"].formatCanonical()
 
         so_far = 0


### PR DESCRIPTION
## Description

Catches the rpc error `nca_s_op_rng_error` when running `--rid-brute` against a target that doesn't support the rpc method. 
Fix #635 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Kali localhost smb

## Screenshots (if appropriate):
Before&After:
![image](https://github.com/user-attachments/assets/0d9f0eaa-0efc-41ce-9f9c-0dbf2f6a3247)
