### PR TITLE
setRemoteName to avoid Kerberos SPN resolution error in rid_brute

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1515,7 +1515,7 @@ class smb(connection):
             135: {"bindstr": rf"ncacn_ip_tcp:{self.remoteName}"},
             139: {"bindstr": rf"ncacn_np:{self.remoteName}[\pipe\lsarpc]"},
             445: {"bindstr": rf"ncacn_np:{self.remoteName}[\pipe\lsarpc]"},
-         }
+        }
 
         try:
             string_binding = KNOWN_PROTOCOLS[self.port]["bindstr"]

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1522,6 +1522,7 @@ class smb(connection):
             self.logger.debug(f"StringBinding {string_binding}")
             rpc_transport = transport.DCERPCTransportFactory(string_binding)
             rpc_transport.setRemoteHost(self.host)
+            rpc_transport.setRemoteName(self.hostname or self.host)
 
             if hasattr(rpc_transport, "set_credentials"):
                 # This method exists only for selected protocol sequences.

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1512,17 +1512,16 @@ class smb(connection):
             max_rid = int(self.args.rid_brute)
 
         KNOWN_PROTOCOLS = {
-            135: {"bindstr": rf"ncacn_ip_tcp:{self.host}"},
-            139: {"bindstr": rf"ncacn_np:{self.host}[\pipe\lsarpc]"},
-            445: {"bindstr": rf"ncacn_np:{self.host}[\pipe\lsarpc]"},
-        }
+            135: {"bindstr": rf"ncacn_ip_tcp:{self.remoteName}"},
+            139: {"bindstr": rf"ncacn_np:{self.remoteName}[\pipe\lsarpc]"},
+            445: {"bindstr": rf"ncacn_np:{self.remoteName}[\pipe\lsarpc]"},
+         }
 
         try:
             string_binding = KNOWN_PROTOCOLS[self.port]["bindstr"]
             self.logger.debug(f"StringBinding {string_binding}")
             rpc_transport = transport.DCERPCTransportFactory(string_binding)
-            rpc_transport.setRemoteHost(self.host)
-            rpc_transport.setRemoteName(self.hostname or self.host)
+            rpc_transport.setRemoteHost(self.remoteName)
 
             if hasattr(rpc_transport, "set_credentials"):
                 # This method exists only for selected protocol sequences.


### PR DESCRIPTION
## Description

While working on a Hack The Box machine, I encountered a situation where **NTLM was disabled**, and only **Kerberos authentication** was available. During enumeration, I realized that the core feature `--rid-brute` in `netexec` failed when used with the `-k` flag.

After some debugging, it turned out that the issue stemmed from an incorrect SPN being used in the DCERPC connection to `\pipe\lsarpc`. The SPN was constructed using the IP address instead of the FQDN, causing the KDC to return a `KDC_ERR_S_PRINCIPAL_UNKNOWN` error.

This PR adds a call to `rpc_transport.setRemoteName(...)` in the `rid_brute` method to ensure the SPN is built with the correct hostname. This small change restores compatibility with Kerberos environments and allows `--rid-brute` to function properly even when NTLM is not available.


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)


## Screenshots (if appropriate):

Before : 

![1](https://github.com/user-attachments/assets/217a40e5-f6f8-4a0c-b0f9-05899f24bbab)

After : 

![2](https://github.com/user-attachments/assets/cb68d88c-57ab-4887-97d2-1777d3391862)


## Checklist:

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
