### PR TITLE
State that using a BINARY for schtask_as is optional

### DIFF
--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -19,9 +19,9 @@ class NXCModule:
 
     def options(self, context, module_options):
         r"""
-        BINARY         Upload the binary to be executed by CMD
         CMD            Command to execute
         USER           User to execute command as
+        BINARY         OPTIONAL: Upload the binary to be executed by CMD
         TASK           OPTIONAL: Set a name for the scheduled task name
         FILE           OPTIONAL: Set a name for the command output file
         LOCATION       OPTIONAL: Set a location for the command output file (e.g. '\tmp\')


### PR DESCRIPTION
## Description

Update documentation of `schtask_as`: State that using a BINARY for schtask_as is optional

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)


## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/3fbc6433-3f94-4772-8b9b-eebb777d705b)
