### PR TITLE
Fix function to check if hosts is a dc or not

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -666,7 +666,7 @@ class smb(connection):
     def check_dc_ports(self, timeout=1):
         """Check multiple DC-specific ports in case first check fails"""
         import socket
-        dc_ports = [88, 389, 636, 3268]  # Kerberos, LDAP, LDAPS, Global Catalog
+        dc_ports = [88, 389, 636, 3268, 9389]  # Kerberos, LDAP, LDAPS, Global Catalog, ADWS
         open_ports = 0
 
         for port in dc_ports:
@@ -693,7 +693,7 @@ class smb(connection):
             self.logger.debug("Port 135 is open, attempting MSRPC connection...")
             try:
                 rpctransport = transport.DCERPCTransportFactory(f"ncacn_ip_tcp:{self.host}[135]")
-                rpctransport.set_connect_timeout(5)
+                rpctransport.set_connect_timeout(2)
 
                 dce = rpctransport.get_dce_rpc()
                 dce.connect()

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -684,7 +684,7 @@ class smb(connection):
         return open_ports >= 3
 
     def is_host_dc(self):
-        from impacket.dcerpc.v5 import transport, nrpc
+        from impacket.dcerpc.v5 import nrpc, epm
 
         self.logger.debug("Performing authentication attempts...")
         
@@ -692,15 +692,8 @@ class smb(connection):
         if self._is_port_open(135):
             self.logger.debug("Port 135 is open, attempting MSRPC connection...")
             try:
-                rpctransport = transport.DCERPCTransportFactory(f"ncacn_ip_tcp:{self.host}[135]")
-                rpctransport.set_connect_timeout(2)
-
-                dce = rpctransport.get_dce_rpc()
-                dce.connect()
-                dce.bind(nrpc.MSRPC_UUID_NRPC)
-
+                epm.hept_map(self.host, nrpc.MSRPC_UUID_NRPC, protocol="ncacn_ip_tcp")
                 self.isdc = True
-                dce.disconnect()
                 return True
             except DCERPCException:
                 self.logger.debug("Error while connecting to host: DCERPCException, which means this is probably not a DC!")


### PR DESCRIPTION
## Description

This PR fix two issue reported by 0xdf:
- the first one is if RPC port is filtered, then the check will take the default 30 second to timeout which is tooooo long and the functionality cannot be used anymore if run on large subnet. A timeout is added to 5 second to fix this
- second point, if the RPC port is filtered, we cannot check if this is a dc or not, another check is then made (basic check over open port), it's not perfect but better than before for sure !

---

This pull request introduces enhancements to the `nxc/protocols/smb.py` file to improve the detection of Domain Controllers (DCs) and handle network connectivity checks more robustly. The changes include adding new methods for checking specific ports and refining the logic for identifying DCs.

### Improvements to Domain Controller Detection:

* **Added `check_dc_ports` method**: This method checks multiple DC-specific ports (Kerberos, LDAP, LDAPS, Global Catalog) to determine if the host is likely a Domain Controller. It returns `True` if three or more ports are open.
* **Refined `is_host_dc` method**: Enhanced the logic to first check if port 135 is open and attempt an MSRPC connection. If port 135 is closed, it falls back to the `check_dc_ports` method to identify DCs based on open ports. Added detailed logging for better debugging.

### Network Connectivity Enhancements:

* **Added `_is_port_open` method**: A helper function to check the status of a specific port on the target host, with configurable timeout. This method is used in both `is_host_dc` and `check_dc_ports` to streamline port-checking logic.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Agains fluffy machine on HTB

## Screenshots (if appropriate):

- FIrst problem with time to check the diff before and after: 

![image](https://github.com/user-attachments/assets/d1adc130-4b71-49fe-b8ae-15a80446b3b5)


- Second problem 

![image](https://github.com/user-attachments/assets/c7924bce-674f-4692-83d9-177784efadcf)



## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
