### PR TITLE
fix(ldap): support get-sid and admin flag when using --use-kcache

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -664,7 +664,7 @@ class ldap(connection):
         resp = self.search(search_filter, attributes, sizeLimit=0, baseDN=self.baseDN)
         resp_parsed = parse_result_attributes(resp)
         answers = []
-        if resp and (self.password != "" or self.lmhash != "" or self.nthash != "" or self.aesKey != "") and self.username != "":
+        if resp and (self.password != "" or self.lmhash != "" or self.nthash != "" or self.aesKey != "" or self.use_kcache) and self.username != "":
             for item in resp_parsed:
                 self.sid_domain = "-".join(item["objectSid"].split("-")[:-1])
 


### PR DESCRIPTION
## Description

This change fixes the `--get-sid` behavior when using a Kerberos ticket cache (`--use-kcache`). Previously, the domain SID was only populated if a password or NT hash was provided, and the “admin” flag was not set when authenticating via cache. With this fix:

- The `use_kcache` flag is initialized in the LDAP client and injected into the `check_if_admin()` condition.
- `check_if_admin()` now runs even when no credentials (password or hashes) are provided, ensuring `self.sid_domain` is populated and `self.is_admin` is set when using a cached ticket.
- The `get_sid()` method is enhanced to query the `objectSid` attribute directly from the `domainDNS` object as a fallback, guaranteeing the domain SID is always retrieved.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):

Before : 

<img width="1607" height="108" alt="1" src="https://github.com/user-attachments/assets/775a9285-9f94-4acf-b3b1-030f65c5a702" />

After : 

<img width="1579" height="103" alt="2" src="https://github.com/user-attachments/assets/8217ddb3-196b-4d70-be5b-02b2a655ec23" />

## Checklist:

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
