### PR TITLE
update ntdsutil.py to behave like --ntds

### DIFF
--- a/nxc/modules/ntdsutil.py
+++ b/nxc/modules/ntdsutil.py
@@ -233,7 +233,7 @@ class NXCModule:
                 subprocess.run(command, stdout=outfile, stderr=subprocess.STDOUT)
 
             # clean impacket-secretsdump output: remove first 7 lines and last line
-            with open(output_file, "r") as f:
+            with open(output_file) as f:
                 lines = f.readlines()
 
             if len(lines) > 8:

--- a/nxc/modules/ntdsutil.py
+++ b/nxc/modules/ntdsutil.py
@@ -143,14 +143,7 @@ class NXCModule:
         add_ntds_hash.ntds_hashes = 0
         add_ntds_hash.added_to_db = 0
 
-        if not connection.output_filename:
-            timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
-            hostname = connection.hostname
-            ip = connection.host
-            filename = f"{hostname}_{ip}_{timestamp}.ntds"
-            output_dir = os.path.join(NXC_PATH, "logs", "ntds")
-            os.makedirs(output_dir, exist_ok=True)
-            connection.output_filename = os.path.join(output_dir, filename).rstrip(".ntds")
+        connection.output_filename = connection.output_file_template.format(output_folder="ntds")
 
         NTDS = NTDSHashes(
             f"{self.dir_result}/Active Directory/ntds.dit",

--- a/nxc/modules/ntdsutil.py
+++ b/nxc/modules/ntdsutil.py
@@ -194,9 +194,7 @@ class NXCModule:
         try:
             context.log.success("Dumping the NTDS, this could take a while so go grab a redbull...")
             NTDS.dump()
-            context.log.success(
-                f"Dumped {highlight(add_ntds_hash.ntds_hashes)} NTDS hashes to {connection.output_filename}.ntds of which {highlight(add_ntds_hash.added_to_db)} were added to the database"
-            )
+            context.log.success(f"Dumped {highlight(add_ntds_hash.ntds_hashes)} NTDS hashes to {connection.output_filename}.ntds of which {highlight(add_ntds_hash.added_to_db)} were added to the database)
         except Exception as e:
             context.log.fail(e)
 

--- a/nxc/modules/ntdsutil.py
+++ b/nxc/modules/ntdsutil.py
@@ -217,8 +217,6 @@ class NXCModule:
             context.log.display(
                 f"secretsdump.py -system '{self.dir_result}/registry/SYSTEM' -security '{self.dir_result}/registry/SECURITY' -ntds '{self.dir_result}/Active Directory/ntds.dit' LOCAL"
             )
-            context.log.display("To extract only enabled accounts from the output file, run the following command: ")
-            context.log.display(f"grep -iv disabled {connection.output_filename}.ntds | cut -d ':' -f1")
         else:
             base_dir = os.path.join(os.environ["HOME"], ".nxc", "logs", "ntds")
 
@@ -256,4 +254,6 @@ class NXCModule:
                     f.writelines(cleaned_lines)
 
             context.log.success(f"impacket-secretsdump output saved to {output_file}")
+            context.log.display("To extract only enabled accounts from the output file, run the following command: ")
+            context.log.display(f"grep -iv disabled {output_file} | cut -d ':' -f1")
 

--- a/nxc/modules/ntdsutil.py
+++ b/nxc/modules/ntdsutil.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import tempfile
 import time
-from nxc.paths import NXC_PATH
 
 from impacket.examples.secretsdump import LocalOperations, NTDSHashes
 

--- a/nxc/modules/ntdsutil.py
+++ b/nxc/modules/ntdsutil.py
@@ -194,7 +194,7 @@ class NXCModule:
         try:
             context.log.success("Dumping the NTDS, this could take a while so go grab a redbull...")
             NTDS.dump()
-            context.log.success(f"Dumped {highlight(add_ntds_hash.ntds_hashes)} NTDS hashes to {connection.output_filename}.ntds of which {highlight(add_ntds_hash.added_to_db)} were added to the database)
+            context.log.success(f"Dumped {highlight(add_ntds_hash.ntds_hashes)} NTDS hashes to {connection.output_filename}.ntds of which {highlight(add_ntds_hash.added_to_db)} were added to the database")
         except Exception as e:
             context.log.fail(e)
 


### PR DESCRIPTION
## Description

in short: -M ntdsutil is not behaving like --ntds. 

if you don't specify dir_result (output directory), then copy of dump is not placed to $home/.nxc/logs/ntds. if you specify dir result, then it only dumps needed files to get complete dump. it's time consuming so this update does every step automatically to behave like --ntds option. also, it's [revealhashed](https://github.com/crosscutsaw/revealhashed) and [revealhashed-python](https://github.com/crosscutsaw/revealhashed-python) compatible.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
tested on my dummy active directory.

## Screenshots (if appropriate):
new ntdsutil with dir_result:
![image](https://github.com/user-attachments/assets/2ed65c65-f7e4-4e62-bd4a-f394f2c40d37)

new ntdsutil default:
![image](https://github.com/user-attachments/assets/8d48aeee-dfac-438f-bd85-1929e2d5b71a)

![image](https://github.com/user-attachments/assets/f28a337c-7da6-44e2-872c-b789df83ce8e)


## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [x] My code follows the style guidelines of this project (should be covered by Ruff above)
- [x] If reliant on third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
