### PR TITLE
Add ability to execute commands via RDP

### DIFF
--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -548,14 +548,12 @@ class rdp(connection):
                 except Exception as e:
                     self.logger.debug(f"Error terminating connection: {e!s}")
     
-    def execute(self, payload=None, get_output=True, shell_type="cmd"):
+    def execute(self, payload=None, shell_type="cmd"):
         """Execute a command via RDP"""
         if not payload:
             payload = self.args.execute
         
-        if self.args.no_output:
-            get_output = False
-            
+
         # Check if screenshot is requested
         capture_screenshot = hasattr(self.args, "screenshot") and self.args.screenshot
         
@@ -580,14 +578,14 @@ class rdp(connection):
             if shell_type == "cmd":
                 self.logger.info("Cannot execute command via cmd - now switching to PowerShell to attempt execution")
                 try:
-                    return self.execute(payload, get_output, shell_type="powershell")
+                    return self.execute(payload, shell_type="powershell")
                 except Exception as e2:
                     self.logger.fail(f"Execute command failed, error: {e2!s}")
             else:
                 self.logger.fail(f"Execute command failed, error: {e!s}")
 
     def ps_execute(self):
-        self.execute(payload=self.args.ps_execute, get_output=True, shell_type="powershell")
+        self.execute(payload=self.args.ps_execute, shell_type="powershell")
 
     async def screen(self):
         try:

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -461,6 +461,12 @@ class rdp(connection):
                     self.logger.highlight(f"Command output screenshot saved: {filename}")
                 except Exception as e:
                     self.logger.debug(f"Error taking screenshot: {e!s}")
+
+            # Exit CMD
+            self.logger.debug("Exiting CMD")
+            await self._send_keystrokes("exit")
+            await self._send_enter()
+            await asyncio.sleep(0.5)
             
             self.logger.debug("Command execution completed")
             return True

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -357,6 +357,25 @@ class rdp(connection):
                     color=("magenta" if ((reason or "CredSSP" in str(e)) and reason != "STATUS_LOGON_FAILURE") else "red"),
                 )
             return False
+        
+    def execute(self, payload=None, get_output=True, shell_type="cmd"):
+        if not payload:
+            payload = self.args.execute
+        
+        if self.args.no_output:
+            get_output = False
+
+        try:
+            result = self.conn.execute_cmd(payload, encoding=self.args.codec) if shell_type == "cmd" else self.conn.execute_ps(payload)
+        except Exception as e:
+            self.logger.info("Cannot execute command via cmd - now switching to Powershell to attempt execution")
+            try:
+                self.execute(payload, get_output, shell_type="poewrshell")
+            except Exception as e:
+                self.logger.fail(f"Execute command failed, error: {e!s}")
+
+    def ps_execute(self):
+        self.sexecute(payload=self.args.ps_execute, get_output=True, shell_type="powershell")
 
     async def screen(self):
         try:

--- a/nxc/protocols/rdp/proto_args.py
+++ b/nxc/protocols/rdp/proto_args.py
@@ -18,7 +18,6 @@ def proto_args(parser, parents):
     egroup.add_argument("--res", default="1024x768", help="Resolution in WIDTHxHEIGHT format")
 
     cgroup = rdp_parser.add_argument_group("Command Execution", "Options for executing commands")
-    cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified command")
     cgroup.add_argument("-X", metavar="PS_COMMAND", dest="ps_execute", help="execute the specified PowerShell command")

--- a/nxc/protocols/rdp/proto_args.py
+++ b/nxc/protocols/rdp/proto_args.py
@@ -18,7 +18,6 @@ def proto_args(parser, parents):
     egroup.add_argument("--res", default="1024x768", help="Resolution in WIDTHxHEIGHT format")
 
     cgroup = rdp_parser.add_argument_group("Command Execution", "Options for executing commands")
-    cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified command")
     cgroup.add_argument("-X", metavar="PS_COMMAND", dest="ps_execute", help="execute the specified PowerShell command")
 

--- a/nxc/protocols/rdp/proto_args.py
+++ b/nxc/protocols/rdp/proto_args.py
@@ -17,4 +17,17 @@ def proto_args(parser, parents):
     egroup.add_argument("--screentime", type=int, default=10, help="Time to wait for desktop image")
     egroup.add_argument("--res", default="1024x768", help="Resolution in WIDTHxHEIGHT format")
 
+    cmd_exec_group = rdp_parser.add_argument_group("Command Execution", "Options for executing commands")
+    cmd_exec_group.add_argument("--exec-method", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
+    cmd_exec_group.add_argument("--dcom-timeout", help="DCOM connection timeout", type=int, default=5)
+    cmd_exec_group.add_argument("--get-output-tries", help="Number of times atexec/smbexec/mmcexec tries to get results", type=int, default=10)
+    cmd_exec_group.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
+    cmd_exec_group.add_argument("--no-output", action="store_true", help="do not retrieve command output")
+
+    cgroup = rdp_parser.add_argument_group("Command Execution", "Options for executing commands")
+    cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
+    cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
+    cgroup.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified command")
+    cgroup.add_argument("-X", metavar="PS_COMMAND", dest="ps_execute", help="execute the specified PowerShell command")
+
     return parser

--- a/nxc/protocols/rdp/proto_args.py
+++ b/nxc/protocols/rdp/proto_args.py
@@ -17,13 +17,6 @@ def proto_args(parser, parents):
     egroup.add_argument("--screentime", type=int, default=10, help="Time to wait for desktop image")
     egroup.add_argument("--res", default="1024x768", help="Resolution in WIDTHxHEIGHT format")
 
-    cmd_exec_group = rdp_parser.add_argument_group("Command Execution", "Options for executing commands")
-    cmd_exec_group.add_argument("--exec-method", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
-    cmd_exec_group.add_argument("--dcom-timeout", help="DCOM connection timeout", type=int, default=5)
-    cmd_exec_group.add_argument("--get-output-tries", help="Number of times atexec/smbexec/mmcexec tries to get results", type=int, default=10)
-    cmd_exec_group.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
-    cmd_exec_group.add_argument("--no-output", action="store_true", help="do not retrieve command output")
-
     cgroup = rdp_parser.add_argument_group("Command Execution", "Options for executing commands")
     cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -253,6 +253,9 @@ netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M web_de
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec {DNS} rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --nla-screenshot
+netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --screenshot
+netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --screenshot
+netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --screenshot
 ##### SSH - Default test passwords and random key; switch these out if you want correct authentication
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD
 netexec ssh TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce


### PR DESCRIPTION
## Description

Adds -x and -X to the RDP protocol to allow command execution.
This uses the [skelsec/aardwolf](https://github.com/skelsec/aardwolf) scriptable keyboard mode to send keystrokes into cmd.exe or powershell.exe. 

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## How Has This Been Tested?
Tested against a random THM room:
RDP e2e tests passing

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/2c209293-01f2-4d57-b677-c207ceec5655)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
