### PR TITLE
Fix logging port and also update the port when switching to LDAPS

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -275,7 +275,7 @@ class connection:
                 extra={
                     "module_name": module.name.upper(),
                     "host": self.host,
-                    "port": self.args.port,
+                    "port": self.port,
                     "hostname": self.hostname,
                 },
             )

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -375,6 +375,7 @@ class ldap(connection):
                     # Connect to LDAPS
                     self.logger.extra["protocol"] = "LDAPS"
                     self.logger.extra["port"] = "636"
+                    self.port = 636
                     ldaps_url = f"ldaps://{self.target}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host} [2]")
                     self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host, signing=False)
@@ -463,6 +464,7 @@ class ldap(connection):
                     # Connect to LDAPS
                     self.logger.extra["protocol"] = "LDAPS"
                     self.logger.extra["port"] = "636"
+                    self.port = 636
                     ldaps_url = f"ldaps://{self.target}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host} [4]")
                     self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host, signing=False)
@@ -553,6 +555,7 @@ class ldap(connection):
                     # We need to try SSL
                     self.logger.extra["protocol"] = "LDAPS"
                     self.logger.extra["port"] = "636"
+                    self.port = 636
                     ldaps_url = f"ldaps://{self.target}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host}")
                     self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host, signing=False)


### PR DESCRIPTION
## Description

While reviewing  #455 the module crashed when running winrm. This is because we use `self.args.port` for the module logger which is a list in case of the winrm protocol. However we have to use `self.port` because this is what ultimately decides the connections port (for all protocols). 

Furthermore i found that we have a similar issue in LDAP where we set the `logger.extra["port"]`, but not the `self.port` attribute. That leads to the similar problem where the module uses the old `self.args.port` even when the handshake restricts us to LDAPS. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Try to execute a module using winrm for the first issue. Execute a LDAP module on a server that requires signing which therefore (at the moment) will lead us to use LDAPS

## Screenshots (if appropriate):
Winrm crash (before&after):
![image](https://github.com/user-attachments/assets/30e3e9b3-3769-4a07-afa1-5943b30e080f)
![image](https://github.com/user-attachments/assets/6e7bf8f5-d488-44e1-90b6-0c732b5fbc65)
![image](https://github.com/user-attachments/assets/3fe450ca-5138-45fa-85d1-6192cb420414)

LDAP before&after:
![image](https://github.com/user-attachments/assets/9d6e8cdd-f718-4cba-bc59-f77538aa1984)

