### PR TITLE
Patches the --filter-shares so that it correctly finds READ,WRITE perm

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1198,7 +1198,7 @@ class smb(connection):
                     self.logger.debug(f"Error adding share: {error}")
 
         if self.args.filter_shares:
-            self.logger.display("[ REMOVED ] Use the --shares read,write options instead.")
+            self.logger.display("[REMOVED] Use the --shares read,write options instead.")
 
         self.logger.display("Enumerated shares")
         self.logger.highlight(f"{'Share':<15} {'Permissions':<15} {'Remark'}")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1197,14 +1197,18 @@ class smb(connection):
                     error = get_error_string(e)
                     self.logger.debug(f"Error adding share: {error}")
 
+        if self.args.filter_shares:
+            self.logger.display("[ REMOVED ] Use the --shares read,write options instead.")
+
         self.logger.display("Enumerated shares")
         self.logger.highlight(f"{'Share':<15} {'Permissions':<15} {'Remark'}")
         self.logger.highlight(f"{'-----':<15} {'-----------':<15} {'------'}")
+        
         for share in permissions:
             name = share["name"]
             remark = share["remark"]
             perms = ",".join(share["access"])
-            if self.args.filter_shares and not any(x in perms for x in self.args.filter_shares):
+            if self.args.shares and self.args.shares.lower() not in perms.lower():
                 continue
             self.logger.highlight(f"{name:<15} {perms:<15} {remark}")
         return permissions

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1203,10 +1203,10 @@ class smb(connection):
         for share in permissions:
             name = share["name"]
             remark = share["remark"]
-            perms = share["access"]
+            perms = ",".join(share["access"])
             if self.args.filter_shares and not any(x in perms for x in self.args.filter_shares):
                 continue
-            self.logger.highlight(f"{name:<15} {','.join(perms):<15} {remark}")
+            self.logger.highlight(f"{name:<15} {perms:<15} {remark}")
         return permissions
 
     def dir(self):

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -37,7 +37,7 @@ def proto_args(parser, parents):
     cred_gathering_group.add_argument("--user", dest="userntds", type=str, help="Dump selected user from DC")
 
     mapping_enum_group = smb_parser.add_argument_group("Mapping/Enumeration", "Options for Mapping/Enumerating")
-    mapping_enum_group.add_argument("--shares", type=str, nargs="?", const="read,write", help="Enumerate shares and access, filter on specified argument (read ; write ; read,write)")
+    mapping_enum_group.add_argument("--shares", type=str, nargs="?", const="", help="Enumerate shares and access, filter on specified argument (read ; write ; read,write)")
     mapping_enum_group.add_argument("--dir", nargs="?", type=str, const="", help="List the content of a path (default path: '%(const)s')")
     mapping_enum_group.add_argument("--interfaces", action="store_true", help="Enumerate network interfaces")
     mapping_enum_group.add_argument("--no-write-check", action="store_true", help="Skip write check on shares (avoid leaving traces when missing delete permissions)")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -37,7 +37,7 @@ def proto_args(parser, parents):
     cred_gathering_group.add_argument("--user", dest="userntds", type=str, help="Dump selected user from DC")
 
     mapping_enum_group = smb_parser.add_argument_group("Mapping/Enumeration", "Options for Mapping/Enumerating")
-    mapping_enum_group.add_argument("--shares", action="store_true", help="Enumerate shares and access")
+    mapping_enum_group.add_argument("--shares", type=str, nargs="?", const="read,write", help="Enumerate shares and access, filter on specified argument (read ; write ; read,write)")
     mapping_enum_group.add_argument("--dir", nargs="?", type=str, const="", help="List the content of a path (default path: '%(const)s')")
     mapping_enum_group.add_argument("--interfaces", action="store_true", help="Enumerate network interfaces")
     mapping_enum_group.add_argument("--no-write-check", action="store_true", help="Skip write check on shares (avoid leaving traces when missing delete permissions)")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -41,7 +41,7 @@ def proto_args(parser, parents):
     mapping_enum_group.add_argument("--dir", nargs="?", type=str, const="", help="List the content of a path (default path: '%(const)s')")
     mapping_enum_group.add_argument("--interfaces", action="store_true", help="Enumerate network interfaces")
     mapping_enum_group.add_argument("--no-write-check", action="store_true", help="Skip write check on shares (avoid leaving traces when missing delete permissions)")
-    mapping_enum_group.add_argument("--filter-shares", nargs="+", help="Filter share by access, option 'read' 'write' or 'read,write'")
+    mapping_enum_group.add_argument("--filter-shares", nargs="+", help="Filter share by access, option 'READ' 'WRITE' or 'READ,WRITE'")
     mapping_enum_group.add_argument("--smb-sessions", action="store_true", help="Enumerate active smb sessions")
     mapping_enum_group.add_argument("--disks", action="store_true", help="Enumerate disks")
     mapping_enum_group.add_argument("--loggedon-users-filter", action="store", help="only search for specific user, works with regex")


### PR DESCRIPTION
## Description

This PR fixes the --filter-shares option that couldn't detect READ,WRITE permission:

![image](https://github.com/user-attachments/assets/9cc518d7-c6d3-4036-b8ac-aafd051a2836)

It now does

![image](https://github.com/user-attachments/assets/d1cbc690-09c9-44c6-bc69-08b0340bbfa2)

If ok, I'll merge the --filter-shares options into the --shares option so that we can use it like that:

```python
python3 nxc/netexec.py smb 192.168.56.11 -u admin -p Defte@WF --shares READ,WRITE
```

Let me know for that part :)