### PR TITLE
Switch impacket branch to Pennyw0rth fork

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -865,7 +865,7 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "impacket"
-version = "0.13.0.dev0+20250513.162347.b7288f23"
+version = "0.13.0.dev0+20250527.90709.eeaef0b7"
 description = "Network protocols Constructors and Dissectors"
 optional = false
 python-versions = "*"
@@ -888,9 +888,9 @@ six = "*"
 
 [package.source]
 type = "git"
-url = "https://github.com/zblurx/impacket.git"
-reference = "ldap_signing"
-resolved_reference = "b7288f233c154b6f73610797f8e0fa3a1541b3a9"
+url = "https://github.com/Pennyw0rth/impacket.git"
+reference = "HEAD"
+resolved_reference = "eeaef0b771790342f6e9b233014c61f718f1f95d"
 
 [[package]]
 name = "iniconfig"
@@ -2463,4 +2463,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "e748a99b7137fb81541ad5152dd98603856a2bfea56d7b9ff23913e950ea2f70"
+content-hash = "199b3ba18467fefbdf05d19a8f9bc6819b0ae72594c5008c135445031e138aec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "terminaltables>=3.1.0",
     "xmltodict>=0.13.0",
     # Git Dependencies
-    "impacket @ git+https://github.com/zblurx/impacket.git@ldap_signing",
+    "impacket @ git+https://github.com/Pennyw0rth/impacket.git",
     "oscrypto @ git+https://github.com/wbond/oscrypto",
     "pynfsclient @ git+https://github.com/Pennyw0rth/NfsClient",
 ]


### PR DESCRIPTION
## Description

Switching impacket version to our fork until the following PRs are merged:
- https://github.com/fortra/impacket/pull/1946
- https://github.com/fortra/impacket/pull/1959

Fixes:
- Querying LDAP with non-ascii chars
- LDAP signing capabilities

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
E.g. compare pso module on the fortra impacket version vs the fixed branch in Pennyw0rth

