### PR TITLE
Update bitlocker.py - Corrected BitLocker EncryptionMethods

### DIFF
--- a/nxc/modules/bitlocker.py
+++ b/nxc/modules/bitlocker.py
@@ -105,7 +105,16 @@ class BitLockerWMI:
                 # Query to get BitLocker status
                 classQuery = "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume"
                 iEnumWbemClassObject = iWbemServices.ExecQuery(classQuery)
-                encryptionTypeMapping = {0: "None", 1: "AES_256_WITH_DIFFUSER", 2: "AES_256_WITH_DIFFUSER", 3: "AES_128", 4: "AES_256", 5: "HARDWARE_ENCRYPTION", 6: "XTS_AES_128", 7: "XTS_AES_256"}
+                encryptionTypeMapping = {
+                    0: "None",
+                    1: "AES_128_WITH_DIFFUSER",
+                    2: "AES_256_WITH_DIFFUSER",
+                    3: "AES_128",
+                    4: "AES_256",
+                    5: "HARDWARE_ENCRYPTION",
+                    6: "XTS_AES_128",
+                    7: "XTS_AES_256_WITH_DIFFUSER"
+                }
                 
                 try:
                     while True:


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/windows/win32/secprov/win32-encryptablevolume, the correct mapping is as follows (changed type 1)

## Description

According to https://learn.microsoft.com/en-us/windows/win32/secprov/win32-encryptablevolume, the correct mapping is as follows.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Please provide guidance on what setup is needed to test the introduced changes, such as your locally running machine Python version & OS, as well as the target(s) you tested against, including software versions.
In particular:
- Bug Fix: Please provide a short description on how to trigger the bug, to make the bug reproducable for the reviewer.
- Added Feature/Enhancement: Please specify what setup is needed in order to test the changes. E.g. is additional software needed? GPO changes required? Specific registry settings that need to be changed?

## Screenshots (if appropriate):
Screenshots are always nice to have and can give a visual representation of the change.
If appropriate include before and after screenshot(s) to show which results are to be expected.
![image](https://github.com/user-attachments/assets/795ddedd-7d17-4474-84ed-a5c6bb004f0b)

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the tests/e2e_commands.txt file if necessary
- [x] New and existing e2e tests pass locally with my changes
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
