### PR TITLE
Fix conn reset error on windows if dc doesnt have tls cert

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -276,7 +276,7 @@ class ldap(connection):
                 self.logger.debug(f"LDAPSessionError while checking for channel binding requirements (likely NTLM disabled): {e!s}")
         except SysCallError as e:
             self.logger.debug(f"Received SysCallError when trying to enumerate channel binding support: {e!s}")
-            if e.args[1] == "ECONNRESET":
+            if e.args[1] in ["ECONNRESET", "WSAECONNRESET"]:
                 self.cbt_status = "No TLS cert"
             else:
                 raise


### PR DESCRIPTION
## Description

Python throws a different SysCallError on Windows than on Linux when the connection is reset because of no TLS cert. That causes nxc to crash as in #742. This PR filters also the Windows SysCallError

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Run nxc ldap against a DC without TLS cert on windows.

## Screenshots (if appropriate):
Before&After:
![image](https://github.com/user-attachments/assets/0046fb49-0c6e-42b5-8356-f5d5955bcf12)
