### PR TITLE
Only display success message if accounts found

### DIFF
--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -79,7 +79,8 @@ class NXCModule:
                         successful_tgts += 1
 
                 # Summary of TGT results
-                context.log.success(f"Successfully obtained TGT for {successful_tgts} pre-created computer accounts. Saved to {ccache_base_dir}")
+                if successful_tgts > 0:
+                    context.log.success(f"Successfully obtained TGT for {successful_tgts} pre-created computer accounts. Saved to {ccache_base_dir}")
 
             except Exception as e:
                 context.log.fail(f"Error occurred during search: {e}")


### PR DESCRIPTION
## Description

Fix that the success message of the pre2k module is displayed even if no accounts were found. See screenshot

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Run pre2k module against domain without a pre windows 2000 computers

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/8c1424ff-c080-4f7d-b9c8-68727080e516)
