### PR TITLE
Move version log after file logger is attached

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -25,7 +25,6 @@ def gen_cli_args():
         COMMIT = ""
         DISTANCE = ""
     CODENAME = "SmoothOperator"
-    nxc_logger.debug(f"NXC VERSION: {VERSION} - {CODENAME} - {COMMIT} - {DISTANCE}")
 
     generic_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
     generic_group = generic_parser.add_argument_group("Generic", "Generic options for nxc across protocols")
@@ -133,7 +132,7 @@ def gen_cli_args():
     if hasattr(args, "get_output_tries"):
         args.get_output_tries = args.get_output_tries * 10
 
-    return args
+    return args, [CODENAME, VERSION, COMMIT, DISTANCE]
 
 
 def get_module_names():

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -69,7 +69,7 @@ async def start_run(protocol_obj, args, db, targets):  # noqa: RUF029
 
 def main():
     first_run_setup(nxc_logger)
-    args = gen_cli_args()
+    args, version_info = gen_cli_args()
 
     # if these are the same, it might double log to file (two FileHandlers will be added)
     # but this should never happen by accident
@@ -78,6 +78,8 @@ def main():
     if hasattr(args, "log") and args.log:
         nxc_logger.add_file_log(args.log)
 
+    CODENAME, VERSION, COMMIT, DISTANCE = version_info
+    nxc_logger.debug(f"NXC VERSION: {VERSION} - {CODENAME} - {COMMIT} - {DISTANCE}")
     nxc_logger.debug(f"PYTHON VERSION: {sys.version}")
     nxc_logger.debug(f"RUNNING ON: {platform.system()} Release: {platform.release()}")
     nxc_logger.debug(f"Passed args: {args}")


### PR DESCRIPTION
## Description

At the moment we first print log the version while parsing the args and then attach the file logger. This leads to the problem, that the version debug message is not in the log file, so we lose that info when someone sends the debug log.

We now pass the version info back when the args are parsed and print them after the file logger is attached.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):
Before:
![image](https://github.com/user-attachments/assets/97c4ace0-0fb3-474e-8424-90d388997c74)
After:
![image](https://github.com/user-attachments/assets/95ae5d5b-4276-463d-9bdf-3274dc82cfc9)
