### PR TITLE
Fix dns resolution when finding 2025 dc

### DIFF
--- a/nxc/modules/badsuccessor.py
+++ b/nxc/modules/badsuccessor.py
@@ -187,7 +187,7 @@ class NXCModule:
         for dc in parsed_resp:
             if "2025" in dc["operatingSystem"]:
                 out = connection.resolver(dc["dNSHostName"])
-                dc_ip = out[0] if out else "Unknown IP"
+                dc_ip = out["host"] if out else "Unknown IP"
                 context.log.success(f"Found domain controller with operating system Windows Server 2025: {dc_ip} ({dc['dNSHostName']})")
             else:
                 context.log.fail("No domain controller with operating system Windows Server 2025 found, attack not possible. Enumerate dMSA objects anyway.")


### PR DESCRIPTION
## Description

Reported issue on discord. The DNS request isn't properly parsed leading to a crash:
![image](https://github.com/user-attachments/assets/519d2b3d-f72b-4516-8380-0eb642e99349)

Just properly access the host value and we are good.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Run badsuccessor against a domain with a server 2025 DC.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/e48552ae-e525-4f02-93c7-81e72f1435ad)

