### PR TITLE
completions: no not complete options without entering `-` first

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -124,7 +124,7 @@ def gen_cli_args():
     except Exception as e:
         nxc_logger.exception(f"Error loading proto_args from proto_args.py file in protocol folder: {protocol} - {e}")
 
-    argcomplete.autocomplete(parser)
+    argcomplete.autocomplete(parser, always_complete_options=False)
     args = parser.parse_args()
 
     if len(sys.argv) == 1:

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -1,3 +1,4 @@
+# PYTHON_ARGCOMPLETE_OK
 import sys
 from nxc.helpers.logger import highlight
 from nxc.helpers.misc import identify_target_file


### PR DESCRIPTION
## Description

Prior to this commit, the shell completions always show `--options` mixed with subcommands and what else. This is contrary to how most other completion engines behave and I consider it more clean to show options only when a leading `-` has been entered.

This is from before this commit (with fish):

![before](https://github.com/user-attachments/assets/76f40882-7e9d-4a9d-8217-5eec405b8c76)

Even worse with bash where subcommands and options come intermixed:

![before-bash](https://github.com/user-attachments/assets/a9d676f7-a280-48bb-85fc-cba60e744abf)

And after:

![after-sub](https://github.com/user-attachments/assets/6126e503-5916-4b6f-9fb9-b9b0d7167093)
![after-opt](https://github.com/user-attachments/assets/8b607ff5-27d3-401e-b244-ea97d16df218)

To make the behavior more like other completion engines I know, I added the `always_complete_options=False` parameter. (I don't know why this isn't the default).

However, feel free to reject if you like the current behavior more.

Besides, this commit makes `activate-global-python-argcomplete` work with `nxc` due to the `PYTHON_ARGCOMPLETE_OK` marker. (Not that I use that but I'm sure some people do.)

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## How Has This Been Tested?

Tested with fish and bash, see screenshots above.


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [ ] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
