### PR TITLE
Enable asreproast with anonymous ldap logins

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -483,7 +483,7 @@ class ldap(connection):
         self.password = password
         self.domain = domain
 
-        if self.password == "" and self.args.asreproast:
+        if self.username and self.password == "" and self.args.asreproast:
             hash_tgt = KerberosAttacks(self).get_tgt_asroast(self.username)
             if hash_tgt:
                 self.logger.highlight(f"{hash_tgt}")
@@ -965,9 +965,6 @@ class ldap(connection):
                 self.logger.highlight(f"{user.get('sAMAccountName', ''):<30}{pwd_last_set:<20}{user.get('badPwdCount', ''):<9}{user.get('description', '')}")
 
     def asreproast(self):
-        if self.password == "" and self.nthash == "" and not self.kerberos:
-            return False
-
         # Building the search filter
         search_filter = f"(&(UserAccountControl:1.2.840.113556.1.4.803:={UF_DONT_REQUIRE_PREAUTH})(!(UserAccountControl:1.2.840.113556.1.4.803:={UF_ACCOUNTDISABLE}))(!(objectCategory=computer)))"
         resp = self.search(search_filter, attributes=["sAMAccountName"], sizeLimit=0)


### PR DESCRIPTION
## Description

As pointed out on discord it isn't currently possible to automatically perform the asreproast with anonymous ldap login.
This is fixed now. 
Asreproast cases:
- User specifies a user(-list) that should be asreproasted `self.username` should not be empty, but `self.password` should be
- Else we either have a valid login with credentials or with anonymous auth

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Configure anonymous auth for ldap and try to asreproast with `-u '' -p ''`. 
Can be configured by changing `dsHeuristics` as described here: https://www.oreilly.com/library/view/active-directory-cookbook/0596004648/ch14s04.html
As well as giving `ANONYMOUS LOGON` read privileges over certain parts of the domain (or the whole domain) with ADSI edit

Configuring an asreproastable user -> check the "disable preauth" checkmark on the users profile in AD

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/68df0a63-37a7-4ee9-bf99-e2de4f0c858e)
