### PR TITLE
Add efsr_spray module

### DIFF
--- a/nxc/modules/efsr_spray.py
+++ b/nxc/modules/efsr_spray.py
@@ -4,23 +4,6 @@ from nxc.context import Context
 from impacket.smb3structs import FILE_SHARE_WRITE, FILE_SHARE_DELETE, FILE_ATTRIBUTE_ENCRYPTED
 from impacket.smbconnection import SessionError, SMBConnection
 
-# Copy-pasta from protocols/smb.py
-smb_error_status = [
-    "STATUS_ACCOUNT_DISABLED",
-    "STATUS_ACCOUNT_EXPIRED",
-    "STATUS_ACCOUNT_RESTRICTION",
-    "STATUS_INVALID_LOGON_HOURS",
-    "STATUS_INVALID_WORKSTATION",
-    "STATUS_LOGON_TYPE_NOT_GRANTED",
-    "STATUS_PASSWORD_EXPIRED",
-    "STATUS_PASSWORD_MUST_CHANGE",
-    "STATUS_ACCESS_DENIED",
-    "STATUS_NO_SUCH_FILE",
-    "KDC_ERR_CLIENT_REVOKED",
-    "KDC_ERR_PREAUTH_FAILED",
-]
-
-
 def get_error_string(exception):
     if hasattr(exception, "getErrorString"):
         try:
@@ -63,7 +46,7 @@ class NXCModule:
             error = get_error_string(e)
             context.log.fail(
                 f"Error enumerating shares: {error}",
-                color="magenta" if error in smb_error_status else "red",
+                color="magenta",
             )
             return
 
@@ -78,7 +61,7 @@ class NXCModule:
             error = get_error_string(e)
             context.log.fail(
                 f"Error enumerating named pipes: {error}",
-                color="magenta" if error in smb_error_status else "red",
+                color="magenta",
             )
             return
 
@@ -126,6 +109,6 @@ class NXCModule:
             else:
                 context.log.fail(
                     f"Error waiting for named pipe: {error}",
-                    color="magenta" if error in smb_error_status else "red",
+                    color="magenta",
                 )
             return

--- a/nxc/modules/efsr_spray.py
+++ b/nxc/modules/efsr_spray.py
@@ -1,0 +1,131 @@
+import ntpath
+from nxc.helpers.misc import gen_random_string
+from nxc.context import Context
+from impacket.smb3structs import FILE_SHARE_WRITE, FILE_SHARE_DELETE, FILE_ATTRIBUTE_ENCRYPTED
+from impacket.smbconnection import SessionError, SMBConnection
+
+# Copy-pasta from protocols/smb.py
+smb_error_status = [
+    "STATUS_ACCOUNT_DISABLED",
+    "STATUS_ACCOUNT_EXPIRED",
+    "STATUS_ACCOUNT_RESTRICTION",
+    "STATUS_INVALID_LOGON_HOURS",
+    "STATUS_INVALID_WORKSTATION",
+    "STATUS_LOGON_TYPE_NOT_GRANTED",
+    "STATUS_PASSWORD_EXPIRED",
+    "STATUS_PASSWORD_MUST_CHANGE",
+    "STATUS_ACCESS_DENIED",
+    "STATUS_NO_SUCH_FILE",
+    "KDC_ERR_CLIENT_REVOKED",
+    "KDC_ERR_PREAUTH_FAILED",
+]
+
+
+def get_error_string(exception):
+    if hasattr(exception, "getErrorString"):
+        try:
+            es = exception.getErrorString()
+        except KeyError:
+            return f"Could not get nt error code {exception.getErrorCode()} from impacket: {exception}"
+        if type(es) is tuple:
+            return es[0]
+        else:
+            return es
+    else:
+        return str(exception)
+
+
+class NXCModule:
+    """EFSR Spray Module
+    Module by @rtpt-romankarwacik
+    """
+
+    name = "efsr_spray"
+    description = "Tries to activate the EFSR service by creating a file with the encryption attribute on some available share."
+    supported_protocols = ["smb"]
+    opsec_safe = True  # Does the module touch disk?
+    multiple_hosts = True  # Does the module support multiple hosts?
+
+    def options(self, context: Context, module_options: dict[str, str]):
+        """
+        FILE_NAME     Name of the file which will be tried to create and afterwards delete
+        SHARE_NAME    If set, ONLY this share will be used
+        """
+        self.file_name = module_options.get("FILE_NAME", ntpath.normpath("\\" + gen_random_string() + ".txt"))
+        self.share_name = module_options.get("SHARE_NAME")
+
+    def on_login(self, context: Context, connection):
+        conn: SMBConnection = connection.conn  # Because typing is broken due to smb being a folder and a file >:(
+
+        try:
+            shares = conn.listShares()
+        except SessionError as e:
+            error = get_error_string(e)
+            context.log.fail(
+                f"Error enumerating shares: {error}",
+                color="magenta" if error in smb_error_status else "red",
+            )
+            return
+
+        # Check if named pipe is already available
+        try:
+            named_pipe_names = [f.get_shortname() for f in conn.listPath("IPC$", "*")]
+            if "efsrpc" in named_pipe_names:
+                context.log.highlight("efsrpc named pipe is already available!")
+                # if it is already activated we just skip this computer
+                return
+        except SessionError as e:
+            error = get_error_string(e)
+            context.log.fail(
+                f"Error enumerating named pipes: {error}",
+                color="magenta" if error in smb_error_status else "red",
+            )
+            return
+
+        # Write an encrypted file on the share root.
+        # This will likely fail with STATUS_ACCESS_DENIED if we do not have the permission to create encrypted files,
+        # but this does not matter as the service will be activated nevertheless if we have WRITE or MODIFY access
+        for share in shares:
+            share_name = share["shi1_netname"][:-1]
+            if self.share_name is not None and self.share_name != share_name:
+                continue
+
+            try:
+                context.log.debug(f"Connecting to share {share_name}...")
+                tid = conn.connectTree(share_name)
+            except SessionError as e:
+                context.log.debug(f"Could not connect to share {share_name}: {e}")
+                continue
+            try:
+                context.log.debug(f"Creating file in {share_name}...")
+                fid = conn.createFile(tid, self.file_name,
+                                      desiredAccess=FILE_SHARE_WRITE,
+                                      shareMode=FILE_SHARE_DELETE,
+                                      fileAttributes=FILE_ATTRIBUTE_ENCRYPTED)
+                conn.closeFile(tid, fid)
+                try:
+                    # this can happen when we have special permissions to create encrypted files
+                    conn.deleteFile(share_name, self.file_name)
+                except SessionError as e:
+                    error = get_error_string(e)
+                    if error == "STATUS_OBJECT_NAME_NOT_FOUND":
+                        pass
+                    context.log.fail(f"Error DELETING created temp file {self.file_name} on share {share_name}: {error}")
+                    return
+            except SessionError as e:
+                context.log.debug(f"Error writing encrypted file on share {share_name}: {get_error_string(e)} (This does not necessarily mean that the attack failed!)")
+
+        try:
+            tid = conn.connectTree("IPC$")
+            conn.waitNamedPipe(tid, "efsrpc", 10)
+            context.log.highlight("Successfully activated efsrpc named pipe!")
+        except SessionError as e:
+            error = get_error_string(e)
+            if error == "STATUS_OBJECT_NAME_NOT_FOUND":
+                context.log.debug("efsrpc pipe was not activated.")
+            else:
+                context.log.fail(
+                    f"Error waiting for named pipe: {error}",
+                    color="magenta" if error in smb_error_status else "red",
+                )
+            return

--- a/nxc/modules/efsr_spray.py
+++ b/nxc/modules/efsr_spray.py
@@ -4,6 +4,7 @@ from nxc.context import Context
 from impacket.smb3structs import FILE_SHARE_WRITE, FILE_SHARE_DELETE, FILE_ATTRIBUTE_ENCRYPTED
 from impacket.smbconnection import SessionError, SMBConnection
 
+
 def get_error_string(exception):
     if hasattr(exception, "getErrorString"):
         try:
@@ -44,10 +45,7 @@ class NXCModule:
             shares = conn.listShares()
         except SessionError as e:
             error = get_error_string(e)
-            context.log.fail(
-                f"Error enumerating shares: {error}",
-                color="magenta",
-            )
+            context.log.fail(f"Error enumerating shares: {error}", color="magenta")
             return
 
         # Check if named pipe is already available
@@ -59,10 +57,7 @@ class NXCModule:
                 return
         except SessionError as e:
             error = get_error_string(e)
-            context.log.fail(
-                f"Error enumerating named pipes: {error}",
-                color="magenta",
-            )
+            context.log.fail(f"Error enumerating named pipes: {error}", color="magenta")
             return
 
         # Write an encrypted file on the share root.
@@ -107,8 +102,5 @@ class NXCModule:
             if error == "STATUS_OBJECT_NAME_NOT_FOUND":
                 context.log.debug("efsrpc pipe was not activated.")
             else:
-                context.log.fail(
-                    f"Error waiting for named pipe: {error}",
-                    color="magenta",
-                )
+                context.log.fail(f"Error waiting for named pipe: {error}", color="magenta")
             return

--- a/nxc/modules/efsr_spray.py
+++ b/nxc/modules/efsr_spray.py
@@ -96,7 +96,6 @@ class NXCModule:
                     if error == "STATUS_OBJECT_NAME_NOT_FOUND":
                         pass
                     context.log.fail(f"Error DELETING created temp file {self.file_name} on share {share_name}: {error}")
-                    return
             except SessionError as e:
                 context.log.debug(f"Error writing encrypted file on share {share_name}: {get_error_string(e)} (This does not necessarily mean that the attack failed!)")
 

--- a/nxc/modules/efsr_spray.py
+++ b/nxc/modules/efsr_spray.py
@@ -40,7 +40,7 @@ class NXCModule:
         self.file_name = module_options.get("FILE_NAME", ntpath.normpath("\\" + gen_random_string() + ".txt"))
         self.share_name = module_options.get("SHARE_NAME")
         if module_options.get("EXCLUDED_SHARES"):
-            self.excluded_shares += module_options.get("EXCLUDED_SHARES","").split(",")
+            self.excluded_shares += module_options.get("EXCLUDED_SHARES", "").split(",")
 
     def on_login(self, context: Context, connection):
         conn: SMBConnection = connection.conn  # Because typing is broken due to smb being a folder and a file >:(


### PR DESCRIPTION
## Description

Since Windows 11 23H2 the EFS service is only activated on demand. One ways to activate it is to write an encrypted file to a share on the respective device. This module automates this by trying to create an encrypted file on all available shares. In practice this works for any shares where the respective user has WRITE or MODIFY permissions, so print queues can also be used for this.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Setup guide for the review

Check on a up-to-date Windows 11 that the EFS service is disabled, and use the tool:

```
$ nxc smb -u rtpttest -p 'test1234!' -d lab.redteam --shares -- 192.0.2.115
SMB         192.0.2.115  445    WIN11VM          [*] Windows 11 Build 22621 x64 (name:WIN11VM) (domain:lab.redteam) (signing:False) (SMBv1:False)
SMB         192.0.2.115  445    WIN11VM          [+] lab.redteam\rtpttest:test1234!
SMB         192.0.2.115  445    WIN11VM          [*] Enumerated shares
SMB         192.0.2.115  445    WIN11VM          Share           Permissions     Remark
SMB         192.0.2.115  445    WIN11VM          -----           -----------     ------
SMB         192.0.2.115  445    WIN11VM          ADMIN$                          Remote Admin
SMB         192.0.2.115  445    WIN11VM          C$                              Default share
SMB         192.0.2.115  445    WIN11VM          IPC$            READ            Remote IPC
SMB         192.0.2.115  445    WIN11VM          PDFCreator      WRITE           PDFCreator Printer
SMB         192.0.2.115  445    WIN11VM          print$          READ            Printer Drivers


$ nxc smb -u rtpttest -p 'test1234!' -d lab.redteam -M efsr_spray -- 192.0.2.115
SMB         192.0.2.115  445    WIN11VM          [*] Windows 11 Build 22621 x64 (name:WIN11VM) (domain:lab.redteam) (signing:False) (SMBv1:False)
SMB         192.0.2.115  445    WIN11VM          [+] lab.redteam\rtpttest:test1234!
EFSR_SPRAY  192.0.2.115  445    WIN11VM          Successfully activated efsrpc named pipe!
```

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
