### PR TITLE
feat(ldap): add user enumeration and Kerberoasting with no-preauth user

### DIFF
--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -13,6 +13,8 @@ def proto_args(parser, parents):
     egroup = ldap_parser.add_argument_group("Retrieve hash on the remote DC", "Options to get hashes from Kerberos")
     egroup.add_argument("--asreproast", help="Output AS_REP response to crack with hashcat to file")
     egroup.add_argument("--kerberoasting", help="Output TGS ticket to crack with hashcat to file")
+    egroup.add_argument("--userenum",metavar=("USERS_FILE", "OUTPUT_FILE"),nargs="+", help="Enumerate users by checking AS-REP without preauth (optionally save valid usernames to a file)")
+    egroup.add_argument("--no-preauth-user", "-npu",dest="no_preauth_user", help="No-preauth user for AS-REQ Kerberoast (use with -u users/SPNs).")
 
     vgroup = ldap_parser.add_argument_group("Retrieve useful information on the domain")
     vgroup.add_argument("--base-dn", metavar="BASE_DN", dest="base_dn", type=str, default=None, help="base DN for search queries")


### PR DESCRIPTION
<!--
Branch:  feat/userenum-kerberoast-no-preauth  
Commit:  feat(ldap): add user enumeration and Kerberoasting with no-preauth user
-->

## Description

This PR adds **two new LDAP capabilities** to NetExec:

1. **New `--userenum` command**
   * Preserves word-list order (no random shuffle)
   * Displays precise Kerberos states: *Valid*, *AS-REP roastable*, *revoked/disabled*, etc.
   * Saves the output file in the same order as the input

2. **Kerberoasting with a *no-preauth* user**
   New flag `--no-preauth-user / -npu` lets you request TGS tickets directly with an account that has **“Do not require Kerberos pre-authentication”** (UF\_DONT\_REQUIRE\_PREAUTH).
   Machine accounts and **krbtgt** are automatically skipped and summarised.

No additional dependencies are required; everything relies on Impacket already bundled with NetExec.

---

## Type of change

* [x] New feature (non-breaking change which adds functionality)
* [ ] Bug fix
* [ ] Breaking change
* [ ] Documentation update
* [ ] Third party update

---

## Setup guide for the review

| Item        | Version / Info              |
| ----------- | --------------------------- |
| NetExec     | current `dev` + this branch |
| Python      | 3.11                        |
| Host OS     | Exegol nightly - v.9590653c                |
| Target DC   | Windows Server 2022 (20348) |
| Realm / KDC | AZOX.CORP (no TLS)          |

### How to test

1. **User enumeration**

   ```bash
   nxc ldap IP --userenum users.txt valid_users.txt
   ```

   Expected: ordered, colourised output (see ① & ②) and `valid_users.txt` containing 14 unique users.

2. **Kerberoast via no-preauth**

   ```bash
   nxc ldap IP -u valid_users.txt --no-preauth-user cdarwin --kerberoasting hashes.txt
   ```

   Expected: single *Skipping account: krbtgt, AZOX\$* line, *Total of records returned 1*, TGS hash saved (see ③).

No GPO / registry tweaks necessary; you only need one user (e.g. **cdarwin**) flagged *no pre-auth*.

---

## Screenshots

### ① `--userenum users.txt`
![1](https://github.com/user-attachments/assets/99214c0a-fc29-4fd6-b20b-795820d5d549)


---

### ② `--userenum users.txt valid_users.txt`
![2](https://github.com/user-attachments/assets/2952f267-d915-45fc-9fad-78375ae08797)


---

### ③ `--no-preauth-user` Kerberoast
![3](https://github.com/user-attachments/assets/49a7fbdd-49c9-4e96-8b51-834a73d1e68d)

---


## Checklist

* [ ] I have run **Ruff** (`poetry run python -m ruff check . --preview`)
* [ ] I have added/updated **tests/e2e\_commands.txt** if needed
* [ ] All e2e tests pass locally
* [ ] I linked any upstream PRs for third-party changes (if applicable)
* [ ] I performed a **self-review** of my code
* [ ] Code is commented where necessary
* [ ] I updated the documentation (PR to [https://github.com/Pennyw0rth/NetExec-Wiki](https://github.com/Pennyw0rth/NetExec-Wiki))

