### PR TITLE
Upgrade the schtask_as module so that we can upload binaries and execute them 

### DIFF
--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -122,7 +122,7 @@ class NXCModule:
                 output = output.decode("cp437")
             if output:
                 for line in output.splitlines():
-                    self.logger.highlight(line.strip())
+                    self.logger.highlight(line.rstrip())
 
         except Exception as e:
             if "SCHED_S_TASK_HAS_NOT_RUN" in str(e):


### PR DESCRIPTION
Until now If I had to run a binary as someone else on the system, I had to:
* Upload the binary somewhere
* Run the schtask_as module

With this PR I added the BINARY option which allows telling nxc to upload the binary, execute it and then remove it leaving no traces on the target. Below is an exemple:

```
poetry run nxc smb 192.168.56.12 -u Administrateur -p Defte@WF -M schtask_as -o USER=WHITEFLAG\\Administrateur CMD=DumpBootKey.exe BINARY=/opt/windev/DumpBootKey/x64/Release/DumpBootKey.exe
```

This command uplaod the DumpBootKey.exe BINARY in \\Windows\Temp and then executes it based on the CMD provided:

![image](https://github.com/user-attachments/assets/c8d2c859-6e3f-41f3-8e72-2bb6c8b27188)

Which allows us retrieveing the targeted user's bootkey without having to manually deploy/undeploy the binary.
