### PR TITLE
update flag to better understand

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -140,7 +140,7 @@ class connection:
                              self.args.use_kcache or
                              self.args.aesKey or
                              (hasattr(self.args, "delegate") and self.args.delegate) or
-                             (hasattr(self.args, "no_preauth") and self.args.no_preauth))
+                             (hasattr(self.args, "no_preauth_targets") and self.args.no_preauth_targets))
         self.aesKey = None if not self.args.aesKey else self.args.aesKey[0]
         self.use_kcache = None if not self.args.use_kcache else self.args.use_kcache
         self.admin_privs = False

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -415,7 +415,7 @@ class ldap(connection):
                 color="yellow",
             )
             # If no preauth is set, we want to be able to execute commands such as --kerberoasting
-            if self.args.no_preauth:  # noqa: SIM103
+            if self.args.no_preauth_targets:  # noqa: SIM103
                 return True
             else:
                 return False
@@ -990,9 +990,9 @@ class ldap(connection):
                         hash_asreproast.write(f"{hash_TGT}\n")
 
     def kerberoasting(self):
-        if self.args.no_preauth:
+        if self.args.no_preauth_targets:
             usernames = []
-            for item in self.args.no_preauth:
+            for item in self.args.no_preauth_targets:
                 if os.path.isfile(item):
                     with open(item, encoding="utf-8") as f:
                         usernames.extend(line.strip() for line in f if line.strip())

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -13,7 +13,7 @@ def proto_args(parser, parents):
     egroup = ldap_parser.add_argument_group("Retrieve hash on the remote DC", "Options to get hashes from Kerberos")
     egroup.add_argument("--asreproast", help="Output AS_REP response to crack with hashcat to file")
     egroup.add_argument("--kerberoasting", help="Output TGS ticket to crack with hashcat to file")
-    egroup.add_argument("--no-preauth-targets", nargs=1, dest="no_preauth", help="Targeted kerberoastable users")
+    egroup.add_argument("--no-preauth-targets", nargs=1, dest="no_preauth_targets", help="Targeted kerberoastable users")
 
     vgroup = ldap_parser.add_argument_group("Retrieve useful information on the domain")
     vgroup.add_argument("--base-dn", metavar="BASE_DN", dest="base_dn", type=str, default=None, help="base DN for search queries")

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -13,7 +13,7 @@ def proto_args(parser, parents):
     egroup = ldap_parser.add_argument_group("Retrieve hash on the remote DC", "Options to get hashes from Kerberos")
     egroup.add_argument("--asreproast", help="Output AS_REP response to crack with hashcat to file")
     egroup.add_argument("--kerberoasting", help="Output TGS ticket to crack with hashcat to file")
-    egroup.add_argument("--no-preauth", nargs=1, dest="no_preauth", help="No-preauth user for AS-REQ Kerberoast (use with -u users/SPNs).")
+    egroup.add_argument("--no-preauth-targets", nargs=1, dest="no_preauth", help="Targeted kerberoastable users")
 
     vgroup = ldap_parser.add_argument_group("Retrieve useful information on the domain")
     vgroup.add_argument("--base-dn", metavar="BASE_DN", dest="base_dn", type=str, default=None, help="base DN for search queries")


### PR DESCRIPTION
## Description

This pull request updates the naming convention for a specific argument across multiple files in the codebase to improve clarity and consistency. The argument `--no-preauth` has been renamed to `--no-preauth-targets`, and corresponding references in the code have been updated to reflect this change.

### Argument Renaming and Code Updates:

* **Renamed Argument in `proto_args`**:
  - The argument `--no-preauth` has been renamed to `--no-preauth-targets` in `proto_args`, and its description was updated to clarify its purpose as targeting kerberoastable users. (`nxc/protocols/ldap/proto_args.py`, [nxc/protocols/ldap/proto_args.pyL16-R16](diffhunk://#diff-b24f079d1a9c675e6aed6fcc4ded0e1906929dee6a7f7b447692c67175950befL16-R16))

* **Updated References in `nxc/connection.py`**:
  - Replaced `self.args.no_preauth` with `self.args.no_preauth_targets` in the initialization logic to reflect the new argument name. (`nxc/connection.py`, [nxc/connection.pyL143-R143](diffhunk://#diff-7cbea1ad52e1b9ab8b7cc02bc235857b0c5ac436813b5b1cf7443805dc0f5433L143-R143))

* **Updated Logic in `kerberos_login`**:
  - Adjusted the condition to check for `self.args.no_preauth_targets` instead of `self.args.no_preauth` for determining preauthentication behavior. (`nxc/protocols/ldap.py`, [nxc/protocols/ldap.pyL418-R418](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76L418-R418))

* **Updated Logic in `kerberoasting`**:
  - Updated the loop and condition to use `self.args.no_preauth_targets` instead of `self.args.no_preauth` for processing targeted usernames. (`nxc/protocols/ldap.py`, [nxc/protocols/ldap.pyL993-R995](diffhunk://#diff-58dbbb4ad45d7ca196b2c60c427281102b0aad1dade02459487c9c598d144e76L993-R995))

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] 
## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
