### PR TITLE
Added more AV Signatures

### DIFF
--- a/nxc/modules/enum_av.py
+++ b/nxc/modules/enum_av.py
@@ -290,6 +290,14 @@ conf = {
             ]
         },
         {
+        "name": "Ivanti Security",
+            "services": [
+                {"name": "STAgent$Shavlik Protect", "description": "Ivanti Security Controls Agent"},
+                {"name": "STDispatch$Shavlik Protect", "description": "Ivanti Security Controls Agent Dispatcher"}
+            ],
+            "pipes": []
+        },
+        {
             "name": "Kaspersky Security for Windows Server",
             "services": [
                 {"name": "kavfsslp", "description": "Kaspersky Security Exploit Prevention Service"},
@@ -333,6 +341,11 @@ conf = {
                 {"name": "SepScanService", "description": "Symantec Endpoint Protection Scan Services"},
                 {"name": "SNAC", "description": "Symantec Network Access Control"}
             ],
+            "pipes": []
+        },
+        {
+            "name": "Rapid7",
+            "services": [{"name": "ir_agent", "description": "Rapid7 Insight Agent"}],
             "pipes": []
         },
         {
@@ -384,7 +397,10 @@ conf = {
                 {"name": "Trend Micro Web Service Communicator", "description": "Trend Micro Web Service Communicator"},
                 {"name": "TMiACAgentSvc", "description": "Trend Micro Application Control Service (Agent)"},
                 {"name": "CETASvc", "description": "Trend Micro Cloud Endpoint Telemetry Service"},
-                {"name": "iVPAgent", "description": "Trend Micro Vulnerability Protection Service (Agent)"}
+                {"name": "iVPAgent", "description": "Trend Micro Vulnerability Protection Service (Agent)"},
+                {"name": "ds_agent", "description": "Trend Micro Deep Security Agent"},
+                {"name": "ds_monitor", "description": "Trend Micro Deep Security Monitor"},
+                {"name": "ds_notifier", "description": "Trend Micro Deep Security Notifier"}
             ],
             "pipes": [
                 {"name": "IPC_XBC_XBC_AGENT_PIPE_*", "processes": ["EndpointBasecamp.exe"]},


### PR DESCRIPTION
Added a few more signatures for Trend Micro monitoring, one for Rapid7 Insight Agent, and some for Ivanti Security

## Description

Please include a summary of the change and which issue is fixed, or what the enhancement does.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes (e2e, single commands, etc)
Please also list any relevant details for your test configuration, such as your locally running machine Python version & OS, as well as the target(s) you tested against, including software versions

If you are using poetry, you can easily run tests via:
`poetry run python tests/e2e_tests.py -t $TARGET -u $USER -p $PASSWORD`
There are additional options like `--errors` to display ALL errors (some may not be failures), `--poetry` (output will include the poetry run prepended), `--line-num $START-$END $SINGLE` for only running a subset

## Screenshots (if appropriate):
Screenshots are always nice to have and can give a visual representation of the change.
If appropriate include before and after screenshot(s) to show which results are to be expected.

## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] My code follows the style guidelines of this project (should be covered by Ruff above)
- [ ] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
