### PR TITLE
Add a check if the database scheme contains the unique attribute

### DIFF
--- a/nxc/protocols/smb/database.py
+++ b/nxc/protocols/smb/database.py
@@ -177,6 +177,16 @@ class database(BaseDB):
                 self.DpapiBackupkey = Table("dpapi_backupkey", self.metadata, autoload_with=self.db_engine)
                 self.ConfChecksTable = Table("conf_checks", self.metadata, autoload_with=self.db_engine)
                 self.ConfChecksResultsTable = Table("conf_checks_results", self.metadata, autoload_with=self.db_engine)
+
+                # Check if Database Schema is correct, due to hanging issues reported on discord introduced by https://github.com/Pennyw0rth/NetExec/pull/658
+                from sqlalchemy.schema import UniqueConstraint
+                ip_is_unique = False
+                for constraint in self.HostsTable.constraints:
+                    if isinstance(constraint, UniqueConstraint) and constraint.columns[0].name == "ip":
+                            ip_is_unique = True
+                            break
+                if not ip_is_unique:
+                    raise NoSuchTableError("ip is not unique in hosts table")
             except (NoInspectionAvailable, NoSuchTableError):
                 print(
                     f"""

--- a/nxc/protocols/smb/database.py
+++ b/nxc/protocols/smb/database.py
@@ -183,8 +183,8 @@ class database(BaseDB):
                 ip_is_unique = False
                 for constraint in self.HostsTable.constraints:
                     if isinstance(constraint, UniqueConstraint) and constraint.columns[0].name == "ip":
-                            ip_is_unique = True
-                            break
+                        ip_is_unique = True
+                        break
                 if not ip_is_unique:
                     raise NoSuchTableError("ip is not unique in hosts table")
             except (NoInspectionAvailable, NoSuchTableError):


### PR DESCRIPTION
## Description

With PR https://github.com/Pennyw0rth/NetExec/pull/658 the database scheme of the smb.py got changed. However, somehow sqlalchemy does not detect the change and throws an Exception like usually, but just keeps hanging as reported multiple times on discord. This PR adds a check for the new UNIQUE constraint and alerts if the smb database has not this attribute yet.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## How Has This Been Tested?
With the v1.4.0 release and the newest upstream version

## Screenshots (if appropriate):
Before:
![image](https://github.com/user-attachments/assets/83e91103-b7f0-4bfe-ba0a-92f45589afbe)

After:
![image](https://github.com/user-attachments/assets/4a174f97-195c-49c1-8e63-0eb15d5a1413)

