### PR TITLE
Additional changes for #748

### DIFF
--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -182,9 +182,9 @@ class NXCAdapter(logging.LoggerAdapter):
 
         with file_handler._open() as f:
             if file_creation:
-                f.write(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]> {' '.join(sys.argv)}\n\n")
+                f.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | {' '.join(sys.argv)}\n\n")
             else:
-                f.write(f"\n[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]> {' '.join(sys.argv)}\n\n")
+                f.write(f"\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | {' '.join(sys.argv)}\n\n")
 
         file_handler.setFormatter(file_formatter)
         self.logger.addHandler(file_handler)

--- a/nxc/logger.py
+++ b/nxc/logger.py
@@ -181,10 +181,10 @@ class NXCAdapter(logging.LoggerAdapter):
         file_handler = RotatingFileHandler(output_file, maxBytes=100000, encoding="utf-8")
 
         with file_handler._open() as f:
-            if file_creation:
-                f.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | {' '.join(sys.argv)}\n\n")
-            else:
-                f.write(f"\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | {' '.join(sys.argv)}\n\n")
+            if not file_creation:
+                f.write("\n")
+
+            f.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} | {' '.join(sys.argv)}\n\n")
 
         file_handler.setFormatter(file_formatter)
         self.logger.addHandler(file_handler)


### PR DESCRIPTION
## Description

Two additional changes to the log entry format for #748 (and PR https://github.com/Pennyw0rth/NetExec/pull/750):
 
 - Remove the brackets "[]" around the datetime
 - Change ">" to " | "

Additionally, a small refactor of the logic around this code block to allow removing the need for two file write() lines.

The log entry is still not quite in the same format but I'll continue discussion in #748.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

No special setup need. Tested the command against an accessible DC.

## Screenshots (if appropriate):

```
2025-06-20 14:48:06 | /usr/bin/netexec smb dc.example.com -u user -p password --log pr-example.log

2025-06-20 14:48:06 | smb.py:327 - INFO - SMB         192.168.0.2   445    dc      [*] Windows 10 / Server 2019 Build 17763 x64 (name:dc) (domain:example.com) (signing:True) (SMBv1:False) 
2025-06-20 14:48:06 | smb.py:481 - INFO - SMB         192.168.0.2   445    dc      [+] example.com\user:password (Pwn3d!)
```

## Checklist:

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
