### PR TITLE
Add base_dn option to subnet module

### DIFF
--- a/nxc/modules/subnets.py
+++ b/nxc/modules/subnets.py
@@ -21,9 +21,8 @@ class NXCModule:
     """
 
     def options(self, context, module_options):
-        """Showservers    Toggle printing of servers (default: true)"""
+        """SHOWSERVERS    Toggle printing of servers (default: true)"""
         self.showservers = True
-        self.base_dn = None
 
         if module_options and "SHOWSERVERS" in module_options:
             if module_options["SHOWSERVERS"].lower() == "true" or module_options["SHOWSERVERS"] == "1":
@@ -31,9 +30,8 @@ class NXCModule:
             elif module_options["SHOWSERVERS"].lower() == "false" or module_options["SHOWSERVERS"] == "0":
                 self.showservers = False
             else:
-                print("Could not parse showservers option.")
-        if module_options and "BASE_DN" in module_options:
-            self.base_dn = module_options["BASE_DN"]
+                context.log.fail("Could not parse showservers option for 'SHOWSERVERS'. Please use 'true' or 'false'.")
+                exit(1)
 
     name = "subnets"
     description = "Retrieves the different Sites and Subnets of an Active Directory"
@@ -42,7 +40,7 @@ class NXCModule:
     multiple_hosts = False
 
     def on_login(self, context, connection):
-        dn = connection.ldap_connection._baseDN if self.base_dn is None else self.base_dn
+        dn = connection.args.base_dn if connection.args.base_dn else connection.ldap_connection._baseDN
 
         context.log.display("Getting the Sites and Subnets from domain")
 


### PR DESCRIPTION
## Description

As pointed out on discord the `--base-dn` arg is not respected in the `subnets` module. This is now fixed, replacing the implemented (but not mentioned) BASE_DN arg of the module.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Setup a domain with a child and try to query subnets from the parent domain while authenticating to the child

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/0a940ea8-0f52-4da8-9222-7e69d57967cf)