### PR TITLE
Database rework

### DIFF
--- a/nxc/database.py
+++ b/nxc/database.py
@@ -6,13 +6,15 @@ from os import mkdir
 from os.path import exists
 from os.path import join as path_join
 from pathlib import Path
-from sqlite3 import connect
 from threading import Lock
 
-from sqlalchemy import create_engine, MetaData, func
-from sqlalchemy.exc import IllegalStateChangeError
+from sqlalchemy import Table, create_engine, MetaData, func
+from sqlalchemy.exc import (
+    IllegalStateChangeError,
+    NoInspectionAvailable,
+    NoSuchTableError,
+)
 from sqlalchemy.orm import sessionmaker, scoped_session
-
 from nxc.loaders.protocolloader import ProtocolLoader
 from nxc.logger import nxc_logger
 from nxc.paths import WORKSPACE_DIR
@@ -57,25 +59,15 @@ def init_protocol_dbs(workspace_name, p_loader=None):
     if p_loader is None:
         p_loader = ProtocolLoader()
     protocols = p_loader.get_protocols()
-
     for protocol in protocols:
         protocol_object = p_loader.load_protocol(protocols[protocol]["dbpath"])
         proto_db_path = path_join(WORKSPACE_DIR, workspace_name, f"{protocol}.db")
 
         if not exists(proto_db_path):
             print(f"[*] Initializing {protocol.upper()} protocol database")
-            conn = connect(proto_db_path)
-            c = conn.cursor()
-
-            # try to prevent some weird sqlite I/O errors
-            c.execute("PRAGMA journal_mode = OFF")
-            c.execute("PRAGMA foreign_keys = 1")
-
-            protocol_object.database.db_schema(c)
-
-            # commit the changes and close everything off
-            conn.commit()
-            conn.close()
+            db_engine = create_db_engine(proto_db_path)
+            protocol_object.database.db_schema(db_engine)
+            db_engine.dispose()
 
 
 def create_workspace(workspace_name, p_loader=None):
@@ -158,6 +150,35 @@ class BaseDB:
 
     def reflect_tables(self):
         raise NotImplementedError("Reflect tables not implemented")
+    
+    def reflect_table(self, table):
+        with self.db_engine.connect():
+            try:
+                reflected_table = Table(table.__tablename__, self.metadata, autoload_with=self.db_engine)
+                
+                # Check for column addition / deletion
+                reflected_columns = set(reflected_table.columns.keys())
+                orm_columns = {column.name for column in table.__table__.columns}
+                if reflected_columns != orm_columns:
+                    raise ValueError(f"Schema mismatch detected! ORM columns: {orm_columns}, Reflected columns: {reflected_columns}")
+                
+                # Check for constraint changes
+                reflected_constraints = [(type(c), c.columns.keys()) for c in reflected_table._sorted_constraints] 
+                orm_constraints = [(type(c), c.columns.keys()) for c in table.__table__._sorted_constraints] 
+                if reflected_constraints != orm_constraints:
+                    raise ValueError(f"Schema mismatch detected! ORM constraints: {orm_constraints}, Reflected constraints: {reflected_constraints}")
+                
+                return reflected_table
+            except (NoInspectionAvailable, NoSuchTableError, ValueError) as e:
+                print(e)
+                print(
+                    f"""
+                    [-] Error reflecting table {table.__tablename__} for the {self.protocol} protocol - this means there is a DB schema mismatch
+                    [-] This is probably because a newer version of nxc is being run on an old DB schema
+                    [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
+                    [-] Then remove the {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""
+                )
+                sys.exit()
 
     def shutdown_db(self):
         try:

--- a/nxc/database.py
+++ b/nxc/database.py
@@ -170,10 +170,10 @@ class BaseDB:
                 
                 return reflected_table
             except (NoInspectionAvailable, NoSuchTableError, ValueError) as e:
-                print(e)
                 print(
                     f"""
-                    [-] Error reflecting table {table.__tablename__} for the {self.protocol} protocol - this means there is a DB schema mismatch
+                    [-] Error reflecting table {table.__tablename__} for the {self.protocol} protocol:
+                    [-] {e} - This means there is a DB schema mismatch
                     [-] This is probably because a newer version of nxc is being run on an old DB schema
                     [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
                     [-] Then remove the {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""

--- a/nxc/protocols/ftp/database.py
+++ b/nxc/protocols/ftp/database.py
@@ -1,14 +1,12 @@
-import sys
 
-from sqlalchemy import Table, select, delete, func
+from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, select, delete, func
 from sqlalchemy.dialects.sqlite import Insert
-from sqlalchemy.exc import (
-    NoInspectionAvailable,
-    NoSuchTableError,
-)
+from sqlalchemy.ext.declarative import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger
+
+Base = declarative_base()
 
 
 class database(BaseDB):
@@ -19,58 +17,59 @@ class database(BaseDB):
 
         super().__init__(db_engine)
 
+    class Credential(Base):
+        __tablename__ = "credentials"
+        id = Column(Integer)
+        username = Column(String)
+        password = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+
+    class Host(Base):
+        __tablename__ = "hosts"
+        id = Column(Integer)
+        host = Column(String)
+        port = Column(Integer)
+        banner = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+
+    class LoggedInRelation(Base):
+        __tablename__ = "loggedin_relations"
+        id = Column(Integer)
+        credid = Column(Integer)
+        hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["credid"], ["credentials.id"]),
+            ForeignKeyConstraint(["hostid"], ["hosts.id"]),
+        )
+
+    class DirectoryListing(Base):
+        __tablename__ = "directory_listings"
+        id = Column(Integer)
+        lir_id = Column(Integer)
+        data = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["lir_id"], ["loggedin_relations.id"]),
+        )
+        
     @staticmethod
     def db_schema(db_conn):
-        db_conn.execute(
-            """CREATE TABLE "credentials" (
-            "id" integer PRIMARY KEY,
-            "username" text,
-            "password" text
-            )"""
-        )
-
-        db_conn.execute(
-            """CREATE TABLE "hosts" (
-            "id" integer PRIMARY KEY,
-            "host" text,
-            "port" integer,
-            "banner" text
-            )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "loggedin_relations" (
-            "id" integer PRIMARY KEY,
-            "credid" integer,
-            "hostid" integer,
-            FOREIGN KEY(credid) REFERENCES credentials(id),
-            FOREIGN KEY(hostid) REFERENCES hosts(id)
-        )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "directory_listings" (
-            "id" integer PRIMARY KEY,
-            "lir_id" integer,
-            "data" text,
-            FOREIGN KEY(lir_id) REFERENCES loggedin_relations(id)
-        )"""
-        )
+        Base.metadata.create_all(db_conn)
 
     def reflect_tables(self):
-        with self.db_engine.connect():
-            try:
-                self.CredentialsTable = Table("credentials", self.metadata, autoload_with=self.db_engine)
-                self.HostsTable = Table("hosts", self.metadata, autoload_with=self.db_engine)
-                self.LoggedinRelationsTable = Table("loggedin_relations", self.metadata, autoload_with=self.db_engine)
-                self.DirectoryListingsTable = Table("directory_listings", self.metadata, autoload_with=self.db_engine)
-            except (NoInspectionAvailable, NoSuchTableError):
-                print(
-                    f"""
-                    [-] Error reflecting tables for the {self.protocol} protocol - this means there is a DB schema mismatch
-                    [-] This is probably because a newer version of nxc is being run on an old DB schema
-                    [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
-                    [-] Then remove the {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""
-                )
-                sys.exit()
+        self.CredentialsTable = self.reflect_table(self.Credential)
+        self.HostsTable = self.reflect_table(self.Host)
+        self.LoggedinRelationsTable = self.reflect_table(self.LoggedInRelation)
+        self.DirectoryListingsTable = self.reflect_table(self.DirectoryListing)
 
     def add_host(self, host, port, banner):
         """Check if this host is already in the DB, if not add it"""

--- a/nxc/protocols/mssql/database.py
+++ b/nxc/protocols/mssql/database.py
@@ -1,15 +1,17 @@
-import sys
 import warnings
 
-from sqlalchemy import func, select, insert, update, delete, Table
+from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, func, select, insert, update, delete
 from sqlalchemy.dialects.sqlite import Insert  # used for upsert
-from sqlalchemy.exc import SAWarning, NoInspectionAvailable, NoSuchTableError
+from sqlalchemy.exc import SAWarning
+from sqlalchemy.ext.declarative import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger
 
 # if there is an issue with SQLAlchemy and a connection cannot be cleaned up properly it spews out annoying warnings
 warnings.filterwarnings("ignore", category=SAWarning)
+
+Base = declarative_base()
 
 
 class database(BaseDB):
@@ -20,55 +22,53 @@ class database(BaseDB):
 
         super().__init__(db_engine)
 
-    @staticmethod
-    def db_schema(db_conn):
-        db_conn.execute(
-            """CREATE TABLE "hosts" (
-            "id" integer PRIMARY KEY,
-            "ip" text,
-            "hostname" text,
-            "domain" text,
-            "os" text,
-            "instances" integer
-            )"""
-        )
-        # This table keeps track of which credential has admin access over which machine and vice-versa
-        db_conn.execute(
-            """CREATE TABLE "admin_relations" (
-            "id" integer PRIMARY KEY,
-            "userid" integer,
-            "hostid" integer,
-            FOREIGN KEY(userid) REFERENCES users(id),
-            FOREIGN KEY(hostid) REFERENCES hosts(id)
-            )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "users" (
-            "id" integer PRIMARY KEY,
-            "credtype" text,
-            "domain" text,
-            "username" text,
-            "password" text,
-            "pillaged_from_hostid" integer,
-            FOREIGN KEY(pillaged_from_hostid) REFERENCES hosts(id)
-            )"""
+    class Host(Base):
+        __tablename__ = "hosts"
+        id = Column(Integer)
+        ip = Column(String)
+        hostname = Column(String)
+        domain = Column(String)
+        os = Column(String)
+        instances = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
         )
 
+    class AdminRelation(Base):
+        __tablename__ = "admin_relations"
+        id = Column(Integer)
+        userid = Column(Integer)
+        hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["userid"], ["users.id"]),
+            ForeignKeyConstraint(["hostid"], ["hosts.id"]),
+        )
+   
+    class User(Base):
+        __tablename__ = "users"
+        id = Column(Integer)
+        credtype = Column(String)
+        domain = Column(String)
+        username = Column(String)
+        password = Column(String)
+        pillaged_from_hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["pillaged_from_hostid"], ["hosts.id"]),
+        )
+
+    @staticmethod
+    def db_schema(db_conn):
+        Base.metadata.create_all(db_conn)
+
     def reflect_tables(self):
-        with self.db_engine.connect():
-            try:
-                self.HostsTable = Table("hosts", self.metadata, autoload_with=self.db_engine)
-                self.UsersTable = Table("users", self.metadata, autoload_with=self.db_engine)
-                self.AdminRelationsTable = Table("admin_relations", self.metadata, autoload_with=self.db_engine)
-            except (NoInspectionAvailable, NoSuchTableError):
-                print(
-                    f"""
-                    [-] Error reflecting tables for the {self.protocol} protocol - this means there is a DB schema mismatch
-                    [-] This is probably because a newer version of nxc is being run on an old DB schema
-                    [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
-                    [-] Then remove the {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""
-                )
-                sys.exit()
+        self.HostsTable = self.reflect_table(self.Host)
+        self.UsersTable = self.reflect_table(self.User)
+        self.AdminRelationsTable = self.reflect_table(self.AdminRelation)
 
     def add_host(self, ip, hostname, domain, os, instances):
         """

--- a/nxc/protocols/rdp/database.py
+++ b/nxc/protocols/rdp/database.py
@@ -1,12 +1,10 @@
-import sys
 
-from sqlalchemy import Table
-from sqlalchemy.exc import (
-    NoInspectionAvailable,
-    NoSuchTableError,
-)
+from sqlalchemy import Column, Integer, PrimaryKeyConstraint, String
+from sqlalchemy.ext.declarative import declarative_base
 
 from nxc.database import BaseDB
+
+Base = declarative_base()
 
 
 class database(BaseDB):
@@ -16,38 +14,33 @@ class database(BaseDB):
 
         super().__init__(db_engine)
 
+    class Credential(Base):
+        __tablename__ = "credentials"
+        id = Column(Integer)
+        username = Column(String)
+        password = Column(String)
+        pkey = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+
+    class Host(Base):
+        __tablename__ = "hosts"
+        id = Column(Integer)
+        ip = Column(String)
+        hostname = Column(String)
+        port = Column(Integer)
+        server_banner = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+        
     @staticmethod
     def db_schema(db_conn):
-        db_conn.execute(
-            """CREATE TABLE "credentials" (
-            "id" integer PRIMARY KEY,
-            "username" text,
-            "password" text,
-            "pkey" text
-            )"""
-        )
-
-        db_conn.execute(
-            """CREATE TABLE "hosts" (
-            "id" integer PRIMARY KEY,
-            "ip" text,
-            "hostname" text,
-            "port" integer,
-            "server_banner" text
-            )"""
-        )
+        Base.metadata.create_all(db_conn)
 
     def reflect_tables(self):
-        with self.db_engine.connect():
-            try:
-                self.CredentialsTable = Table("credentials", self.metadata, autoload_with=self.db_engine)
-                self.HostsTable = Table("hosts", self.metadata, autoload_with=self.db_engine)
-            except (NoInspectionAvailable, NoSuchTableError):
-                print(
-                    f"""
-                    [-] Error reflecting tables for the {self.protocol} protocol - this means there is a DB schema mismatch
-                    [-] This is probably because a newer version of nxc is being run on an old DB schema
-                    [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
-                    [-] Then remove the {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""
-                )
-                sys.exit()
+        self.CredentialsTable = self.reflect_table(self.Credential)
+        self.HostsTable = self.reflect_table(self.Host)

--- a/nxc/protocols/smb/database.py
+++ b/nxc/protocols/smb/database.py
@@ -1,21 +1,22 @@
 import base64
-import sys
+import threading
 import warnings
 from datetime import datetime
 
-from sqlalchemy import func, Table, select, delete
+from sqlalchemy import Boolean, Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, UniqueConstraint, func, select, delete
 from sqlalchemy.dialects.sqlite import Insert  # used for upsert
 from sqlalchemy.exc import (
-    NoInspectionAvailable,
-    NoSuchTableError,
+    SAWarning
 )
-from sqlalchemy.exc import SAWarning
+from sqlalchemy.ext.declarative import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger
 
 # if there is an issue with SQLAlchemy and a connection cannot be cleaned up properly it spews out annoying warnings
 warnings.filterwarnings("ignore", category=SAWarning)
+
+BaseTable = declarative_base()
 
 
 class database(BaseDB):
@@ -29,173 +30,180 @@ class database(BaseDB):
         self.LoggedinRelationsTable = None
         self.ConfChecksTable = None
         self.ConfChecksResultsTable = None
-        self.DpapiBackupkey = None
-        self.DpapiSecrets = None
+        self.DpapiBackupkeyTable = None
+        self.DpapiSecretsTable = None
+
+        self._lock = threading.Lock()
 
         super().__init__(db_engine)
 
+    # Table declaration
+
+    class Host(BaseTable):
+        __tablename__ = "hosts"
+        id = Column(Integer)
+        ip = Column(String)
+        hostname = Column(String)
+        domain = Column(String)
+        os = Column(String)
+        dc = Column(Boolean)
+        smbv1 = Column(Boolean)
+        signing = Column(Boolean)
+        spooler = Column(Boolean)
+        zerologon = Column(Boolean)
+        petitpotam = Column(Boolean)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            UniqueConstraint("ip"),
+        )
+
+    class ConfCheck(BaseTable):
+        __tablename__ = "conf_checks"
+        id = Column(Integer)
+        name = Column(String)
+        description = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+
+    class ConfCheckResult(BaseTable):
+        __tablename__ = "conf_checks_results"
+        id = Column(Integer)
+        host_id = Column(Integer)
+        check_id = Column(Integer)
+        secure = Column(Boolean)
+        reasons = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["host_id"], ["hosts.id"]),
+            ForeignKeyConstraint(["check_id"], ["conf_checks.id"]),
+        )
+
+    class User(BaseTable):
+        __tablename__ = "users"
+        id = Column(Integer)
+        domain = Column(String)
+        username = Column(String)
+        password = Column(String)
+        credtype = Column(String)
+        pillaged_from_hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["pillaged_from_hostid"], ["hosts.id"]),
+        )
+
+    class Group(BaseTable):
+        __tablename__ = "groups"
+        id = Column(Integer)
+        domain = Column(String)
+        name = Column(String)
+        rid = Column(String)
+        member_count_ad = Column(Integer)
+        last_query_time = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+
+    class AdminRelation(BaseTable):
+        __tablename__ = "admin_relations"
+        id = Column(Integer)
+        userid = Column(Integer)
+        hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["userid"], ["users.id"]),
+            ForeignKeyConstraint(["hostid"], ["hosts.id"]),
+        )
+
+    class GroupRelation(BaseTable):
+        __tablename__ = "group_relations"
+        id = Column(Integer)
+        userid = Column(Integer)
+        groupid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["userid"], ["users.id"]),
+            ForeignKeyConstraint(["groupid"], ["groups.id"]),
+        )
+
+    class Share(BaseTable):
+        __tablename__ = "shares"
+        id = Column(Integer)
+        hostid = Column(Integer)
+        userid = Column(Integer)
+        name = Column(String)
+        remark = Column(String)
+        read = Column(Boolean)
+        write = Column(Boolean)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["hostid"], ["hosts.id"]),
+            ForeignKeyConstraint(["userid"], ["users.id"]),
+            UniqueConstraint("hostid", "userid", "name"),
+        )
+
+    class LoggedInRelation(BaseTable):
+        __tablename__ = "loggedin_relations"
+        id = Column(Integer)
+        userid = Column(Integer)
+        hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["userid"], ["users.id"]),
+            ForeignKeyConstraint(["hostid"], ["hosts.id"]),
+        )
+    
+    class DpapiSecret(BaseTable):
+        __tablename__ = "dpapi_secrets"
+        id = Column(Integer)
+        host = Column(String)
+        dpapi_type = Column(String)
+        windows_user = Column(String)
+        username = Column(String)
+        password = Column(String)
+        url = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            UniqueConstraint("host", "dpapi_type", "windows_user", "username", "password", "url"),
+        )
+
+    class DpapiBackupKey(BaseTable):
+        __tablename__ = "dpapi_backupkey"
+        id = Column(Integer)
+        domain = Column(String)
+        pvk = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            UniqueConstraint("domain"),
+        )
+
     @staticmethod
     def db_schema(db_conn):
-        db_conn.execute(
-            """CREATE TABLE "hosts" (
-            "id" integer PRIMARY KEY,
-            "ip" text UNIQUE,
-            "hostname" text,
-            "domain" text,
-            "os" text,
-            "dc" boolean,
-            "smbv1" boolean,
-            "signing" boolean,
-            "spooler" boolean,
-            "zerologon" boolean,
-            "petitpotam" boolean
-            )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "conf_checks" (
-            "id" integer PRIMARY KEY,
-            "name" text,
-            "description" text
-            )"""
-        )
-
-        db_conn.execute(
-            """CREATE TABLE "conf_checks_results" (
-            "id" integer PRIMARY KEY,
-            "host_id" integer,
-            "check_id" integer,
-            "secure" boolean,
-            "reasons" text,
-            FOREIGN KEY(host_id) REFERENCES hosts(id),
-            FOREIGN KEY(check_id) REFERENCES conf_checks(id)
-            )
-            """
-        )
-
-        db_conn.execute(
-            """CREATE TABLE "users" (
-            "id" integer PRIMARY KEY,
-            "domain" text,
-            "username" text,
-            "password" text,
-            "credtype" text,
-            "pillaged_from_hostid" integer,
-            FOREIGN KEY(pillaged_from_hostid) REFERENCES hosts(id)
-            )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "groups" (
-            "id" integer PRIMARY KEY,
-            "domain" text,
-            "name" text,
-            "rid" text,
-            "member_count_ad" integer,
-            "last_query_time" text
-            )"""
-        )
-        # This table keeps track of which credential has admin access over which machine and vice-versa
-        db_conn.execute(
-            """CREATE TABLE "admin_relations" (
-            "id" integer PRIMARY KEY,
-            "userid" integer,
-            "hostid" integer,
-            FOREIGN KEY(userid) REFERENCES users(id),
-            FOREIGN KEY(hostid) REFERENCES hosts(id)
-            )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "group_relations" (
-            "id" integer PRIMARY KEY,
-            "userid" integer,
-            "groupid" integer,
-            FOREIGN KEY(userid) REFERENCES users(id),
-            FOREIGN KEY(groupid) REFERENCES groups(id)
-            )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "shares" (
-            "id" integer PRIMARY KEY,
-            "hostid" text,
-            "userid" integer,
-            "name" text,
-            "remark" text,
-            "read" boolean,
-            "write" boolean,
-            FOREIGN KEY(userid) REFERENCES users(id)
-            UNIQUE(hostid, userid, name)
-        )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "loggedin_relations" (
-            "id" integer PRIMARY KEY,
-            "userid" integer,
-            "hostid" integer,
-            FOREIGN KEY(userid) REFERENCES users(id),
-            FOREIGN KEY(hostid) REFERENCES hosts(id)
-        )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "dpapi_secrets" (
-            "id" integer PRIMARY KEY,
-            "host" text,
-            "dpapi_type" text,
-            "windows_user" text,
-            "username" text,
-            "password" text,
-            "url" text,
-            UNIQUE(host, dpapi_type, windows_user, username, password, url)
-        )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "dpapi_backupkey" (
-            "id" integer PRIMARY KEY,
-            "domain" text,
-            "pvk" text,
-            UNIQUE(domain)
-        )"""
-        )
-        # db_conn.execute('''CREATE TABLE "ntds_dumps" (
-        #    "id" integer PRIMARY KEY,
-        #    "hostid", integer,
-        #    "domain" text,
-        #    "username" text,
-        #    "hash" text,
-        #    FOREIGN KEY(hostid) REFERENCES hosts(id)
-        #    )''')
+        BaseTable.metadata.create_all(db_conn)
 
     def reflect_tables(self):
-        with self.db_engine.connect():
-            try:
-                self.HostsTable = Table("hosts", self.metadata, autoload_with=self.db_engine)
-                self.UsersTable = Table("users", self.metadata, autoload_with=self.db_engine)
-                self.GroupsTable = Table("groups", self.metadata, autoload_with=self.db_engine)
-                self.SharesTable = Table("shares", self.metadata, autoload_with=self.db_engine)
-                self.AdminRelationsTable = Table("admin_relations", self.metadata, autoload_with=self.db_engine)
-                self.GroupRelationsTable = Table("group_relations", self.metadata, autoload_with=self.db_engine)
-                self.LoggedinRelationsTable = Table("loggedin_relations", self.metadata, autoload_with=self.db_engine)
-                self.DpapiSecrets = Table("dpapi_secrets", self.metadata, autoload_with=self.db_engine)
-                self.DpapiBackupkey = Table("dpapi_backupkey", self.metadata, autoload_with=self.db_engine)
-                self.ConfChecksTable = Table("conf_checks", self.metadata, autoload_with=self.db_engine)
-                self.ConfChecksResultsTable = Table("conf_checks_results", self.metadata, autoload_with=self.db_engine)
-
-                # Check if Database Schema is correct, due to hanging issues reported on discord introduced by https://github.com/Pennyw0rth/NetExec/pull/658
-                from sqlalchemy.schema import UniqueConstraint
-                ip_is_unique = False
-                for constraint in self.HostsTable.constraints:
-                    if isinstance(constraint, UniqueConstraint) and constraint.columns[0].name == "ip":
-                        ip_is_unique = True
-                        break
-                if not ip_is_unique:
-                    raise NoSuchTableError("ip is not unique in hosts table")
-            except (NoInspectionAvailable, NoSuchTableError):
-                print(
-                    f"""
-                    [-] Error reflecting tables for the {self.protocol} protocol - this means there is a DB schema mismatch
-                    [-] This is probably because a newer version of nxc is being run on an old DB schema
-                    [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
-                    [-] Then remove the {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""
-                )
-                sys.exit()
+        self.HostsTable = self.reflect_table(self.Host)
+        self.UsersTable = self.reflect_table(self.User)
+        self.GroupsTable = self.reflect_table(self.Group)
+        self.SharesTable = self.reflect_table(self.Share)
+        self.AdminRelationsTable = self.reflect_table(self.AdminRelation)
+        self.GroupRelationsTable = self.reflect_table(self.GroupRelation)
+        self.LoggedinRelationsTable = self.reflect_table(self.LoggedInRelation)
+        self.DpapiSecretsTable = self.reflect_table(self.DpapiSecret)
+        self.DpapiBackupkeyTable = self.reflect_table(self.DpapiBackupKey)
+        self.ConfChecksTable = self.reflect_table(self.ConfCheck)
+        self.ConfChecksResultsTable = self.reflect_table(self.ConfCheckResult)
 
     # pull/545
     def add_host(
@@ -688,7 +696,7 @@ class database(BaseDB):
         :domain is the domain fqdn
         :pvk is the domain backupkey
         """
-        q = select(self.DpapiBackupkey).filter(func.lower(self.DpapiBackupkey.c.domain) == func.lower(domain))
+        q = select(self.DpapiBackupkeyTable).filter(func.lower(self.DpapiBackupkeyTable.c.domain) == func.lower(domain))
         results = self.db_execute(q).all()
 
         if not len(results):
@@ -696,7 +704,7 @@ class database(BaseDB):
             backup_key = {"domain": domain, "pvk": pvk_encoded}
             try:
                 # TODO: find a way to abstract this away to a single Upsert call
-                q = Insert(self.DpapiBackupkey)  # .returning(self.DpapiBackupkey.c.id)
+                q = Insert(self.DpapiBackupkeyTable)  # .returning(self.DpapiBackupkeyTable.c.id)
 
                 self.db_execute(q, [backup_key])  # .scalar()
                 nxc_logger.debug(f"add_domain_backupkey(domain={domain}, pvk={pvk_encoded})")
@@ -708,9 +716,9 @@ class database(BaseDB):
         Get domain backupkey
         :domain is the domain fqdn
         """
-        q = select(self.DpapiBackupkey)
+        q = select(self.DpapiBackupkeyTable)
         if domain is not None:
-            q = q.filter(func.lower(self.DpapiBackupkey.c.domain) == func.lower(domain))
+            q = q.filter(func.lower(self.DpapiBackupkeyTable.c.domain) == func.lower(domain))
         results = self.db_execute(q).all()
 
         nxc_logger.debug(f"get_domain_backupkey(domain={domain}) => {results}")
@@ -724,7 +732,7 @@ class database(BaseDB):
         Check if this group ID is valid.
         :dpapi_secret_id is a primary id
         """
-        q = select(self.DpapiSecrets).filter(func.lower(self.DpapiSecrets.c.id) == dpapi_secret_id)
+        q = select(self.DpapiSecretsTable).filter(func.lower(self.DpapiSecretsTable.c.id) == dpapi_secret_id)
         results = self.db_execute(q).first()
         valid = results is not None
         nxc_logger.debug(f"is_dpapi_secret_valid(groupID={dpapi_secret_id}) => {valid}")
@@ -748,7 +756,7 @@ class database(BaseDB):
             "password": password,
             "url": url,
         }
-        q = Insert(self.DpapiSecrets).on_conflict_do_nothing()  # .returning(self.DpapiSecrets.c.id)
+        q = Insert(self.DpapiSecretsTable).on_conflict_do_nothing()  # .returning(self.DpapiSecretsTable.c.id)
 
         self.db_execute(q, [secret])  # .scalar()
 
@@ -765,28 +773,28 @@ class database(BaseDB):
         url: str | None = None,
     ):
         """Get dpapi secrets from nxcdb"""
-        q = select(self.DpapiSecrets)
+        q = select(self.DpapiSecretsTable)
 
         if self.is_dpapi_secret_valid(filter_term):
-            q = q.filter(self.DpapiSecrets.c.id == filter_term)
+            q = q.filter(self.DpapiSecretsTable.c.id == filter_term)
             results = self.db_execute(q).first()
             # all() returns a list, so we keep the return format the same so consumers don't have to guess
             return [results]
         elif host:
-            q = q.filter(self.DpapiSecrets.c.host == host)
+            q = q.filter(self.DpapiSecretsTable.c.host == host)
             results = self.db_execute(q).first()
             # all() returns a list, so we keep the return format the same so consumers don't have to guess
             return [results]
         elif dpapi_type:
-            q = q.filter(func.lower(self.DpapiSecrets.c.dpapi_type) == func.lower(dpapi_type))
+            q = q.filter(func.lower(self.DpapiSecretsTable.c.dpapi_type) == func.lower(dpapi_type))
         elif windows_user:
             like_term = func.lower(f"%{windows_user}%")
-            q = q.filter(func.lower(self.DpapiSecrets.c.windows_user).like(like_term))
+            q = q.filter(func.lower(self.DpapiSecretsTable.c.windows_user).like(like_term))
         elif username:
             like_term = func.lower(f"%{username}%")
-            q = q.filter(func.lower(self.DpapiSecrets.c.windows_user).like(like_term))
+            q = q.filter(func.lower(self.DpapiSecretsTable.c.windows_user).like(like_term))
         elif url:
-            q = q.filter(func.lower(self.DpapiSecrets.c.url) == func.lower(url))
+            q = q.filter(func.lower(self.DpapiSecretsTable.c.url) == func.lower(url))
         results = self.db_execute(q).all()
 
         nxc_logger.debug(f"get_dpapi_secrets(filter_term={filter_term}, host={host}, dpapi_type={dpapi_type}, windows_user={windows_user}, username={username}, url={url}) => {results}")

--- a/nxc/protocols/ssh/database.py
+++ b/nxc/protocols/ssh/database.py
@@ -1,13 +1,9 @@
 import configparser
 import os
-import sys
 
-from sqlalchemy import Table, select, func, delete
+from sqlalchemy import Boolean, Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, select, func, delete
 from sqlalchemy.dialects.sqlite import Insert
-from sqlalchemy.exc import (
-    NoInspectionAvailable,
-    NoSuchTableError,
-)
+from sqlalchemy.ext.declarative import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger
@@ -17,6 +13,8 @@ from nxc.paths import NXC_PATH
 nxc_config = configparser.ConfigParser()
 nxc_config.read(os.path.join(NXC_PATH, "nxc.conf"))
 nxc_workspace = nxc_config.get("nxc", "workspace", fallback="default")
+
+Base = declarative_base()
 
 
 class database(BaseDB):
@@ -29,71 +27,76 @@ class database(BaseDB):
 
         super().__init__(db_engine)
 
-    @staticmethod
-    def db_schema(db_conn):
-        db_conn.execute(
-            """CREATE TABLE "credentials" (
-            "id" integer PRIMARY KEY,
-            "username" text,
-            "password" text,
-            "credtype" text
-        )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "hosts" (
-            "id" integer PRIMARY KEY,
-            "host" text,
-            "port" integer,
-            "banner" text,
-            "os" text
-        )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "loggedin_relations" (
-            "id" integer PRIMARY KEY,
-            "credid" integer,
-            "hostid" integer,
-            "shell" boolean,
-            FOREIGN KEY(credid) REFERENCES credentials(id),
-            FOREIGN KEY(hostid) REFERENCES hosts(id)
-        )"""
-        )
-        # "admin" access with SSH means we have root access, which implies shell access since we run commands to check
-        db_conn.execute(
-            """CREATE TABLE "admin_relations" (
-            "id" integer PRIMARY KEY,
-            "credid" integer,
-            "hostid" integer,
-            FOREIGN KEY(credid) REFERENCES credentials(id),
-            FOREIGN KEY(hostid) REFERENCES hosts(id)
-        )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "keys" (
-            "id" integer PRIMARY KEY,
-            "credid" integer,
-            "data" text,
-            FOREIGN KEY(credid) REFERENCES credentials(id)
-        )"""
+    class Credential(Base):
+        __tablename__ = "credentials"
+        id = Column(Integer)
+        username = Column(String)
+        password = Column(String)
+        credtype = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
         )
 
+    class Host(Base):
+        __tablename__ = "hosts"
+        id = Column(Integer)
+        host = Column(String)
+        port = Column(Integer)
+        banner = Column(String)
+        os = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+
+    class LoggedInRelation(Base):
+        __tablename__ = "loggedin_relations"
+        id = Column(Integer)
+        credid = Column(Integer)
+        hostid = Column(Integer)
+        shell = Column(Boolean)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["credid"], ["credentials.id"]),
+            ForeignKeyConstraint(["hostid"], ["hosts.id"]),
+        )
+
+    # "admin" access with SSH means we have root access, which implies shell access since we run commands to check
+    class AdminRelation(Base):
+        __tablename__ = "admin_relations"
+        id = Column(Integer)
+        credid = Column(Integer)
+        hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["credid"], ["credentials.id"]),
+            ForeignKeyConstraint(["hostid"], ["hosts.id"]),
+        )
+
+    class Key(Base):
+        __tablename__ = "keys"
+        id = Column(Integer)
+        credid = Column(Integer)
+        data = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["credid"], ["credentials.id"]),
+        )
+
+    @staticmethod
+    def db_schema(db_conn):
+        Base.metadata.create_all(db_conn)
+
     def reflect_tables(self):
-        with self.db_engine.connect():
-            try:
-                self.CredentialsTable = Table("credentials", self.metadata, autoload_with=self.db_engine)
-                self.HostsTable = Table("hosts", self.metadata, autoload_with=self.db_engine)
-                self.LoggedinRelationsTable = Table("loggedin_relations", self.metadata, autoload_with=self.db_engine)
-                self.AdminRelationsTable = Table("admin_relations", self.metadata, autoload_with=self.db_engine)
-                self.KeysTable = Table("keys", self.metadata, autoload_with=self.db_engine)
-            except (NoInspectionAvailable, NoSuchTableError):
-                print(
-                    f"""
-                    [-] Error reflecting tables for the {self.protocol} protocol - this means there is a DB schema mismatch
-                    [-] This is probably because a newer version of nxc is being run on an old DB schema
-                    [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
-                    [-] Then remove the nxc {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""
-                )
-                sys.exit()
+        self.CredentialsTable = self.reflect_table(self.Credential)
+        self.HostsTable = self.reflect_table(self.Host)
+        self.LoggedinRelationsTable = self.reflect_table(self.LoggedInRelation)
+        self.AdminRelationsTable = self.reflect_table(self.AdminRelation)
+        self.KeysTable = self.reflect_table(self.Key)
 
     def add_host(self, host, port, banner, os=None):
         """Check if this host has already been added to the database, if not, add it in."""

--- a/nxc/protocols/vnc/database.py
+++ b/nxc/protocols/vnc/database.py
@@ -1,17 +1,15 @@
-import sys
 import warnings
 
-from sqlalchemy import Table
-from sqlalchemy.exc import (
-    NoInspectionAvailable,
-    NoSuchTableError,
-)
+from sqlalchemy import Column, Integer, PrimaryKeyConstraint, String
 from sqlalchemy.exc import SAWarning
+from sqlalchemy.ext.declarative import declarative_base
 
 from nxc.database import BaseDB
 
 # if there is an issue with SQLAlchemy and a connection cannot be cleaned up properly it spews out annoying warnings
 warnings.filterwarnings("ignore", category=SAWarning)
+
+Base = declarative_base()
 
 
 class database(BaseDB):
@@ -21,38 +19,33 @@ class database(BaseDB):
 
         super().__init__(db_engine)
 
+    class Credential(Base):
+        __tablename__ = "credentials"
+        id = Column(Integer)
+        username = Column(String)
+        password = Column(String)
+        pkey = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+
+    class Host(Base):
+        __tablename__ = "hosts"
+        id = Column(Integer)
+        ip = Column(String)
+        hostname = Column(String)
+        port = Column(Integer)
+        server_banner = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+
     @staticmethod
     def db_schema(db_conn):
-        db_conn.execute(
-            """CREATE TABLE "credentials" (
-            "id" integer PRIMARY KEY,
-            "username" text,
-            "password" text,
-            "pkey" text
-            )"""
-        )
-
-        db_conn.execute(
-            """CREATE TABLE "hosts" (
-            "id" integer PRIMARY KEY,
-            "ip" text,
-            "hostname" text,
-            "port" integer,
-            "server_banner" text
-            )"""
-        )
+        Base.metadata.create_all(db_conn)
 
     def reflect_tables(self):
-        with self.db_engine.connect():
-            try:
-                self.HostsTable = Table("hosts", self.metadata, autoload_with=self.db_engine)
-                self.CredentialsTable = Table("credentials", self.metadata, autoload_with=self.db_engine)
-            except (NoInspectionAvailable, NoSuchTableError):
-                print(
-                    f"""
-                    [-] Error reflecting tables for the {self.protocol} protocol - this means there is a DB schema mismatch
-                    [-] This is probably because a newer version of nxc is being run on an old DB schema
-                    [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
-                    [-] Then remove the {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""
-                )
-                sys.exit()
+        self.HostsTable = self.reflect_table(self.Host)
+        self.CredentialsTable = self.reflect_table(self.Credential)

--- a/nxc/protocols/winrm/database.py
+++ b/nxc/protocols/winrm/database.py
@@ -1,13 +1,11 @@
-import sys
-from sqlalchemy import Table, select, func, delete
+from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, select, func, delete
 from sqlalchemy.dialects.sqlite import Insert
-from sqlalchemy.exc import (
-    NoInspectionAvailable,
-    NoSuchTableError,
-)
+from sqlalchemy.ext.declarative import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger
+
+Base = declarative_base()
 
 
 class database(BaseDB):
@@ -19,64 +17,66 @@ class database(BaseDB):
 
         super().__init__(db_engine)
 
-    @staticmethod
-    def db_schema(db_conn):
-        db_conn.execute(
-            """CREATE TABLE "hosts" (
-            "id" integer PRIMARY KEY,
-            "ip" text,
-            "port" integer,
-            "hostname" text,
-            "domain" text,
-            "os" text
-            )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "users" (
-            "id" integer PRIMARY KEY,
-            "domain" text,
-            "username" text,
-            "password" text,
-            "credtype" text,
-            "pillaged_from_hostid" integer,
-            FOREIGN KEY(pillaged_from_hostid) REFERENCES hosts(id)
-            )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "admin_relations" (
-            "id" integer PRIMARY KEY,
-            "userid" integer,
-            "hostid" integer,
-            FOREIGN KEY(userid) REFERENCES users(id),
-            FOREIGN KEY(hostid) REFERENCES hosts(id)
-        )"""
-        )
-        db_conn.execute(
-            """CREATE TABLE "loggedin_relations" (
-            "id" integer PRIMARY KEY,
-            "userid" integer,
-            "hostid" integer,
-            FOREIGN KEY(userid) REFERENCES users(id),
-            FOREIGN KEY(hostid) REFERENCES hosts(id)
-        )"""
+    class Host(Base):
+        __tablename__ = "hosts"
+        id = Column(Integer)
+        ip = Column(String)
+        port = Column(Integer)
+        hostname = Column(String)
+        domain = Column(String)
+        os = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
         )
 
+    class User(Base):
+        __tablename__ = "users"
+        id = Column(Integer)
+        domain = Column(String)
+        username = Column(String)
+        password = Column(String)
+        credtype = Column(String)
+        pillaged_from_hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["pillaged_from_hostid"], ["hosts.id"]),
+        )
+
+    class AdminRelation(Base):
+        __tablename__ = "admin_relations"
+        id = Column(Integer)
+        userid = Column(Integer)
+        hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["userid"], ["users.id"]),
+            ForeignKeyConstraint(["hostid"], ["hosts.id"]),
+        )
+
+    class LoggedInRelation(Base):
+        __tablename__ = "loggedin_relations"
+        id = Column(Integer)
+        userid = Column(Integer)
+        hostid = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+            ForeignKeyConstraint(["userid"], ["users.id"]),
+            ForeignKeyConstraint(["hostid"], ["hosts.id"]),
+        )
+        
+    @staticmethod
+    def db_schema(db_conn):
+        Base.metadata.create_all(db_conn)
+
     def reflect_tables(self):
-        with self.db_engine.connect():
-            try:
-                self.HostsTable = Table("hosts", self.metadata, autoload_with=self.db_engine)
-                self.UsersTable = Table("users", self.metadata, autoload_with=self.db_engine)
-                self.AdminRelationsTable = Table("admin_relations", self.metadata, autoload_with=self.db_engine)
-                self.LoggedinRelationsTable = Table("loggedin_relations", self.metadata, autoload_with=self.db_engine)
-            except (NoInspectionAvailable, NoSuchTableError):
-                print(
-                    f"""
-                    [-] Error reflecting tables for the {self.protocol} protocol - this means there is a DB schema mismatch
-                    [-] This is probably because a newer version of nxc is being run on an old DB schema
-                    [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
-                    [-] Then remove the {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""
-                )
-                sys.exit()
+        self.HostsTable = self.reflect_table(self.Host)
+        self.UsersTable = self.reflect_table(self.User)
+        self.AdminRelationsTable = self.reflect_table(self.AdminRelation)
+        self.LoggedinRelationsTable = self.reflect_table(self.LoggedInRelation)
 
     def add_host(self, ip, port, hostname, domain, os=None):
         """

--- a/nxc/protocols/wmi/database.py
+++ b/nxc/protocols/wmi/database.py
@@ -1,74 +1,42 @@
-from pathlib import Path
-from sqlalchemy.orm import sessionmaker, scoped_session
-from sqlalchemy import MetaData, Table
-from sqlalchemy.exc import (
-    IllegalStateChangeError,
-    NoInspectionAvailable,
-    NoSuchTableError,
-)
-from nxc.logger import nxc_logger
-import sys
+from sqlalchemy import Column, Integer, PrimaryKeyConstraint, String
+from sqlalchemy.ext.declarative import declarative_base
+from nxc.database import BaseDB
+
+Base = declarative_base()
 
 
-class database:
+class database(BaseDB):
     def __init__(self, db_engine):
         self.CredentialsTable = None
         self.HostsTable = None
 
-        self.db_engine = db_engine
-        self.db_path = self.db_engine.url.database
-        self.protocol = Path(self.db_path).stem.upper()
-        self.metadata = MetaData()
-        self.reflect_tables()
-        session_factory = sessionmaker(bind=self.db_engine, expire_on_commit=True)
+        super().__init__(db_engine)
 
-        Session = scoped_session(session_factory)
-        # this is still named "conn" when it is the session object; TODO: rename
-        self.conn = Session()
+    class Credential(Base):
+        __tablename__ = "credentials"
+        id = Column(Integer)
+        username = Column(String)
+        password = Column(String)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
+
+    class Host(Base):
+        __tablename__ = "hosts"
+        id = Column(Integer)
+        ip = Column(String)
+        hostname = Column(String)
+        port = Column(Integer)
+
+        __table_args__ = (
+            PrimaryKeyConstraint("id"),
+        )
 
     @staticmethod
     def db_schema(db_conn):
-        db_conn.execute(
-            """CREATE TABLE "credentials" (
-            "id" integer PRIMARY KEY,
-            "username" text,
-            "password" text
-            )"""
-        )
-
-        db_conn.execute(
-            """CREATE TABLE "hosts" (
-            "id" integer PRIMARY KEY,
-            "ip" text,
-            "hostname" text,
-            "port" integer
-            )"""
-        )
+        Base.metadata.create_all(db_conn)
 
     def reflect_tables(self):
-        with self.db_engine.connect():
-            try:
-                self.CredentialsTable = Table("credentials", self.metadata, autoload_with=self.db_engine)
-                self.HostsTable = Table("hosts", self.metadata, autoload_with=self.db_engine)
-            except (NoInspectionAvailable, NoSuchTableError):
-                print(
-                    f"""
-                    [-] Error reflecting tables for the {self.protocol} protocol - this means there is a DB schema mismatch
-                    [-] This is probably because a newer version of nxc is being run on an old DB schema
-                    [-] Optionally save the old DB data (`cp {self.db_path} ~/nxc_{self.protocol.lower()}.bak`)
-                    [-] Then remove the nxc {self.protocol} DB (`rm -f {self.db_path}`) and run nxc to initialize the new DB"""
-                )
-                sys.exit()
-
-    def shutdown_db(self):
-        try:
-            self.conn.close()
-        # due to the async nature of nxc, sometimes session state is a bit messy and this will throw:
-        # Method 'close()' can't be called here; method '_connection_for_bind()' is already in progress and
-        # this would cause an unexpected state change to <SessionTransactionState.CLOSED: 5>
-        except IllegalStateChangeError as e:
-            nxc_logger.debug(f"Error while closing session db object: {e}")
-
-    def clear_database(self):
-        for table in self.metadata.sorted_tables:
-            self.conn.execute(table.delete())
+        self.CredentialsTable = self.reflect_table(self.Credential)
+        self.HostsTable = self.reflect_table(self.Host)


### PR DESCRIPTION
## Description

Here is a big database rework. The goal was to change how databases is declared in the code to have a cleaner table decalaration. This allows to change the behaviour of `reflect_tables()` function, which now is verifying schema mismatch for column and constraints.  

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
