### PR TITLE
Fix winrm's ps_execute() to return output

### DIFF
--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -266,7 +266,9 @@ class winrm(connection):
 
     def ps_execute(self, payload=None, get_output=False):
         command = payload if payload else self.args.ps_execute
-        self.execute(payload=command, get_output=get_output, shell_type="powershell")
+        result = self.execute(payload=command, get_output=get_output, shell_type="powershell")
+        if get_output:
+            return result
 
     # Dos attack prevent:
     # if someboby executed "reg save HKLM\sam C:\windows\temp\sam" before, but didn't remove "C:\windows\temp\sam" file,


### PR DESCRIPTION
## Description

There's a bug in protocols/winrm.py ps_execute(), where the output of the execution is not returned to the caller when requested via a True get_output parameter. This is simply due to a missing return statement.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
The following PoC module will show the issue and the correction:
```
class NXCModule:
    """
    Example:
    -------
    Module by @yomama
    """

    name = "bug-poc"
    description = "I do something"
    supported_protocols = ['winrm']  # Example: ['smb', 'mssql']
    opsec_safe = True  # Does the module touch disk?
    multiple_hosts = True  # Does it make sense to run this module on multiple hosts at a time?

    def __init__(self):
        self.context = None
        self.module_options = None

    def options(self, context, module_options):
        """Required.
        Module options get parsed here. Additionally, put the modules usage here as well
        """

    def on_login(self, context, connection):
        """Concurrent.
        Required if on_admin_login is not present. This gets called on each authenticated connection
        """
        context.log.display("Running ps_execute('whoami') with False get_output")
        connection.ps_execute("whoami", False)
        context.log.display("Now running ps_execute('whoami') with True get_output, and logging result the same way")
        result = connection.ps_execute("whoami", True)
        for line in StringIO(result).readlines():
            context.log.highlight(line.strip())
```

## Screenshots (if appropriate):
Executing the PoC before the fix:
<img width="1290" alt="before" src="https://github.com/user-attachments/assets/067fe78a-cf5b-45c9-9f6f-6618453239bd" />

Executing the PoC after the fix:
<img width="1286" alt="after" src="https://github.com/user-attachments/assets/f75b0ae6-4d9b-4d0d-8b26-e731d6f84e1b" />

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
