### PR TITLE
Add module to find the entra-id sync server

### DIFF
--- a/nxc/modules/entra-id.py
+++ b/nxc/modules/entra-id.py
@@ -1,0 +1,78 @@
+
+import re
+from nxc.parsers.ldap_results import parse_result_attributes
+
+
+class NXCModule:
+    """Module by @NeffIsBack"""
+
+    name = "entra-id"
+    description = "Find the Entra ID sync server"
+    supported_protocols = ["ldap"]
+    opsec_safe = True
+    multiple_hosts = True
+
+    def __init__(self):
+        self.context = None
+        self.module_options = None
+
+    def options(self, context, module_options):
+        """No options available."""
+
+    def on_login(self, context, connection):
+        self.context = context
+
+        # For every Entra ID syncronization server, there is a corresponding MSOL_ account and likely an ADSyncMSA service account.
+        msol_parsed = parse_result_attributes(connection.search(
+            searchFilter="(sAMAccountName=MSOL_*)",
+            attributes=["sAMAccountName", "cn", "description"],
+        ))
+        adsync_parsed = parse_result_attributes(connection.search(
+            searchFilter="(sAMAccountName=ADSyncMSA*)",
+            attributes=["sAMAccountName", "cn", "msDS-HostServiceAccountBL"],
+        ))
+
+        hosts = []
+        for acc in msol_parsed:
+            host = re.search(r"computer (?P<host>.*) configured", acc["description"])
+            if host:
+                hostname = host.group("host")
+                # Try to get the dNSHostName for the host, if not use the NetBIOS name from the description
+                resp = parse_result_attributes(connection.search(f"(sAMAccountName={hostname}$)", ["dNSHostName"]))
+                ip = connection.resolver(resp[0]["dNSHostName"] if resp else hostname)
+
+                hosts.append({
+                    "hostname": hostname,
+                    "ip": ip,
+                    "msol_account": acc["sAMAccountName"],
+                })
+
+        for adsync in adsync_parsed:
+            # The last 5 chars of the ADSyncMSA account name are the identifier for the corresponding MSOL account
+            identifier = str(adsync["cn"]).removeprefix("ADSyncMSA")
+            msol_acc = next((x for x in msol_parsed if str(x["sAMAccountName"]).startswith(f"MSOL_{identifier}")), None)
+            self.context.log.debug(f"Found ADSyncMSA account: {adsync['sAMAccountName']}, corresponding MSOL account: {msol_acc['sAMAccountName'] if msol_acc else 'None'}")
+
+            # Get the computer object for the ADSyncMSA service account
+            computer = parse_result_attributes(connection.search(
+                searchFilter=f"(distinguishedName={adsync['msDS-HostServiceAccountBL']})",
+                attributes=["dNSHostName", "cn", "sAMAccountName"],
+            ))[0]
+
+            # If we already found a host with its MSOL account, extend that info, otherwise create a new host entry
+            host = next((x for x in hosts if x["hostname"] == computer["cn"]), None)
+            if host and host["ip"]:   # Skip if host and IP are already set
+                self.context.log.debug(f"Host '{host['hostname']}' already exists with IP {host['ip'].get('host')}, skipping update.")
+                continue
+            elif host:                # If host exists but IP is not set, update it
+                host["ip"] = connection.resolver(computer["dNSHostName"])
+            else:                     # If host does not exist, create a new entry
+                hosts.append({
+                    "hostname": computer["cn"],
+                    "ip": connection.resolver(computer["dNSHostName"]),
+                })
+
+        if hosts:
+            self.context.log.success("Found Entra ID sync servers:")
+        for host in hosts:
+            self.context.log.highlight(f"{host['hostname']}: {host['ip'].get('host', '<not found>')} (MSOL Account: {host.get('msol_account', 'N/A')})")


### PR DESCRIPTION
## Description

When installing the Entra ID sync server the MSOL account and a service account is created. The location of the sync server can
1. be found in the description of the MSOL account
2. be found in the `msDS-HostServiceAccountBL` attribute of the service account

If either of these values should not be found, the other will be enumerated and displayed, so we should get the entra id sync server if either of these accounts are missing/malformated.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
You will need a tenant. If you have one just install the Entra ID synchronization service on one of your servers.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/1c015cfc-bcb6-483e-a47d-18b506a5f8e4)
