### PR TITLE
Fix winrm database logic

### DIFF
--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -31,7 +31,6 @@ class winrm(connection):
         self.server_os = None
         self.output_filename = None
         self.endpoint = None
-        self.hash = None
         self.lmhash = ""
         self.nthash = ""
         self.ssl = False
@@ -165,11 +164,13 @@ class winrm(connection):
 
             self.logger.debug(f"Adding credential: {domain}/{self.username}:{self.password}")
             self.db.add_credential("plaintext", domain, self.username, self.password)
-            # TODO: when we can easily get the host_id via RETURNING statements, readd this in
+            user_id = self.db.get_credential("plaintext", domain, self.username, self.password)
+            host_id = self.db.get_hosts(self.host)[0].id
+            self.db.add_loggedin_relation(user_id, host_id)
 
             if self.admin_privs:
                 self.logger.debug("Inside admin privs")
-                self.db.add_admin_user("plaintext", domain, self.username, self.password, self.host)  # , user_id=user_id)
+                self.db.add_admin_user("plaintext", domain, self.username, self.password, self.host, user_id=user_id)  # , user_id=user_id)
                 add_user_bh(f"{self.hostname}$", domain, self.logger, self.config)
 
             if not self.args.local_auth and self.username != "":
@@ -211,8 +212,13 @@ class winrm(connection):
             self.check_if_admin()
             self.logger.success(f"{self.domain}\\{self.username}:{process_secret(nthash)} {self.mark_pwned()}")
 
+            self.db.add_credential("hash", domain, self.username, ntlm_hash)
+            user_id = self.db.get_credential("hash", domain, self.username, ntlm_hash)
+            host_id = self.db.get_hosts(self.host)[0].id
+            self.db.add_loggedin_relation(user_id, host_id)
+
             if self.admin_privs:
-                self.db.add_admin_user("hash", domain, self.username, nthash, self.host)
+                self.db.add_admin_user("hash", domain, self.username, nthash, self.host, user_id=user_id)
                 add_user_bh(f"{self.hostname}$", domain, self.logger, self.config)
 
             if not self.args.local_auth and self.username != "":

--- a/nxc/protocols/winrm/database.py
+++ b/nxc/protocols/winrm/database.py
@@ -128,7 +128,6 @@ class database(BaseDB):
 
     def add_credential(self, credtype, domain, username, password, pillaged_from=None):
         """Check if this credential has already been added to the database, if not add it in."""
-        domain = domain.split(".")[0].upper()
         credentials = []
 
         credential_data = {}
@@ -274,6 +273,16 @@ class database(BaseDB):
             q = select(self.UsersTable)
 
         return self.db_execute(q).all()
+
+    def get_credential(self, cred_type, domain, username, password):
+        q = select(self.UsersTable).filter(
+            self.UsersTable.c.domain == domain,
+            self.UsersTable.c.username == username,
+            self.UsersTable.c.password == password,
+            self.UsersTable.c.credtype == cred_type,
+        )
+        results = self.db_execute(q).first()
+        return results.id
 
     def is_credential_local(self, credential_id):
         q = select(self.UsersTable.c.domain).filter(self.UsersTable.c.id == credential_id)


### PR DESCRIPTION
## Description

This PR fixes #690 and #646.

The root cause of the problem was, that half of the logic for adding users to the db and adding the admin relations properly for password/hash login was missing. The domain added to the db was also the NETBIOS domain name and not the fqdn, which in turn wasn't found when adding the admin relation with the fqdn.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## How Has This Been Tested?
Plaintext&Hash login against GOAD

## Screenshots (if appropriate):
Before:
![image](https://github.com/user-attachments/assets/4b1c5d77-a184-486e-9567-ce16c87cf42a)
![image](https://github.com/user-attachments/assets/b825b629-ec63-496c-ba81-cc425cb258ea)

After:
![image](https://github.com/user-attachments/assets/95094ffe-6cc5-40cc-8a3d-67bb790ce918)
![image](https://github.com/user-attachments/assets/02006740-42d9-4781-9632-0af6d8ca8104)
