### PR TITLE
Added share exclusion functionality

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1035,7 +1035,9 @@ class smb(connection):
             self.logger.fail(f"Error getting user: {error}")
 
         try:
+            self.logger.debug("Attempting to list shares...")
             shares = self.conn.listShares()
+            self.logger.debug(f"Successfully listed shares: {shares}")
             self.logger.info(f"Shares returned: {shares}")
         except SessionError as e:
             error = get_error_string(e)
@@ -1049,11 +1051,23 @@ class smb(connection):
             self.logger.fail(
                 f"Error enumerating shares: {error}",
                 color="magenta" if error in smb_error_status else "red",
-            )
+            ) 
             return permissions
+
+        # Get list of shares to exclude
+        excluded_shares = []
+        if hasattr(self.args, "exclude_shares") and self.args.exclude_shares:
+            excluded_shares = [share.upper() for share in self.args.exclude_shares]
+            self.logger.debug(f"Excluding shares: {excluded_shares}")
 
         for share in shares:
             share_name = share["shi1_netname"][:-1]
+            
+            # Skip excluded shares
+            if share_name.upper() in excluded_shares:
+                self.logger.debug(f"Skipping excluded share: {share_name}")
+                continue
+                
             share_remark = share["shi1_remark"][:-1]
             share_info = {"name": share_name, "remark": share_remark, "access": []}
             read = False

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -38,6 +38,7 @@ def proto_args(parser, parents):
 
     mapping_enum_group = smb_parser.add_argument_group("Mapping/Enumeration", "Options for Mapping/Enumerating")
     mapping_enum_group.add_argument("--shares", action="store_true", help="Enumerate shares and access")
+    mapping_enum_group.add_argument("--exclude-shares", nargs="+", help="List of shares to exclude from enumeration (e.g., C$ Admin$ IPC$)")
     mapping_enum_group.add_argument("--dir", nargs="?", type=str, const="", help="List the content of a path (default path: '%(const)s')")
     mapping_enum_group.add_argument("--interfaces", action="store_true", help="Enumerate network interfaces")
     mapping_enum_group.add_argument("--no-write-check", action="store_true", help="Skip write check on shares (avoid leaving traces when missing delete permissions)")


### PR DESCRIPTION
## Description

Added the `--exclude-shares` argument to exclude shares while enumerating using `--shares`.
Had a few detections regarding access to C$ and ADMIN$, this argument can prevent this.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested on Kali:
```
❯ lsb_release -a
No LSB modules are available.
Distributor ID: Kali
Description:    Kali GNU/Linux Rolling
Release:        2024.4
Codename:       kali-rolling
❯ uname -a
Linux LX01-MON 6.11.2-amd64 #1 SMP PREEMPT_DYNAMIC Kali 6.11.2-1kali1 (2024-10-15) x86_64 GNU/Linux
```

Target was GOAD-Light
```
PS C:\Users\administrator> systeminfo

Host Name:                 WINTERFELL
OS Name:                   Microsoft Windows Server 2019 Standard Evaluation
OS Version:                10.0.17763 N/A Build 17763
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Primary Domain Controller
OS Build Type:             Multiprocessor Free
Registered Owner:          User
Registered Organization:   User Inc.
Product ID:                00431-10000-00000-AA694
Original Install Date:     4/18/2025, 4:34:19 AM
System Boot Time:          4/18/2025, 7:46:21 AM
System Manufacturer:       BOCHS_
System Model:              BXPC____
System Type:               x64-based PC
Processor(s):              1 Processor(s) Installed.
                           [01]: AMD64 Family 25 Model 68 Stepping 1 AuthenticAMD ~3294 Mhz
BIOS Version:              N/A, 4/1/2014
Windows Directory:         C:\Windows
System Directory:          C:\Windows\system32
Boot Device:               \Device\HarddiskVolume1
System Locale:             en-us;English (United States)
Input Locale:              en-us;English (United States)
Time Zone:                 (UTC-05:00) Eastern Time (US & Canada)
Total Physical Memory:     4,095 MB
Available Physical Memory: 1,093 MB
Virtual Memory: Max Size:  5,503 MB
Virtual Memory: Available: 2,653 MB
Virtual Memory: In Use:    2,850 MB
Page File Location(s):     C:\pagefile.sys
Domain:                    north.sevenkingdoms.local
Logon Server:              \\WINTERFELL
Hotfix(s):                 4 Hotfix(s) Installed.
                           [01]: KB5036604
                           [02]: KB4512577
                           [03]: KB5036896
                           [04]: KB5037017
Network Card(s):           1 NIC(s) Installed.
                           [01]: Red Hat VirtIO Ethernet Adapter
                                 Connection Name: Ethernet
                                 DHCP Enabled:    No
                                 IP address(es)
                                 [01]: 10.6.10.11
Hyper-V Requirements:      A hypervisor has been detected. Features required for Hyper-V will not be displayed.
```

## Screenshots (if appropriate):
`poetry run NetExec smb 10.6.10.11 -u arya.stark -p Needle --shares --exclude-shares C$ admin$`

![image](https://github.com/user-attachments/assets/d7934ebb-7d79-4f31-b036-cb2045e5ad91)

No more Event ID `5140` & `4663` when using the exclusion argument:

![image](https://github.com/user-attachments/assets/b3f9d9fe-157b-4b89-be35-4c9217965732)


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
