### PR TITLE
Fix bloodhound ingestor ntlm fallback kerberos

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1455,7 +1455,7 @@ class ldap(connection):
 
         if self.args.kerberos:
             self.logger.highlight("Using kerberos auth")
-            # Don’t re-request a TGT if we’re using an existing cache
+            # Don't re-request a TGT if we're using an existing cache
             if self.args.use_kcache:
                 self.logger.highlight("Loading TGT from Kerberos cache")
                 if not auth.load_ccache():


### PR DESCRIPTION
## Description

This patch makes NetExec’s LDAP protocol collector honour pure-Kerberos mode when NTLM is disabled and properly loads a ticket cache when `--use-kcache` is set. Without this change, NetExec will still fall back to NTLM in BloodHound’s ingestor (and then error out with `NTLM needs domain\username and a password`) even after you’ve loaded a TGT from ccache.

**What it does**

* Instantiates the `ADAuthentication` helper with `auth_method="kerberos"` whenever NTLM is not supported (`self.no_ntlm == True`).
* In the BloodHound kickoff block (around line 1440), only calls `auth.get_tgt()` when not using ccache; otherwise calls `auth.load_ccache()` and aborts early if loading fails.

> **Note:** this is not a complete fix on its own—you also need a small change in **bloodhound-ce-python**’s `ADAuthentication.getLDAPConnection()` (skip the NTLM fallback when `auth_method=='kerberos'`).

Fixes #752.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

* **Environment**: Linux (Fedora / Ubuntu), Python 3.12
* **NetExec version**: current `main` branch + this diff
* **Target**: a Domain Controller with NTLM authentication disabled (e.g. Windows Server 2019/2022, GPO “Network security: Configure encryption types allowed for Kerberos” set to refuse NTLM)
* **Reproduce before**:

  ```bash
  uv run netexec ldap 10.10.11.168 \
    --kdcHost dc1.scrm.local -k --use-kcache --bloodhound -c All --debug
  # → falls back to NTLM and errors
  ```
* **Verify after**:

  ```bash
  uv run netexec ldap 10.10.11.168 \
    --kdcHost dc1.scrm.local -k --use-kcache --bloodhound -c All --debug
  # → loads TGT from ccache, does GSSAPI bind, and completes BloodHound collection
  ```

## Screenshots (if appropriate)

*None*

## Checklist:

* [x] I have ran Ruff against my changes (`poetry run python -m ruff check . --preview`)
* [ ] I have added or updated tests/e2e\_commands.txt if necessary
* [ ] New and existing e2e tests pass locally with my changes
* [ ] If reliant on changes of third party dependencies (bloodhound-ce-python), I have linked the relevant PRs/issues
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation (NetExec-Wiki PR)

---

A [PR](https://github.com/dirkjanm/BloodHound.py/pull/231) in **bloodhound-ce-python** has been opened to adjust `ADAuthentication.getLDAPConnection()` so that when `auth_method=='kerberos'` it skips attempting NTLM entirely.