### PR TITLE
Update database.py

### DIFF
--- a/nxc/protocols/smb/database.py
+++ b/nxc/protocols/smb/database.py
@@ -257,7 +257,7 @@ class database(BaseDB):
         # TODO: find a way to abstract this away to a single Upsert call
         q = Insert(self.HostsTable)  # .returning(self.HostsTable.c.id)
         update_columns = {col.name: col for col in q.excluded if col.name not in "id"}
-        q = q.on_conflict_do_update(index_elements=['ip'], set_=update_columns)
+        q = q.on_conflict_do_update(index_elements=["ip"], set_=update_columns)
 
         self.db_execute(q, hosts)  # .scalar()
         # we only return updated IDs for now - when RETURNING clause is allowed we can return inserted

--- a/nxc/protocols/smb/database.py
+++ b/nxc/protocols/smb/database.py
@@ -39,7 +39,7 @@ class database(BaseDB):
         db_conn.execute(
             """CREATE TABLE "hosts" (
             "id" integer PRIMARY KEY,
-            "ip" text,
+            "ip" text UNIQUE,
             "hostname" text,
             "domain" text,
             "os" text,
@@ -257,7 +257,7 @@ class database(BaseDB):
         # TODO: find a way to abstract this away to a single Upsert call
         q = Insert(self.HostsTable)  # .returning(self.HostsTable.c.id)
         update_columns = {col.name: col for col in q.excluded if col.name not in "id"}
-        q = q.on_conflict_do_update(index_elements=self.HostsTable.primary_key, set_=update_columns)
+        q = q.on_conflict_do_update(index_elements=['ip'], set_=update_columns)
 
         self.db_execute(q, hosts)  # .scalar()
         # we only return updated IDs for now - when RETURNING clause is allowed we can return inserted


### PR DESCRIPTION
# Prevent duplicate host insertion

## Description

So as discussed on discord, on unspecified occasion, the select query performed by ```add_host()``` function will fail:

```python
q = select(self.HostsTable).filter(self.HostsTable.c.ip == ip)
        results = self.db_execute(q).all()

        # create new host
        if not results:
            new_host = {
          
```

This will result in an empty resultset. Because of this, the function will attempt to insert an host whose ip is already present in the Sqlite database.

Moreover, when inserting the row, the call to ```on_conflict_do_update()``` will fail to detect a collision because the detection (index_elements argument) is made on the primary_key instead of the ip column:

```python
q = q.on_conflict_do_update(index_elements=self.HostsTable.primary_key, set_=update_columns)
```

After that, connection to this ip will likely trigger stacktrace of error  such as:

```python
Exception while calling proto_flow() on target 10.5.0.88: zip() argument 2 is longer than argument 1
```

## Type of change

This is a proposed change aiming at preventing the insertion of duplicate when the add_host select query fail:

* Adding a UNIQUE constraint to the ip column in db_schema() of smb/database.py
* Change the call to on_conflict_do_update to perform the detection on 'ip' column instead of the primary_key