### PR TITLE
Fix bunch of stuff from ippsec and 0xdf writeup for vintage box 

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -168,7 +168,7 @@ class ldap(connection):
         target_domain = ""
         base_dn = ""
         try:
-            proto = "ldaps" if (self.args.gmsa or self.port == 636) else "ldap"
+            proto = "ldaps" if self.port == 636 else "ldap"
             ldap_url = f"{proto}://{self.host}"
             self.logger.info(f"Connecting to {ldap_url} with no baseDN")
             try:
@@ -309,9 +309,9 @@ class ldap(connection):
 
         try:
             # Connect to LDAP
-            self.logger.extra["protocol"] = "LDAPS" if (self.args.gmsa or self.port == 636) else "LDAP"
-            self.logger.extra["port"] = "636" if (self.args.gmsa or self.port == 636) else "389"
-            proto = "ldaps" if (self.args.gmsa or self.port == 636) else "ldap"
+            self.logger.extra["protocol"] = "LDAPS" if self.port == 636 else "LDAP"
+            self.logger.extra["port"] = "636" if self.port == 636 else "389"
+            proto = "ldaps" if self.port == 636 else "ldap"
             ldap_url = f"{proto}://{self.target}"
             self.logger.info(f"Connecting to {ldap_url} - {self.baseDN} - {self.host} [1]")
             self.ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
@@ -425,9 +425,9 @@ class ldap(connection):
 
         try:
             # Connect to LDAP
-            self.logger.extra["protocol"] = "LDAPS" if (self.args.gmsa or self.port == 636) else "LDAP"
-            self.logger.extra["port"] = "636" if (self.args.gmsa or self.port == 636) else "389"
-            proto = "ldaps" if (self.args.gmsa or self.port == 636) else "ldap"
+            self.logger.extra["protocol"] = "LDAPS" if self.port == 636 else "LDAP"
+            self.logger.extra["port"] = "636" if self.port == 636 else "389"
+            proto = "ldaps" if self.port == 636 else "ldap"
             ldap_url = f"{proto}://{self.target}"
             self.logger.info(f"Connecting to {ldap_url} - {self.baseDN} - {self.host} [3]")
             self.ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
@@ -515,9 +515,9 @@ class ldap(connection):
 
         try:
             # Connect to LDAP
-            self.logger.extra["protocol"] = "LDAPS" if (self.args.gmsa or self.port == 636) else "LDAP"
-            self.logger.extra["port"] = "636" if (self.args.gmsa or self.port == 636) else "389"
-            proto = "ldaps" if (self.args.gmsa or self.port == 636) else "ldap"
+            self.logger.extra["protocol"] = "LDAPS" if self.port == 636 else "LDAP"
+            self.logger.extra["port"] = "636" if self.port == 636 else "389"
+            proto = "ldaps" if self.port == 636 else "ldap"
             ldaps_url = f"{proto}://{self.target}"
             self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host}")
             self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -26,7 +26,7 @@ from impacket.dcerpc.v5.epm import MSRPC_UUID_PORTMAP
 from impacket.dcerpc.v5.samr import SID_NAME_USE
 from impacket.dcerpc.v5.dtypes import MAXIMUM_ALLOWED
 from impacket.krb5.ccache import CCache
-from impacket.krb5.kerberosv5 import SessionKeyDecryptionError
+from impacket.krb5.kerberosv5 import SessionKeyDecryptionError, getKerberosTGT
 from impacket.krb5.types import KerberosException, Principal
 from impacket.krb5 import constants
 from impacket.dcerpc.v5.dtypes import NULL
@@ -674,6 +674,34 @@ class smb(connection):
             with sem, open(self.args.gen_relay_list, "a+") as relay_list:
                 if self.host not in relay_list.read():
                     relay_list.write(self.host + "\n")
+
+    def generate_tgt(self):
+        self.logger.info(f"Attempting to get TGT for {self.username}@{self.domain}")
+        userName = Principal(self.username, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+
+        try:
+            tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(
+                clientName=userName,
+                password=self.password,
+                domain=self.domain.upper(),
+                lmhash=binascii.unhexlify(self.lmhash) if self.lmhash else "",
+                nthash=binascii.unhexlify(self.nthash) if self.nthash else "",
+                aesKey=self.aesKey,
+                kdcHost=self.kdcHost
+            )
+
+            self.logger.debug(f"TGT successfully obtained for {self.username}@{self.domain}")
+            self.logger.debug(f"Using cipher: {cipher}")
+
+            ccache = CCache()
+            ccache.fromTGT(tgt, oldSessionKey, sessionKey)
+            tgt_file = f"{self.args.generate_tgt}.ccache"
+            ccache.saveFile(tgt_file)
+
+            self.logger.success(f"TGT saved to: {tgt_file}")
+            self.logger.success(f"Run the following command to use the TGT: export KRB5CCNAME={tgt_file}")
+        except Exception as e:
+            self.logger.fail(f"Failed to get TGT: {e}")
 
     @requires_admin
     def execute(self, payload=None, get_output=False, methods=None) -> str:

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -22,6 +22,7 @@ def proto_args(parser, parents):
     smb_parser.add_argument("--laps", dest="laps", metavar="LAPS", type=str, help="LAPS authentification", nargs="?", const="administrator")
     smb_parser.add_argument("--generate-hosts-file", type=str, help="Generate a hosts file like from a range of IP")
     smb_parser.add_argument("--generate-krb5-file", type=str, help="Generate a krb5 file like from a range of IP")
+    smb_parser.add_argument("--generate-tgt", type=str, help="Generate a tgt ticket")
     self_delegate_arg.make_required = [delegate_arg]
 
     cred_gathering_group = smb_parser.add_argument_group("Credential Gathering", "Options for gathering credentials")

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -58,7 +58,7 @@ class winrm(connection):
         try:
             ntlm_info = parse_challenge(base64.b64decode(self.challenge_header.split(" ")[1].replace(",", "")))
         except Exception as e:
-            self.logger.debug(f"Error parsing NTLM challenge: {str(e)}")
+            self.logger.debug(f"Error parsing NTLM challenge: {e!s}")
             self.logger.debug(f"Raw challenge: {self.challenge_header.split(' ')[1].replace(',', '')[:20]}...")
             self.logger.error("Invalid NTLM challenge received from server. This may indicate NTLM is not supported and nxc winrm only support NTLM currently")
             self.no_ntlm = True

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -9,10 +9,11 @@ from io import StringIO
 from datetime import datetime
 from pypsrp.wsman import NAMESPACES
 from pypsrp.client import Client
+from termcolor import colored
 
 from impacket.examples.secretsdump import LocalOperations, LSASecrets, SAMHashes
 
-from nxc.config import process_secret
+from nxc.config import process_secret, host_info_colors
 from nxc.connection import connection
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.misc import gen_random_string
@@ -35,6 +36,8 @@ class winrm(connection):
         self.nthash = ""
         self.ssl = False
         self.challenge_header = None
+        self.targetDomain = None
+        self.no_ntlm = False
 
         connection.__init__(self, args, db, host)
 
@@ -52,7 +55,15 @@ class winrm(connection):
         )
 
     def enum_host_info(self):
-        ntlm_info = parse_challenge(base64.b64decode(self.challenge_header.split(" ")[1].replace(",", "")))
+        try:
+            ntlm_info = parse_challenge(base64.b64decode(self.challenge_header.split(" ")[1].replace(",", "")))
+        except Exception as e:
+            self.logger.debug(f"Error parsing NTLM challenge: {str(e)}")
+            self.logger.debug(f"Raw challenge: {self.challenge_header.split(' ')[1].replace(',', '')[:20]}...")
+            self.logger.error("Invalid NTLM challenge received from server. This may indicate NTLM is not supported and nxc winrm only support NTLM currently")
+            self.no_ntlm = True
+            return False
+
         self.targetDomain = self.domain = ntlm_info["domain"]
         self.hostname = ntlm_info["hostname"]
         self.server_os = ntlm_info["os_version"]
@@ -70,7 +81,8 @@ class winrm(connection):
     def print_host_info(self):
         self.logger.extra["protocol"] = "WINRM-SSL" if self.ssl else "WINRM"
         self.logger.extra["port"] = self.port
-        self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.targetDomain})")
+        ntlm = colored(f"(NTLM:{not self.no_ntlm})", host_info_colors[2], attrs=["bold"]) if self.no_ntlm else ""
+        self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.targetDomain}) {ntlm}")
 
     def create_conn_obj(self):
         if self.is_link_local_ipv6:

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,7 +865,7 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "impacket"
-version = "0.13.0.dev0+20250314.172046.8b4566b1"
+version = "0.13.0.dev0+20250422.104055.27bebb13"
 description = "Network protocols Constructors and Dissectors"
 optional = false
 python-versions = "*"
@@ -890,7 +890,7 @@ six = "*"
 type = "git"
 url = "https://github.com/fortra/impacket.git"
 reference = "HEAD"
-resolved_reference = "8b4566b12fc79acb520d045dbae8f13446a9d4d7"
+resolved_reference = "27bebb1347569fa810e432326266acf17560f274"
 
 [[package]]
 name = "iniconfig"


### PR DESCRIPTION
## Description

Some improvement regarding the usage of nxc against vintage box

- Add a new option to generate TGT from nxc and avoid getTGT
- Allow dump gmsa from LDAP and LDAPS
- Fix big stacktrace on winrm

This pull request introduces several changes across multiple files to improve the functionality and robustness of the `nxc` protocols. The most notable updates include simplifying LDAP protocol logic, adding functionality for generating Kerberos TGTs in SMB, and enhancing error handling and logging in the WinRM protocol.

---

### LDAP Protocol Updates:
* Simplified the logic for determining the LDAP protocol (`ldap` or `ldaps`) by removing checks for `self.args.gmsa`, relying solely on the port number (`636` for `ldaps`). This change applies to multiple methods, including `create_conn_obj`, `kerberos_login`, `plaintext_login`, and `hash_login` in `nxc/protocols/ldap.py`. [[1]](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76L171-R171) [[2]](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76L312-R314) [[3]](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76L428-R430) [[4]](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76L518-R520)

### SMB Protocol Enhancements:
* Added a new method, `generate_tgt`, to support the generation of Kerberos TGTs. This includes obtaining a TGT using user credentials, saving it to a `.ccache` file, and providing instructions for usage.
* Introduced a new command-line argument, `--generate-tgt`, to trigger the TGT generation functionality.

### WinRM Protocol Improvements:
* Enhanced error handling in `enum_host_info` to detect and log invalid NTLM challenges, setting a flag (`self.no_ntlm`) if NTLM is unsupported by the server.
* Updated `print_host_info` to include NTLM support status in the output, using colored formatting for better visibility.
* Added new attributes `targetDomain` and `no_ntlm` to the `WinRM` class to manage NTLM-related state.

### General Updates:
* Added imports for new functionality, such as `getKerberosTGT` in `nxc/protocols/smb.py` and `colored` in `nxc/protocols/winrm.py`. [[1]](diffhunk://#diff-03a263aab56e8880814c8a586230088900d62ab9c53b93744492f6fcd1bf7630L29-R29) [[2]](diffhunk://#diff-0deb27294893605affddad6e3a4f92d8d701783f93496493cd0e5cf77618cf65R12-R16)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

against Vintage box

If you are using poetry, you can easily run tests via:
`poetry run python tests/e2e_tests.py -t $TARGET -u $USER -p $PASSWORD`
There are additional options like `--errors` to display ALL errors (some may not be failures), `--poetry` (output will include the poetry run prepended), `--line-num $START-$END $SINGLE` for only running a subset

## Screenshots (if appropriate):

- Gmsa:
![image](https://github.com/user-attachments/assets/a2807397-6d62-4843-9dd7-e6f44af1eceb)

- Winrm:
before
![2025-04-26_20-33](https://github.com/user-attachments/assets/f90d3f10-813a-4bd8-b548-74b89548c24b)
after

![2025-04-26_20-41](https://github.com/user-attachments/assets/3cbdab92-5306-4612-b1f3-a21e13e30e50)


- TGT:
![2025-04-26_20-26](https://github.com/user-attachments/assets/4d38d71d-57f5-4894-bf52-f9f6c0579981)




## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
