### PR TITLE
Fix ldap simple auth with base object

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -232,7 +232,7 @@ class connection:
             self.logger.debug("Created connection object")
             self.enum_host_info()
             self.print_host_info()
-            if (self.args.username[0] == "" and self.args.password[0] == "") or self.login():
+            if self.login() or (self.username and self.password):
                 if hasattr(self.args, "module") and self.args.module:
                     self.load_modules()
                     self.logger.debug("Calling modules")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -232,7 +232,7 @@ class connection:
             self.logger.debug("Created connection object")
             self.enum_host_info()
             self.print_host_info()
-            if self.login() or (self.username == "" and self.password == ""):
+            if (self.args.username[0] == "" and self.args.password[0] == "") or self.login():
                 if hasattr(self.args, "module") and self.args.module:
                     self.load_modules()
                     self.logger.debug("Calling modules")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -232,7 +232,7 @@ class connection:
             self.logger.debug("Created connection object")
             self.enum_host_info()
             self.print_host_info()
-            if self.login() or (self.username and self.password):
+            if self.login() or (self.username == "" and self.password == ""):
                 if hasattr(self.args, "module") and self.args.module:
                     self.load_modules()
                     self.logger.debug("Calling modules")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -639,17 +639,17 @@ class ldap(connection):
                     searchControls=paged_search_control,
                 )
         except ldap_impacket.LDAPSearchError as e:
-            if e.getErrorString().find("sizeLimitExceeded") >= 0:
+            if "sizeLimitExceeded" in str(e):
                 # We should never reach this code as we use paged search now
                 self.logger.fail("sizeLimitExceeded exception caught, giving up and processing the data received")
                 e.getAnswers()
-            else:
+            elif "operationsError" in str(e) and self.scope is None:
                 # if empty username and password is possible that we need to change the scope, we try with a baseObject before returning a fail
                 if self.username == "" and self.password == "":
                     self.scope = ldapasn1_impacket.Scope("baseObject")
                     return self.search(searchFilter, attributes, sizeLimit, baseDN)
-                else:
-                    self.logger.fail(e)
+            else:
+                self.logger.fail(e)
                 return []
         return []
 

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -416,7 +416,9 @@ class ldap(connection):
     def plaintext_login(self, domain, username, password):
         if username == "" and password == "" and self.no_ntlm:
             self.scope = ldapasn1_impacket.Scope("baseObject")
+            self.logger.success(f"{domain}\\{self.username}:{process_secret(self.password)} {self.mark_pwned()}")
             return True
+
         self.username = username
         self.password = password
         self.domain = domain

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -414,6 +414,8 @@ class ldap(connection):
                 return False
 
     def plaintext_login(self, domain, username, password):
+        if username == "" and password == "":
+            return True
         self.username = username
         self.password = password
         self.domain = domain
@@ -628,7 +630,7 @@ class ldap(connection):
                 self.logger.debug(f"Search Filter={searchFilter}")
 
                 # Microsoft Active Directory set an hard limit of 1000 entries returned by any search
-                paged_search_control = ldapasn1_impacket.SimplePagedResultsControl(criticality=True, size=1000) if not self.no_ntlm else ""
+                paged_search_control = ldapasn1_impacket.SimplePagedResultsControl(criticality=True, size=1000) if self.no_ntlm else ""
                 return self.ldap_connection.search(
                     scope=self.scope,
                     searchBase=baseDN,

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -630,7 +630,7 @@ class ldap(connection):
                 self.logger.debug(f"Search Filter={searchFilter}")
 
                 # Microsoft Active Directory set an hard limit of 1000 entries returned by any search
-                paged_search_control = ldapasn1_impacket.SimplePagedResultsControl(criticality=True, size=1000) if self.no_ntlm else ""
+                paged_search_control = [ldapasn1_impacket.SimplePagedResultsControl(criticality=True, size=1000)] if self.no_ntlm else ""
                 return self.ldap_connection.search(
                     scope=self.scope,
                     searchBase=baseDN,

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -643,11 +643,10 @@ class ldap(connection):
                 # We should never reach this code as we use paged search now
                 self.logger.fail("sizeLimitExceeded exception caught, giving up and processing the data received")
                 e.getAnswers()
-            elif "operationsError" in str(e) and self.scope is None:
-                # if empty username and password is possible that we need to change the scope, we try with a baseObject before returning a fail
-                if self.username == "" and self.password == "":
-                    self.scope = ldapasn1_impacket.Scope("baseObject")
-                    return self.search(searchFilter, attributes, sizeLimit, baseDN)
+            # if empty username and password is possible that we need to change the scope, we try with a baseObject before returning a fail
+            elif "operationsError" in str(e) and self.scope is None and self.username == "" and self.password == "":
+                self.scope = ldapasn1_impacket.Scope("baseObject")
+                return self.search(searchFilter, attributes, sizeLimit, baseDN)
             else:
                 self.logger.fail(e)
                 return []

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -414,8 +414,6 @@ class ldap(connection):
                 return False
 
     def plaintext_login(self, domain, username, password):
-        if username == "" and password == "" and self.no_ntlm:
-            self.scope = ldapasn1_impacket.Scope("baseObject")
 
         self.username = username
         self.password = password
@@ -646,7 +644,12 @@ class ldap(connection):
                 self.logger.fail("sizeLimitExceeded exception caught, giving up and processing the data received")
                 e.getAnswers()
             else:
-                self.logger.fail(e)
+                # if empty username and password is possible that we need to change the scope, we try with a baseObject before returning a fail
+                if self.username == "" and self.password == "":
+                    self.scope = ldapasn1_impacket.Scope("baseObject")
+                    return self.search(searchFilter, attributes, sizeLimit, baseDN)
+                else:
+                    self.logger.fail(e)
                 return []
         return []
 

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -416,8 +416,6 @@ class ldap(connection):
     def plaintext_login(self, domain, username, password):
         if username == "" and password == "" and self.no_ntlm:
             self.scope = ldapasn1_impacket.Scope("baseObject")
-            self.logger.success(f"{domain}\\{self.username}:{process_secret(self.password)} {self.mark_pwned()}")
-            return True
 
         self.username = username
         self.password = password


### PR DESCRIPTION
## Description

This command is working `ldapsearch -x -H ldap://10.10.11.60 -b "" -s base "(objectclass=\*)"` but not this one `netexec ldap 10.10.11.60 -u '' -p '' --base "" --query "(objectclass=*)" ""`

This pull request introduces several updates to the `nxc/protocols/ldap.py` file, focusing on improving LDAP search functionality, handling NTLM challenges, and refining login and search behavior. The most significant changes include adding a `scope` attribute, improving NTLM error handling, and enhancing the search logic to adapt dynamically based on credentials and NTLM availability.

### Enhancements to LDAP search functionality:
* Added a `scope` attribute to the class, which is dynamically updated during searches to support fallback to a `baseObject` scope if username and password are empty. (`[[1]](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76R153)`, `[[2]](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76L628-R650)`)
* Updated the `search` method to check if `baseDN` is explicitly `None` before assigning it, ensuring clarity in conditional logic. (`[nxc/protocols/ldap.pyL618-R622](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76L618-R622)`)
* Modified the `search` method to conditionally handle paged search controls based on the `no_ntlm` flag, improving compatibility with environments where NTLM is unavailable. (`[nxc/protocols/ldap.pyL628-R650](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76L628-R650)`)

### Improved NTLM challenge handling:
* Updated the `enum_host_info` method to set the `no_ntlm` attribute to `True` when no NTLM challenge is detected, ensuring proper handling of NTLM-unavailable scenarios. (`[nxc/protocols/ldap.pyR253-R254](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76R253-R254)`)

### Minor code refinements:
* Added a blank line in the `kerberos_login` method for readability and to maintain consistent formatting. (`[nxc/protocols/ldap.pyR417](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76R417)`)


## How Has This Been Tested?
Against HTB frizz

If you are using poetry, you can easily run tests via:
`poetry run python tests/e2e_tests.py -t $TARGET -u $USER -p $PASSWORD`
There are additional options like `--errors` to display ALL errors (some may not be failures), `--poetry` (output will include the poetry run prepended), `--line-num $START-$END $SINGLE` for only running a subset

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/79562efa-2454-4cc5-a29e-f38880870ed8)


## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] My code follows the style guidelines of this project (should be covered by Ruff above)
- [ ] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
