### PR TITLE
Image size improvements and pinned Netexec version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,35 @@
-FROM python:3.11-slim
+# --- Build Stage ---
+FROM python:3.13-slim-bookworm AS builder
+ENV TAG=1.4.0
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PIP_NO_CACHE_DIR=off
+
+WORKDIR /usr/src/netexec
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libffi-dev \
+        libxml2-dev \
+        libxslt-dev \
+        libssl-dev \
+        openssl \
+        autoconf \
+        g++ \
+        python3-dev \
+        curl \
+        git \
+        unzip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN git clone --depth 1 --branch v${TAG} https://github.com/Pennyw0rth/NetExec.git . \
+    && pip install .
+
+FROM python:3.13-slim-bookworm
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -6,17 +37,12 @@ ENV PIP_NO_CACHE_DIR=off
 
 WORKDIR /usr/src/netexec
 
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
 RUN apt-get update && \
-    apt-get install -y libffi-dev libxml2-dev libxslt-dev libssl-dev openssl autoconf g++ python3-dev curl git
-RUN apt-get update
-# Get Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-# Add .cargo/bin to PATH
-ENV PATH="/root/.cargo/bin:${PATH}"
-# Check cargo is visible
-RUN cargo --help
+    apt-get install -y --no-install-recommends \
+        openssl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY . .
-RUN pip install .
-
-ENTRYPOINT [ "nxc" ]
+ENTRYPOINT ["nxc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-# --- Build Stage ---
 FROM python:3.13-slim-bookworm AS builder
-ENV TAG=1.4.0
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV PIP_NO_CACHE_DIR=off
 
 WORKDIR /usr/src/netexec
 
-# Install build dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt update && \
+    apt install -y --no-install-recommends \
         libffi-dev \
         libxml2-dev \
         libxslt-dev \
@@ -21,12 +18,12 @@ RUN apt-get update && \
         curl \
         git \
         unzip \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt clean && rm -rf /var/lib/apt/lists/*
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain stable
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN git clone --depth 1 --branch v${TAG} https://github.com/Pennyw0rth/NetExec.git . \
+RUN git clone https://github.com/Pennyw0rth/NetExec.git . \
     && pip install .
 
 FROM python:3.13-slim-bookworm
@@ -40,9 +37,9 @@ WORKDIR /usr/src/netexec
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt update && \
+    apt install -y --no-install-recommends \
         openssl \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt clean && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["nxc"]


### PR DESCRIPTION
## Description
This PR introduces a multi-stage Docker build for latest version of NetExec, using the latest python:3.13-slim-bookworm as the base image. The multi-stage setup optimizes the final image size by separating the build environment from the runtime environment.
Summary of Changes

Adds a builder stage that Installs necessary build dependencies The final stage:
- [x] Copies only the required Python site-packages and binaries from the builder
- [x] Minimizes runtime dependencies

Issue Fixed / Enhancement
This results in a smaller, cleaner final image suitable for deployment and CI/CD


## Type of change
- [x] New feature (non-breaking change which adds functionality)

Ensure Docker is installed on your machine. No external dependencies are required beyond Docker itself.

Checklist:
- [x] I have tested the Docker build and run locally
- [x] I have performed a self-review of my own code
