### PR TITLE
Skip cbt check if port explicitly set to 389

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -312,7 +312,10 @@ class ldap(connection):
             self.domain = self.targetDomain
 
         self.check_ldap_signing()
-        self.check_ldaps_cbt()
+        if getattr(self.args, "port_explicitly_set", False) and self.port == 389:
+            self.cbt_status = "Unknown"
+        else:
+            self.check_ldaps_cbt()
 
         # using kdcHost is buggy on impacket when using trust relation between ad so we kdcHost must stay to none if targetdomain is not equal to domain
         if not self.kdcHost and self.domain and self.domain == self.targetDomain:

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -1,10 +1,10 @@
-from nxc.helpers.args import DisplayDefaultsNotNone
+from nxc.helpers.args import DefaultTrackingAction, DisplayDefaultsNotNone
 
 
 def proto_args(parser, parents):
     ldap_parser = parser.add_parser("ldap", help="own stuff using LDAP", parents=parents, formatter_class=DisplayDefaultsNotNone)
     ldap_parser.add_argument("-H", "--hash", metavar="HASH", dest="hash", nargs="+", default=[], help="NTLM hash(es) or file(s) containing NTLM hashes")
-    ldap_parser.add_argument("--port", type=int, default=389, help="LDAP port")
+    ldap_parser.add_argument("--port", type=int, default=389, action=DefaultTrackingAction, help="LDAP port")
 
     dgroup = ldap_parser.add_mutually_exclusive_group()
     dgroup.add_argument("-d", metavar="DOMAIN", dest="domain", type=str, default=None, help="domain to authenticate to")


### PR DESCRIPTION
## Description

Fix #740. If the port is manually set to `389` we will skip the cbt check.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Specify `--port 389` -> cbt check will result in "Unkown"

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c3c67387-8d2e-43d0-a55a-c71deaad3d4c)
