### PR TITLE
Fixing --generate-hosts-file smb option

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -169,6 +169,7 @@ class smb(connection):
 
     def enum_host_info(self):
         self.local_ip = self.conn.getSMBServer().get_socket().getsockname()[0]
+        self.is_host_dc()
 
         try:
             self.conn.login("", "")
@@ -190,7 +191,7 @@ class smb(connection):
         else:
             try:
                 # If we know the host is a DC we can still get the hostname over LDAP if NTLM is not available
-                if self.is_host_dc() and detect_if_ip(self.host):
+                if self.isdc and detect_if_ip(self.host):
                     self.hostname, self.domain = LDAPResolution(self.host).get_resolution()
                     self.targetDomain = self.domain
                 # If we can't authenticate with NTLM and the target is supplied as a FQDN we must parse it


### PR DESCRIPTION
## Description

Moved `is_host_dc` check to beginning of enum_host_info so it would be picked up by `--generate-hosts-file` option.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots:

Before change:

![image](https://github.com/user-attachments/assets/8fd3044b-f5b4-4a18-a3ce-7287165321a6)

Domain is not included in hosts file due to is_host_dc not being checked during NTLM authentication so it is never set to true.

After change:

![image](https://github.com/user-attachments/assets/f419404c-9cbe-40c7-abe0-1c6399b33d1c)

Domain is included in hosts file as expected.

## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
