### PR TITLE
fix hashcat/John format for TGS-REP

### DIFF
--- a/nxc/protocols/ldap/kerberos.py
+++ b/nxc/protocols/ldap/kerberos.py
@@ -117,7 +117,7 @@ class KerberosAttacks:
         if etype == constants.EncryptionTypes.rc4_hmac.value:  # 23
             chk = hexlify(cipher[:16]).decode()
             data = hexlify(cipher[16:]).decode()
-            entry = f"$krb5tgs${etype}*{service}${realm}${spn_fmt}*${chk}${data}"
+            entry = f"$krb5tgs${etype}$*{service}${realm}${spn_fmt}*${chk}${data}"
 
         elif etype in (
             constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value,  # 17


### PR DESCRIPTION
## Description

This PR fixes a formatting issue in $krb5tgs$23 hashes used for Kerberoasting attacks.
A missing $ separator after 23 was preventing hashcat (mode 13100) from recognizing the hash format properly.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Checklist:

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
