### PR TITLE
Fix pfx output path on windows

### DIFF
--- a/nxc/helpers/pfx.py
+++ b/nxc/helpers/pfx.py
@@ -503,7 +503,7 @@ def pfx_auth(self):
         return None
 
     username = self.args.username[0]
-    log_ccache = os.path.expanduser(f"{NXC_PATH}/logs/{self.hostname}_{self.host}_{datetime.datetime.now().strftime('%Y-%m-%d_%H%M%S')}-{username}.ccache".replace(":", "-"))
+    log_ccache = os.path.normpath(os.path.expanduser(f"{NXC_PATH}/logs/{self.hostname}_{self.host}_{datetime.datetime.now().strftime('%Y-%m-%d_%H%M%S')}-{username}.ccache".replace(":", "-")))
 
     # Request a TGT with the cert data
     req = ini.build_asreq(self.domain, username)

--- a/nxc/helpers/pfx.py
+++ b/nxc/helpers/pfx.py
@@ -503,7 +503,8 @@ def pfx_auth(self):
         return None
 
     username = self.args.username[0]
-    log_ccache = os.path.normpath(os.path.expanduser(f"{NXC_PATH}/logs/{self.hostname}_{self.host}_{datetime.datetime.now().strftime('%Y-%m-%d_%H%M%S')}-{username}.ccache".replace(":", "-")))
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H%M%S").replace(":", "-")
+    log_ccache = os.path.normpath(os.path.expanduser(f"{NXC_PATH}/logs/{self.hostname}_{self.host}_{timestamp}-{username}.ccache"))
 
     # Request a TGT with the cert data
     req = ini.build_asreq(self.domain, username)


### PR DESCRIPTION
## Description

This pull request includes a small but important change to the `pfx_auth` method in the `nxc/helpers/pfx.py` file. The change ensures that the `log_ccache` path is normalized to handle platform-specific path variations properly.

* [`nxc/helpers/pfx.py`](diffhunk://#diff-97ca4e831fe1e1713a19e40737e916e903cb2c25567d4bd5e0a2b2752ac3edd3L506-R506): Updated the `log_ccache` variable to use `os.path.normpath` to normalize the constructed file path. This change improves compatibility across different operating systems.

Fixes #656. Added `os.path.normpath()`, so the path containing slashes is converted to double backslashes on windows.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manual testing on windows.
Should wait for #656 to report if the issue was fixed.
