### PR TITLE
fix: Refactor output file path construction in SMB protocol

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -287,7 +287,10 @@ class smb(connection):
             self.logger.debug(e)
 
         self.os_arch = self.get_os_arch()
-        self.output_file_template = os.path.expanduser(f"{NXC_PATH}/logs/{{output_folder}}/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-"))
+        # Construct the output file template using os.path.join for OS compatibility
+        base_log_dir = os.path.join(os.path.expanduser(NXC_PATH), "logs")
+        filename_pattern = f"{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-")
+        self.output_file_template = os.path.join(base_log_dir, "{output_folder}", filename_pattern)
 
         try:
             # DCs seem to want us to logoff first, windows workstations sometimes reset the connection


### PR DESCRIPTION
- Updated the output file template to use os.path.join for improved OS compatibility.
- Enhanced readability by separating base log directory and filename pattern construction.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes (e2e, single commands, etc)
Please also list any relevant details for your test configuration, such as your locally running machine Python version & OS, as well as the target(s) you tested against, including software versions

poetry run NetExec smb 192.168.144.132 -u Administrator -p '' --local-auth --sam or --lsa had errors related to paths 
![image](https://github.com/user-attachments/assets/92a0bfe0-34a0-4f57-ab79-c0061e881ac1)

The previous method for constructing the log file path template
in `enum_host_info` used hardcoded forward slashes (`/`).
On Windows, `os.path.expanduser()` correctly uses backslashes (`\`),
resulting in an invalid mixed-separator path (e.g., `C:\Users\user\.nxc/logs/sam/...`).

This caused `FileNotFoundError` when attempting to write log files
(like SAM/LSA dumps) on Windows systems.

This commit replaces the hardcoded path string concatenation with
`os.path.join()` to ensure native path separators are used,
resolving the error on Windows while maintaining compatibility
with Linux/macOS.

