### PR TITLE
Fix querying when non searchResultEntries are returned

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1070,6 +1070,8 @@ class ldap(connection):
             self.logger.fail(f"LDAP Filter Syntax Error: {e}")
             return
         for idx, entry in enumerate(resp_parsed):
+            if not isinstance(resp[idx], ldapasn1_impacket.SearchResultEntry):
+                idx += 1  # Skip non-entry responses
             self.logger.success(f"Response for object: {resp[idx]['objectName']}")
             for attribute in entry:
                 if isinstance(entry[attribute], list) and entry[attribute]:


### PR DESCRIPTION
## Description

Sometimes the raw result contains the `SearchResultReference` in the middle of the returned objects, instead at the end of the query. My theory is, that this happens when querying large domains with >1000 results, but AD always returns 1000 results in one answer, leading to a `SearchResultReference` in between the answers:
![image](https://github.com/user-attachments/assets/22539a40-1a53-4b16-aff6-3751b09ce02f)

Now, when hitting a non LDAP SearchResultEntry we skip it by incrementing the `idx` which is used to reference the raw object. This is the same as the ldap result parser handles non-SearchResultEntries which therefore should match in behavior (and idx).

Fixes #693 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Probably set up a domain and query >1000 objects at once
