### PR TITLE
Fix enum_links module privilege requirement

### DIFF
--- a/nxc/modules/enum_links.py
+++ b/nxc/modules/enum_links.py
@@ -27,18 +27,18 @@ class NXCModule:
                 self.context.log.display(f"  - {server}")
         else:
             self.context.log.fail("No linked servers found.")
-
-    def on_admin_login(self, context, connection):
-        res = self.mssql_conn.sql_query("EXEC sp_helplinkedsrvlogin")
-        srvs = [srv for srv in res if srv["Local Login"] != "NULL"]
-        if not srvs:
-            self.context.log.fail("No linked servers found.")
-            return
-        self.context.log.success("Linked servers found:")
-        for srv in srvs:
-            self.context.log.display(f"Linked server: {srv['Linked Server']}")
-            self.context.log.display(f"  - Local login: {srv['Local Login']}")
-            self.context.log.display(f"  - Remote login: {srv['Remote Login']}")
+            
+        if connection.admin_privs:
+            res = self.mssql_conn.sql_query("EXEC sp_helplinkedsrvlogin")
+            srvs = [srv for srv in res if srv["Local Login"] != "NULL"]
+            if not srvs:
+                self.context.log.fail("No linked servers found.")
+                return
+            self.context.log.success("Linked servers found:")
+            for srv in srvs:
+                self.context.log.display(f"Linked server: {srv['Linked Server']}")
+                self.context.log.display(f"  - Local login: {srv['Local Login']}")
+                self.context.log.display(f"  - Remote login: {srv['Remote Login']}")
 
     def get_linked_servers(self) -> list:
         """


### PR DESCRIPTION
## Description

Since `enum_links` module has `on_login()` AND `on_admin_login()` methods, it is listed in `HIGH PRIVILEGES` modules when you list mssql modules, which is confusing because you can use it even if you are not admin.
This change add all the code of `on_admin_login()` in `on_login()` under an if statement that check is the connection has admin privileges. Hence, the module is now listed in `LOW PRIVILEGES` modules 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots (if appropriate):
Before : 
![image](https://github.com/user-attachments/assets/b76c42ad-fd13-43d0-b1f5-52de6ec49378)

After : 
![image](https://github.com/user-attachments/assets/e7e854e8-5bb6-427e-86bc-446b07a97bc1)


## Checklist:
It's all checked mate

