### PR TITLE
Fix hostname info if no ntlm and not resolution

### DIFF
--- a/nxc/helpers/misc.py
+++ b/nxc/helpers/misc.py
@@ -77,3 +77,15 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
                 name = os.path.join(p, thefile)
                 if _access_check(name, mode):
                     return name
+
+def detect_ip_or_fqdn(input_string):
+    # Regex for matching IP address (both IPv4 and IPv6)
+    ip_pattern = re.compile(r"^(\d{1,3}\.){3}\d{1,3}$")  # Simple IPv4 pattern
+    fqdn_pattern = re.compile(r"^[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")  # Simple FQDN pattern
+
+    if ip_pattern.match(input_string):
+        return True
+    elif fqdn_pattern.match(input_string):
+        return False
+    else:
+        return False

--- a/nxc/helpers/misc.py
+++ b/nxc/helpers/misc.py
@@ -83,5 +83,5 @@ def detect_if_ip(target):
     try:
         ip_address(target)
         return True
-    except Exception as e:
+    except Exception:
         return False

--- a/nxc/helpers/misc.py
+++ b/nxc/helpers/misc.py
@@ -4,6 +4,7 @@ import re
 import inspect
 import os
 
+from ipaddress import ip_address
 
 def identify_target_file(target_file):
     with open(target_file) as target_file_handle:
@@ -78,14 +79,9 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
                 if _access_check(name, mode):
                     return name
 
-def detect_ip_or_fqdn(input_string):
-    # Regex for matching IP address (both IPv4 and IPv6)
-    ip_pattern = re.compile(r"^(\d{1,3}\.){3}\d{1,3}$")  # Simple IPv4 pattern
-    fqdn_pattern = re.compile(r"^[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")  # Simple FQDN pattern
-
-    if ip_pattern.match(input_string):
+def detect_if_ip(target):
+    try:
+        ip_address(target)
         return True
-    elif fqdn_pattern.match(input_string):
-        return False
-    else:
+    except Exception as e:
         return False

--- a/nxc/protocols/ldap/resolution.py
+++ b/nxc/protocols/ldap/resolution.py
@@ -1,0 +1,63 @@
+from re import sub, I
+from errno import EHOSTUNREACH, ETIMEDOUT, ENETUNREACH
+from OpenSSL.SSL import SysCallError
+
+from impacket.ldap import ldap as ldap_impacket
+from impacket.ldap import ldapasn1 as ldapasn1_impacket
+
+from nxc.parsers.ldap_results import parse_result_attributes
+from nxc.logger import nxc_logger
+
+class LDAPResolution:
+
+    def __init__(self, host):
+        self.host = host
+
+    def get_resolution(self):
+        target = ""
+        target_domain = ""
+        base_dn = ""
+        try:
+            ldap_url = f"ldap://{self.host}"
+            nxc_logger.info(f"Connecting to {ldap_url} with no baseDN")
+            try:
+                self.ldap_connection = ldap_impacket.LDAPConnection(ldap_url, dstIp=self.host)
+                if self.ldap_connection:
+                    nxc_logger.debug(f"ldap_connection: {self.ldap_connection}")
+            except SysCallError as e:
+                nxc_logger.fail(f"LDAP connection to {ldap_url} failed: {e}")
+                return False
+
+            resp = self.ldap_connection.search(
+                scope=ldapasn1_impacket.Scope("baseObject"),
+                attributes=["defaultNamingContext", "dnsHostName"],
+                sizeLimit=0,
+            )
+            resp_parsed = parse_result_attributes(resp)[0]
+
+            target = resp_parsed["dnsHostName"]
+            base_dn = resp_parsed["defaultNamingContext"]
+            target_domain = sub(
+                ",DC=",
+                ".",
+                base_dn[base_dn.lower().find("dc="):],
+                flags=I,
+            )[3:]
+            # Extract machine name from target (hostname part of FQDN)
+            if target:
+                machine_name = target.split(".")[0]
+                nxc_logger.debug(f"Extracted machine name: {machine_name}")
+
+            self.ldap_connection.close()
+        except ConnectionRefusedError as e:
+            nxc_logger.debug(f"{e} on host {self.host}")
+            return False
+        except OSError as e:
+            if e.errno in (EHOSTUNREACH, ENETUNREACH, ETIMEDOUT):
+                nxc_logger.info(f"Error connecting to {self.host} - {e}")
+                return False
+            else:
+                nxc_logger.error(f"Error getting ldap info {e}")
+
+        nxc_logger.debug(f"Target: {machine_name}.{target_domain}; target_domain: {target_domain}; base_dn: {base_dn}")
+        return machine_name, target_domain

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -56,7 +56,7 @@ from nxc.protocols.ldap.gmsa import MSDS_MANAGEDPASSWORD_BLOB
 from nxc.helpers.logger import highlight
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.powershell import create_ps_command
-from nxc.helpers.misc import detect_ip_or_fqdn
+from nxc.helpers.misc import detect_if_ip
 from nxc.protocols.ldap.resolution import LDAPResolution
 
 from dploot.triage.vaults import VaultsTriage
@@ -236,7 +236,7 @@ class smb(connection):
                 self.targetDomain = self.hostname
         else:
             try:
-                if self.is_host_dc() and detect_ip_or_fqdn(self.host):
+                if self.is_host_dc() and detect_if_ip(self.host):
                     self.hostname, self.domain = LDAPResolution(self.host).get_resolution()
                     self.targetDomain = self.domain
                 # If we can't authenticate with NTLM and the target is supplied as a FQDN we must parse it

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -236,11 +236,13 @@ class smb(connection):
                 self.targetDomain = self.hostname
         else:
             try:
+                # If we know the host is a DC we can still get the hostname over LDAP if NTLM is not available
                 if self.is_host_dc() and detect_if_ip(self.host):
                     self.hostname, self.domain = LDAPResolution(self.host).get_resolution()
                     self.targetDomain = self.domain
                 # If we can't authenticate with NTLM and the target is supplied as a FQDN we must parse it
                 else:
+                    # Check if the host is a valid IP address, if not we parse the FQDN in the Exception
                     import socket
                     socket.inet_aton(self.host)
                     self.logger.debug("NTLM authentication not available! Authentication will fail without a valid hostname and domain name")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -56,6 +56,8 @@ from nxc.protocols.ldap.gmsa import MSDS_MANAGEDPASSWORD_BLOB
 from nxc.helpers.logger import highlight
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.powershell import create_ps_command
+from nxc.helpers.misc import detect_ip_or_fqdn
+from nxc.protocols.ldap.resolution import LDAPResolution
 
 from dploot.triage.vaults import VaultsTriage
 from dploot.triage.browser import BrowserTriage, LoginData, GoogleRefreshToken, Cookie
@@ -172,6 +174,7 @@ class smb(connection):
         self.no_ntlm = False
         self.protocol = "SMB"
         self.is_guest = None
+        self.isdc = False
 
         connection.__init__(self, args, db, host)
 
@@ -232,13 +235,17 @@ class smb(connection):
             if not self.targetDomain:   # Not sure if that can even happen but now we are safe
                 self.targetDomain = self.hostname
         else:
-            # If we can't authenticate with NTLM and the target is supplied as a FQDN we must parse it
             try:
-                import socket
-                socket.inet_aton(self.host)
-                self.logger.debug("NTLM authentication not available! Authentication will fail without a valid hostname and domain name")
-                self.hostname = self.host
-                self.targetDomain = self.host
+                if self.is_host_dc() and detect_ip_or_fqdn(self.host):
+                    self.hostname, self.domain = LDAPResolution(self.host).get_resolution()
+                    self.targetDomain = self.domain
+                # If we can't authenticate with NTLM and the target is supplied as a FQDN we must parse it
+                else:
+                    import socket
+                    socket.inet_aton(self.host)
+                    self.logger.debug("NTLM authentication not available! Authentication will fail without a valid hostname and domain name")
+                    self.hostname = self.host
+                    self.targetDomain = self.host
             except OSError:
                 if self.host.count(".") >= 1:
                     self.hostname = self.host.split(".")[0]
@@ -246,6 +253,10 @@ class smb(connection):
                 else:
                     self.hostname = self.host
                     self.targetDomain = self.host
+            except Exception as e:
+                self.logger.debug(f"Error getting hostname from LDAP: {e}")
+                self.hostname = self.host
+                self.targetDomain = self.host
 
         if self.args.domain:
             self.domain = self.args.domain
@@ -330,21 +341,12 @@ class smb(connection):
         self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.targetDomain}) ({signing}) ({smbv1}) {ntlm}")
 
         if self.args.generate_hosts_file or self.args.generate_krb5_file:
-            from impacket.dcerpc.v5 import nrpc, epm
-            self.logger.debug("Performing authentication attempts...")
-            isdc = False
-            try:
-                epm.hept_map(self.host, nrpc.MSRPC_UUID_NRPC, protocol="ncacn_ip_tcp")
-                isdc = True
-            except DCERPCException:
-                self.logger.debug("Error while connecting to host: DCERPCException, which means this is probably not a DC!")
-
             if self.args.generate_hosts_file:
                 with open(self.args.generate_hosts_file, "a+") as host_file:
-                    dc_part = f" {self.targetDomain}" if isdc else ""
+                    dc_part = f" {self.targetDomain}" if self.isdc else ""
                     host_file.write(f"{self.host}     {self.hostname}.{self.targetDomain}{dc_part} {self.hostname}\n")
-                    self.logger.debug(f"{self.host}    {self.hostname}.{self.targetDomain}{dc_part} {self.hostname}")
-            elif self.args.generate_krb5_file and isdc:
+                    self.logger.debug(f"Line added to {self.args.generate_hosts_file} {self.host}    {self.hostname}.{self.targetDomain}{dc_part} {self.hostname}")
+            elif self.args.generate_krb5_file and self.isdc:
                 with open(self.args.generate_krb5_file, "w+") as host_file:
                     data = f"""
 [libdefaults]
@@ -702,6 +704,18 @@ class smb(connection):
             self.logger.success(f"Run the following command to use the TGT: export KRB5CCNAME={tgt_file}")
         except Exception as e:
             self.logger.fail(f"Failed to get TGT: {e}")
+
+    def is_host_dc(self):
+        from impacket.dcerpc.v5 import nrpc, epm
+        self.logger.debug("Performing authentication attempts...")
+        try:
+            epm.hept_map(self.host, nrpc.MSRPC_UUID_NRPC, protocol="ncacn_ip_tcp")
+            self.isdc = True
+            return True
+        except DCERPCException:
+            self.logger.debug("Error while connecting to host: DCERPCException, which means this is probably not a DC!")
+        self.isdc = False
+        return False
 
     @requires_admin
     def execute(self, payload=None, get_output=False, methods=None) -> str:


### PR DESCRIPTION
## Description

This PR fix host info if there is not ntlm and no dns resolution. The fix is rather simple, if this is a DC we can quicly get all the info we need using a simple ldap query (without auth) and since ldap is always open on a DC, it's working. It's the same technique that we use for ldap in fact, but used for smb proto in order to make the commande `--generate-hosts-file` works.

---

This pull request introduces several enhancements and new functionalities across multiple files, focusing on LDAP resolution, SMB protocol improvements, and utility updates. The main changes include adding an LDAP resolution class, improving SMB host information enumeration and logging, and introducing a utility function to detect IP addresses. These changes aim to enhance functionality, error handling, and maintainability.

### LDAP Resolution Enhancements:
* Added a new `LDAPResolution` class in `nxc/protocols/ldap/resolution.py` to handle LDAP connections, retrieve domain and machine name information, and parse LDAP search results. This includes robust error handling for connection issues.

### SMB Protocol Improvements:
* Introduced the `is_host_dc` method in `nxc/protocols/smb.py` to check if a host is a domain controller (DC) using DCERPC. This method sets the `isdc` flag and improves domain controller detection.
* Updated the `enum_host_info` method to use the new `LDAPResolution` class for resolving hostnames and domains when the host is a DC and provided as an IP address. Added fallback error handling for LDAP resolution failures. [[1]](diffhunk://#diff-03a263aab56e8880814c8a586230088900d62ab9c53b93744492f6fcd1bf7630L235-R243) [[2]](diffhunk://#diff-03a263aab56e8880814c8a586230088900d62ab9c53b93744492f6fcd1bf7630R256-R259)
* Refactored the `print_host_info` method to use the `isdc` flag for generating hosts and Kerberos configuration files, replacing inline DC detection logic.

### Utility Updates:
* Added a `detect_if_ip` function in `nxc/helpers/misc.py` to determine if a given target is an IP address. This function is used in SMB host enumeration logic. [[1]](diffhunk://#diff-3ad7e902b9a1f923e445db0a41cd9f3e70477845b7add96c3eb20f4ccb7b8ce8R81-R87) [[2]](diffhunk://#diff-03a263aab56e8880814c8a586230088900d62ab9c53b93744492f6fcd1bf7630R59-R60)

These changes collectively improve the robustness of LDAP and SMB functionalities, streamline code, and enhance error handling and logging.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
against vintage and fizz

## Screenshots (if appropriate):
Before:
![image](https://github.com/user-attachments/assets/49b5d004-4c9a-48a9-af5c-2dc091b4e0b8)


After:
![image](https://github.com/user-attachments/assets/41fc46ed-1e5f-4348-957d-0996c664930d)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] My code follows the style guidelines of this project (should be covered by Ruff above)
- [ ] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
