### PR TITLE
Change ignore_opsec default value to False

### DIFF
--- a/nxc/data/nxc.conf
+++ b/nxc/data/nxc.conf
@@ -5,7 +5,7 @@ pwn3d_label = Pwn3d!
 audit_mode = 
 reveal_chars_of_pwd = 0
 log_mode = False
-ignore_opsec = True
+ignore_opsec = False
 host_info_colors = ["green", "red", "yellow", "cyan"]
 
 [BloodHound]


### PR DESCRIPTION
Change ignore_opsec default value to False (i.e. don't ignore warnings).


## Description
- change default value of ignore_opsec to match documentation and use the safe version as standard

## Type of change
- [?] Bug fix (non-breaking change which fixes an issue)

## Setup guide for the review
- basic setting, perform an opsec relevant action (e.g. dumping LSASS) to check if warning appears or not

## Screenshots (if appropriate):
(no visible output)

## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [-] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)


poetry fails to build the projekt on my machine for the moment unfortunately and i don't find any information on how the tests are to be run. 
Would be great if anyone could check my change until i managed to get everything running. It could be that tests for opsec critical task will fail if prompted for continuation and expecting user input.. in that case the tests might have to override the flag or we'd need an option flag to confirm ignore_opsec when executing?