### PR TITLE
fix(ntlm): include server hostname in Workstation field of Authentication

### DIFF
--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -146,6 +146,7 @@ class winrm(connection):
 
     def plaintext_login(self, domain, username, password):
         # Add server hostname to the Workstation field in NTLM Authenticate Message (Message 3)
+        # This helps fix false negatives during NTLM auth — see issue #694 for details
         os.environ["NETBIOS_COMPUTER_NAME"] = self.hostname
         self.admin_privs = False
         self.password = password
@@ -185,6 +186,9 @@ class winrm(connection):
             return False
 
     def hash_login(self, domain, username, ntlm_hash):
+        # Add server hostname to the Workstation field in NTLM Authenticate Message (Message 3)
+        # This helps fix false negatives during NTLM auth — see issue #694 for details
+        os.environ["NETBIOS_COMPUTER_NAME"] = self.hostname
         self.admin_privs = False
         lmhash = "00000000000000000000000000000000"
         nthash = ""

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -145,6 +145,8 @@ class winrm(connection):
         return True
 
     def plaintext_login(self, domain, username, password):
+        # Add server hostname to the Workstation field in NTLM Authenticate Message (Message 3)
+        os.environ["NETBIOS_COMPUTER_NAME"] = self.hostname
         self.admin_privs = False
         self.password = password
         self.username = username


### PR DESCRIPTION
## Description

**fix(ntlm)**: include server hostname in Workstation field of Authenticate message
This ensures compatibility with systems that rely on the Workstation field
in NTLMv2 authentication (Message 3) for auditing or validation. Specifically those that set specific computer names for users.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## How Has This Been Tested?
Tested authentication against windows server 2016 Datacenter version 1607 OS Build 14393.7515.

```nxc winrm 192.168.65.200 -u 'mark' -p 'Password123!'```

I use kali linux 2024, with Python 3.13.2, and nxc installed using `pipx install git+https://github.com/Pennyw0rth/NetExec`

![image](https://github.com/user-attachments/assets/530d87a0-4ff5-4f25-899b-9420d958a797)


now to reproduce this, we need to specify the computer name for our user `mark`

![image](https://github.com/user-attachments/assets/63fb1ded-891e-4b32-8fcc-553ad484ccd7)

In mark user properties, we added dc01 which is our DC name as the allowed computer name for mark.

![image](https://github.com/user-attachments/assets/0c377022-baa2-4919-a639-02b0c8106ae6)

the default behavior of netexec is using the kali hostname as the workstation name when sending the authentication message type 3.

![image](https://github.com/user-attachments/assets/2101c535-9311-4fb5-9c1d-20ec19635579)

decoding, netexec's authentication request reveals the workstation name used which is our kali hostname

![image](https://github.com/user-attachments/assets/9dd63d40-84c6-436f-aca9-a2c9b90c145e)

Diving even deeper, the issue is actually in the pysrp library which is using spnego for the ntlm authentication

![image](https://github.com/user-attachments/assets/48ed6415-dd7f-43de-81ff-128c1b1bbeeb)

The `spnego/_ntlm.py` file handles **NTLMSSP message construction**, including:

- Generating Type 1/2/3 messages
    
- Setting fields like domain, username, and **workstation name**

we can see that spnego first checks the environment variable "NETBIOS_COMPUTER_NAME", if that environment variable is not set, it uses the machine's hostname using `socket.gethostname().upper()` in upper case, as we have seen in the captured authenticate message 3 of the NTLM authentication process.

now if we set that environment variable as the server hostname, we get a successful authentication in netexec

![image](https://github.com/user-attachments/assets/98f2b8bd-580a-443d-82db-28f409e87419)

the server accepts the authentication request with no issues this time

![image](https://github.com/user-attachments/assets/96b77e04-48d2-4ec6-9e04-9f6070bce379)

![image](https://github.com/user-attachments/assets/1369d437-a98a-4b44-875a-fb6be102a4b5)

decoding the message type 3 this time, we can also see the workstation name is set as we specified in the environment variable

![image](https://github.com/user-attachments/assets/676e4357-9495-4344-bf62-fa1d3981e2b4)

it also works with empty workstation field, we can set our hostname as an empty string and get the same results

![image](https://github.com/user-attachments/assets/faa94fe2-583c-451c-ba1a-0e4c728ecdf5)

Now to fix this in Netexec, all we need to do is set the environment variable to the server hostname right before doing any NTLM authentication.

![image](https://github.com/user-attachments/assets/ad26cd7a-2f19-4b44-aef1-259a0139a6b6)

This fixes the issue, and let's us get a successful authentication even when users have specific computer names set.

![image](https://github.com/user-attachments/assets/6378e506-2bb6-4802-9c8d-e5df2eb8a5b6)

