### PR TITLE
Updated whoami and find-computer modules

### DIFF
--- a/nxc/modules/find-computer.py
+++ b/nxc/modules/find-computer.py
@@ -35,7 +35,7 @@ class NXCModule:
             sys.exit(1)
 
     def on_login(self, context, connection):
-        search_filter = f"(&(objectCategory=computer)(&(|(operatingSystem=*{self.TEXT}*))(name=*{self.TEXT}*)))"
+        search_filter = f"(&(objectCategory=computer)(|(operatingSystem=*{self.TEXT}*)(name=*{self.TEXT}*)))"
 
         try:
             context.log.debug(f"Search Filter={search_filter}")

--- a/nxc/modules/whoami.py
+++ b/nxc/modules/whoami.py
@@ -43,7 +43,7 @@ class NXCModule:
                 "badPwdCount",
                 "memberOf",
             ],
-            sizeLimit=50,
+            sizeLimit=999,
         )
         try:
             resp_parsed = parse_result_attributes(r)

--- a/nxc/modules/whoami.py
+++ b/nxc/modules/whoami.py
@@ -74,7 +74,7 @@ class NXCModule:
                 context.log.highlight(f"Enabled: {'No' if is_disabled else 'Yes'}")
                 context.log.highlight(f"Password Never Expires: {'Yes' if password_never_expires else 'No'}")
 
-            # Process User PrincipalName 
+            # Process User PrincipalName
             if "userPrincipalName" in response:
                 context.log.highlight(f"User Principal Name: {response['userPrincipalName']}")
 
@@ -116,7 +116,7 @@ class NXCModule:
                 else:
                     context.log.highlight(f"Service Account Name: {spns}")
 
-            # Process DistinguishedName 
+            # Process DistinguishedName
             if "distinguishedName" in response:
                 context.log.highlight(f"Distinguished Name: {response['distinguishedName']}")
 
@@ -128,7 +128,7 @@ class NXCModule:
                         context.log.highlight(f"Member of: {group}")
                 else:
                     context.log.highlight(f"Member of: {groups}")
-            
+
             # Process User Sid
             if "objectSid" in response:
                 context.log.highlight(f"User SID: {response['objectSid']}")

--- a/nxc/modules/whoami.py
+++ b/nxc/modules/whoami.py
@@ -48,11 +48,7 @@ class NXCModule:
             ],
             sizeLimit=999,
         )
-        try:
-            resp_parsed = parse_result_attributes(r)
-        except LDAPFilterSyntaxError as e:
-            self.logger.fail(f"LDAP Filter Syntax Error: {e}")
-            return
+        resp_parsed = parse_result_attributes(r)
 
         for response in resp_parsed:
 

--- a/nxc/modules/whoami.py
+++ b/nxc/modules/whoami.py
@@ -1,4 +1,7 @@
 import datetime
+from nxc.parsers.ldap_results import parse_result_attributes
+
+
 class NXCModule:
     """
     Basic enumeration of provided user information and privileges


### PR DESCRIPTION
Hey, just wanted to add some changes to modules I use a lot. One is my own named find-computer which I noticed it only looked in name and didn't look in description too so I updated that and the second is the great whoami module. 

I realise there is now the ability to query ldap with the --query feature but whoami I still find is very good for retrieving key details and also telling you if an account is enabled or not although I needed to fix that piece of code too. 

I also added 'mail' and 'userPrincipalName' which can be useful to know what the Cloud account could be called which may be different to sAMAccountname. I also updated 'Password Last Set' and 'Last Logon' to be human readable. Here are some before and after screenshots:

Whoami before:
![image](https://github.com/user-attachments/assets/9fd011ff-290e-4fe5-a43b-cfb8756a2c62)


Whoami after:
![image](https://github.com/user-attachments/assets/50970021-22cb-43a0-a467-4eee38038cae)


Find-computer before:
![image](https://github.com/user-attachments/assets/4f82e884-b28c-4f48-a392-05e989c2f5b8)

Find-computer after:
![image](https://github.com/user-attachments/assets/fe67bf6f-93d5-4306-8afe-e83ffd6c08a8)






