### PR TITLE
Add sid parsing directly to the ldap attribute parser

### DIFF
--- a/nxc/parsers/ldap_results.py
+++ b/nxc/parsers/ldap_results.py
@@ -1,4 +1,5 @@
 from impacket.ldap import ldapasn1 as ldapasn1_impacket
+from uuid import UUID
 
 
 def parse_result_attributes(ldap_response):
@@ -11,12 +12,19 @@ def parse_result_attributes(ldap_response):
         for attribute in entry["attributes"]:
             val_list = []
             for val in attribute["vals"].components:
-                try:
-                    encoding = val.encoding
-                    val_decoded = str(val).encode(encoding).decode("utf-8")
-                except UnicodeDecodeError:
-                    # If we can't decode the value, we'll just return the bytes
-                    val_decoded = val.__bytes__()
+                # Typical Byte objects we know how to decode
+                if str(attribute["type"]) == "objectGUID":
+                    val_decoded = UUID(bytes=val.__bytes__())
+                elif str(attribute["type"]) == "objectSid":
+                    val_decoded = sid_to_str(val.__bytes__())
+                else:
+                    # For the rest we try to decode the value with its encoding
+                    try:
+                        encoding = val.encoding
+                        val_decoded = str(val).encode(encoding).decode("utf-8")
+                    except UnicodeDecodeError:
+                        # If we can't decode the value, we'll just return the bytes
+                        val_decoded = val.__bytes__()
                 val_list.append(val_decoded)
             if len(val_list) == 1:
                 attribute_map[str(attribute["type"])] = val_list[0]
@@ -24,3 +32,23 @@ def parse_result_attributes(ldap_response):
                 attribute_map[str(attribute["type"])] = val_list
         parsed_response.append(attribute_map)
     return parsed_response
+
+
+def sid_to_str(sid):
+    try:
+        # revision
+        revision = int(sid[0])
+        # count of sub authorities
+        sub_authorities = int(sid[1])
+        # big endian
+        identifier_authority = int.from_bytes(sid[2:8], byteorder="big")
+        # If true then it is represented in hex
+        if identifier_authority >= 2**32:
+            identifier_authority = hex(identifier_authority)
+
+        # loop over the count of small endians
+        sub_authority = "-" + "-".join([str(int.from_bytes(sid[8 + (i * 4): 12 + (i * 4)], byteorder="little")) for i in range(sub_authorities)])
+        return "S-" + str(revision) + "-" + str(identifier_authority) + sub_authority
+    except Exception:
+        pass
+    return sid


### PR DESCRIPTION
## Description

When querying or parsing results from LDAP in general the `objectSid` and `objectGUID` is returned as bytes, because they aren't encoded as strings. But as they have a standardized format we can just decode them properly in the parser, so it is displayed as a string.

Also moved the `sid_to_str` function to the parser as well, because it isn't needed in the LDAP protocol anymore.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
GOAD

## Screenshots (if appropriate):
Before&After:
![image](https://github.com/user-attachments/assets/dac81ffe-08f6-4c49-b112-b2c93f80d5e1)
