### PR TITLE
Fix authentication with an empty domain

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -389,7 +389,7 @@ class connection:
                         if "\\" in line and len(line.split("\\")) == 2:
                             domain_single, username_single = line.split("\\")
                         else:
-                            domain_single = self.args.domain if hasattr(self.args, "domain") and self.args.domain else self.domain
+                            domain_single = self.args.domain if hasattr(self.args, "domain") and self.args.domain is not None else self.domain
                             username_single = line
                         domain.append(domain_single)
                         username.append(username_single.strip())
@@ -398,7 +398,7 @@ class connection:
                 if "\\" in user:
                     domain_single, username_single = user.split("\\")
                 else:
-                    domain_single = self.args.domain if hasattr(self.args, "domain") and self.args.domain else self.domain
+                    domain_single = self.args.domain if hasattr(self.args, "domain") and self.args.domain is not None else self.domain
                     username_single = user
                 domain.append(domain_single)
                 username.append(username_single)

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -191,7 +191,7 @@ class mssql(connection):
             return False
         except Exception:
             error_msg = self.handle_mssql_reply()
-            self.logger.fail(f"{self.domain}\\{self.username}:{kerb_pass} {error_msg if error_msg else ''}")
+            self.logger.fail(f"{self.domain}\\{self.username}:{used_ccache} {error_msg if error_msg else ''}")
             return False
 
     @reconnect_mssql

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -89,7 +89,7 @@ class mssql(connection):
         else:
             if is_admin:
                 self.admin_privs = True
-    
+
     @reconnect_mssql
     def enum_host_info(self):
         challenge = None
@@ -102,7 +102,7 @@ class mssql(connection):
             login["ClientPID"] = random.randint(0, 1024)
             login["PacketSize"] = self.conn.packetSize
             login["OptionFlags2"] = tds.TDS_INIT_LANG_FATAL | tds.TDS_ODBC_ON | tds.TDS_INTEGRATED_SECURITY_ON
-            
+
             # NTLMSSP Negotiate
             auth = ntlm.getNTLMSSPType1("", "")
             login["SSPI"] = auth.getData()
@@ -144,16 +144,7 @@ class mssql(connection):
         self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.targetDomain})")
 
     @reconnect_mssql
-    def kerberos_login(
-        self,
-        domain,
-        username,
-        password="",
-        ntlm_hash="",
-        aesKey="",
-        kdcHost="",
-        useCache=False,
-    ):
+    def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
         self.username = username
         self.password = password
         self.domain = domain
@@ -200,7 +191,7 @@ class mssql(connection):
             return False
         except Exception:
             error_msg = self.handle_mssql_reply()
-            self.logger.fail("{}\\{}:{} {}".format(self.domain, self.username, kerb_pass, error_msg if error_msg else ""))
+            self.logger.fail(f"{self.domain}\\{self.username}:{kerb_pass} {error_msg if error_msg else ''}")
             return False
 
     @reconnect_mssql
@@ -208,21 +199,13 @@ class mssql(connection):
         self.password = password
         self.username = username
         self.domain = domain
-        
+
         try:
-            res = self.conn.login(
-                None,
-                self.username,
-                self.password,
-                self.domain,
-                None,
-                not self.args.local_auth,
-            )
+            res = self.conn.login(None, self.username, self.password, self.domain, None, not self.args.local_auth)
             if res is not True:
                 raise
             self.check_if_admin()
-            out = f"{self.domain}\\{self.username}:{process_secret(self.password)} {self.mark_pwned()}"
-            self.logger.success(out)
+            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(self.password)} {self.mark_pwned()}")
             if not self.args.local_auth and self.username != "":
                 add_user_bh(self.username, self.domain, self.logger, self.config)
             if self.admin_privs:
@@ -233,7 +216,7 @@ class mssql(connection):
             return False
         except Exception:
             error_msg = self.handle_mssql_reply()
-            self.logger.fail("{}\\{}:{} {}".format(self.domain, self.username, process_secret(self.password), error_msg if error_msg else ""))
+            self.logger.fail(f"{self.domain}\\{self.username}:{process_secret(self.password)} {error_msg if error_msg else ''}")
             return False
 
     @reconnect_mssql
@@ -242,26 +225,18 @@ class mssql(connection):
         self.domain = domain
         self.lmhash = ""
         self.nthash = ""
-        
+
         if ntlm_hash.find(":") != -1:
             self.lmhash, self.nthash = ntlm_hash.split(":")
         else:
             self.nthash = ntlm_hash
 
         try:
-            res = self.conn.login(
-                None,
-                self.username,
-                "",
-                self.domain,
-                f"{self.lmhash}:{self.nthash}",
-                not self.args.local_auth,
-            )
+            res = self.conn.login(None, self.username, "", self.domain, f"{self.lmhash}:{self.nthash}", not self.args.local_auth)
             if res is not True:
                 raise
             self.check_if_admin()
-            out = f"{self.domain}\\{self.username}:{process_secret(self.nthash)} {self.mark_pwned()}"
-            self.logger.success(out)
+            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(self.nthash)} {self.mark_pwned()}")
             if not self.args.local_auth and self.username != "":
                 add_user_bh(self.username, self.domain, self.logger, self.config)
             if self.admin_privs:
@@ -272,7 +247,7 @@ class mssql(connection):
             return False
         except Exception:
             error_msg = self.handle_mssql_reply()
-            self.logger.fail("{}\\{}:{} {}".format(self.domain, self.username, process_secret(self.nthash), error_msg if error_msg else ""))
+            self.logger.fail(f"{self.domain}\\{self.username}:{process_secret(self.nthash)} {error_msg if error_msg else ''}")
             return False
 
     def mssql_query(self):
@@ -305,10 +280,10 @@ class mssql(connection):
         if not payload:
             self.logger.error("No command to execute specified!")
             return None
-        
+
         get_output = True if not self.args.no_output else get_output
         self.logger.debug(f"{get_output=}")
-        
+
         try:
             exec_method = MSSQLEXEC(self.conn, self.logger)
             output = exec_method.execute(payload)
@@ -317,7 +292,7 @@ class mssql(connection):
             self.logger.fail(f"Execute command failed, error: {e!s}")
             return False
         else:
-            self.logger.success("Executed command via mssqlexec")   
+            self.logger.success("Executed command via mssqlexec")
             if output:
                 output_lines = StringIO(output).readlines()
                 for line in output_lines:
@@ -330,24 +305,24 @@ class mssql(connection):
         if not payload:
             self.logger.error("No command to execute specified!")
             return None
-        
+
         response = []
         obfs = obfs if obfs else self.args.obfs
         encode = encode if encode else not self.args.no_encode
         force_ps32 = force_ps32 if force_ps32 else self.args.force_ps32
         get_output = True if not self.args.no_output else get_output
-                
+
         self.logger.debug(f"Starting PS execute: {payload=} {get_output=} {methods=} {force_ps32=} {obfs=} {encode=}")
         amsi_bypass = self.args.amsi_bypass[0] if self.args.amsi_bypass else None
         self.logger.debug(f"AMSI Bypass: {amsi_bypass}")
-        
+
         if os.path.isfile(payload):
             self.logger.debug(f"File payload set: {payload}")
             with open(payload) as commands:
                 response = [self.execute(create_ps_command(c.strip(), force_ps32=force_ps32, obfs=obfs, custom_amsi=amsi_bypass, encode=encode), get_output) for c in commands]
         else:
             response = [self.execute(create_ps_command(payload, force_ps32=force_ps32, obfs=obfs, custom_amsi=amsi_bypass, encode=encode), get_output)]
-            
+
         self.logger.debug(f"ps_execute response: {response}")
         return response
 
@@ -368,7 +343,7 @@ class mssql(connection):
                 self.logger.fail(f"Error during upload : {e}")
 
     @requires_admin
-    def get_file(self): 
+    def get_file(self):
         remote_path = self.args.get_file[0]
         download_path = self.args.get_file[1]
         self.logger.display(f'Copying "{remote_path}" to "{download_path}"')


### PR DESCRIPTION
## Description

This PR contains a bunch of mssql formating stuff, because i initially thought we had a bug in here which was reported in #647, but it turns out that the issue is protocol independent in `connection.py`.
The problem: When an empty domain is specified with `-d ''` the current implementation evaluates the empty string as `False`. Therefore we explicitly have to check if the domain arg is set to None (default) or not:

![image](https://github.com/user-attachments/assets/59c6779c-46de-4220-bb94-9d8ae6709cc5)
![image](https://github.com/user-attachments/assets/769c75da-de9c-4b1e-96ec-6315093611d1)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Against GOAD with SMB and MSSQL

## Screenshots (if appropriate):
Before&After MSSQL:
![image](https://github.com/user-attachments/assets/aa079754-f86c-4cda-95c7-23ff3374c90a)

Before&After SMB (notice it is guest not Pwned):
![image](https://github.com/user-attachments/assets/f5722ed9-b360-43be-9342-c9f970750cb5)

