### PR TITLE
Add process filtering in --tasklist

### DIFF
--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -54,7 +54,7 @@ def proto_args(parser, parents):
     mapping_enum_group.add_argument("--pass-pol", action="store_true", help="dump password policy")
     mapping_enum_group.add_argument("--rid-brute", nargs="?", type=int, const=4000, metavar="MAX_RID", help="Enumerate users by bruteforcing RIDs")
     mapping_enum_group.add_argument("--qwinsta", action="store_true", help="Enumerate RDP connections")
-    mapping_enum_group.add_argument("--tasklist", action="store_true", help="Enumerate running processes")
+    mapping_enum_group.add_argument("--tasklist", type=str, nargs="?", const=True, help="Enumerate running processes and filter for the specified one if specified")
     
     wmi_group = smb_parser.add_argument_group("WMI", "Options for WMI Queries")
     wmi_group.add_argument("--wmi", metavar="QUERY", type=str, help="issues the specified WMI query")


### PR DESCRIPTION
This PR makes it possible to specify a process to look for when using --tasklist allowing finding (or not) specific processes (greping for keepass, edr agents and so on):

```bash
nxc smb 192.168.56.12 -u Administrateur -p Defte@WF --tasklist notepad.exeeeeee
```

![image](https://github.com/user-attachments/assets/e5acc9a4-7d06-4ca0-a11c-5443c73f89f3)
