### PR TITLE
Fix two minor bugs

### DIFF
--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -182,9 +182,9 @@ class NXCAdapter(logging.LoggerAdapter):
 
         with file_handler._open() as f:
             if file_creation:
-                f.write(f"[{datetime.now().strftime('%d-%m-%Y %H:%M:%S')}]> {' '.join(sys.argv)}\n\n")
+                f.write(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]> {' '.join(sys.argv)}\n\n")
             else:
-                f.write(f"\n[{datetime.now().strftime('%d-%m-%Y %H:%M:%S')}]> {' '.join(sys.argv)}\n\n")
+                f.write(f"\n[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]> {' '.join(sys.argv)}\n\n")
 
         file_handler.setFormatter(file_formatter)
         self.logger.addHandler(file_handler)

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -323,7 +323,8 @@ class ldap(connection):
             self.kdcHost = result["host"] if result else None
             self.logger.info(f"Resolved domain: {self.domain} with dns, kdcHost: {self.kdcHost}")
 
-        self.output_filename = os.path.expanduser(f"{NXC_PATH}/logs/{self.hostname}_{self.host}".replace(":", "-"))
+        filename = f"{self.hostname}_{self.host}".replace(":", "-")
+        self.output_filename = os.path.expanduser(os.path.join(NXC_PATH, "logs", filename))
 
         try:
             self.db.add_host(


### PR DESCRIPTION
## Description

Fixes #746 and #748.
#748: When we have the path `C:/` on Windows we should not replace `:` with `-`, fixed now.
#746: Changed logger format for date in the log. Changed from `%d-%m-%Y` to `%Y-%m-%d` like in the normal log.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
See issues

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/9cfdaa86-5338-41d3-a6bc-78da4ad2a4c7)
