### PR TITLE
Improve eventlog_creds

### DIFF
--- a/nxc/modules/eventlog_creds.py
+++ b/nxc/modules/eventlog_creds.py
@@ -41,8 +41,6 @@ class NXCModule:
     def find_credentials(self, content, context):
         # remove unnecessary words
         content = content.replace("\r\n", "\n")
-        content = content.replace("/add", "")
-        content = content.replace("/active:yes", "")
 
         # sort and unique lines
         content = "\n".join(sorted(set(content.split("\n"))))
@@ -66,9 +64,16 @@ class NXCModule:
         # Extracting credentials
         for line in content.split("\n"):
             for reg in regexps:
-                # verbose context.log.debug("Line: " + line)
-                # verbose context.log.debug("Reg: " + reg)
-                match = re.search(reg, line, re.IGNORECASE)
+                # Remove unnecessary words
+                line_stripped = line.replace("/add", "") \
+                    .replace("/active:yes", "") \
+                    .replace("/delete", "") \
+                    .replace("/domain", "") \
+                # Remove command lines that were executed with nxc
+                line_stripped = re.sub(r"1> \\Windows\\Temp\\[\w]{6} 2>&1", "", line_stripped)
+
+                # Use regex to find credentials
+                match = re.search(reg, line_stripped, re.IGNORECASE)
                 if match:
                     # eleminate false positives
                     # C:\Windows\system32\svchost.exe -k DcomLaunch -p -s PlugPlay
@@ -128,7 +133,6 @@ class NXCModule:
                         content += "CommandLine: " + match.group("CommandLine") + "\n"
                 except Exception as e:
                     context.log.error(f"Error: {e}")
-                    continue
 
         self.find_credentials(content, context)
 

--- a/nxc/modules/eventlog_creds.py
+++ b/nxc/modules/eventlog_creds.py
@@ -182,7 +182,7 @@ class MSEven6Trigger:
 
 
 class MSEven6Result:
-    def __init__(self, conn, handle, limit):
+    def __init__(self, conn, handle, limit=None):
         self._conn = conn
         self._handle = handle
         self._hardlimit = limit
@@ -192,11 +192,12 @@ class MSEven6Result:
         return self
 
     def __next__(self):
-        self._hardlimit -= 1
-        if self._hardlimit < 0:
-            raise StopIteration
+        if self._hardlimit is not None:
+            self._hardlimit -= 1
+            if self._hardlimit < 0:
+                raise StopIteration
         if self._resp is not None and self._resp["NumActualRecords"] == 0:
-            return None
+            raise StopIteration
 
         if self._resp is None or self._index == self._resp["NumActualRecords"]:
             req = even6.EvtRpcQueryNext()


### PR DESCRIPTION
## Description

As pointed out on social media, the eventlog_creds module has some false positives that should be now a bit more strict.
Changes:
- The `limit` was previously 1000 (which was quite low imo) and is now unlimited
- Eventlog lines that were produced by NetExec should now trigger a few less false positives (removed `1> \Windows\Temp\uNMOSg 2>&1`)
- Eventlog lines should now print the full command instead of the previsously removed snippeds, which were deleted to reduce false positives. E.g. `/add` is now removed for the regex match, but not for the printed command.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
See initial review of the PR for the setup

## Screenshots (if appropriate):
Inifinte rpc querying until we don't get more data:
![image](https://github.com/user-attachments/assets/f4127cd7-24c0-4631-9dad-7f353f1df8e5)

Before:
![image](https://github.com/user-attachments/assets/fa97b914-238d-4c65-8a81-970a323cdbfa)
After:
![image](https://github.com/user-attachments/assets/9d0802a8-2e93-44db-ab40-703394219a32)
