### PR TITLE
docs: add deprecation change type and clarify e2e tests checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@ Please include a summary of the change and which issue is fixed, or what the enh
 List any dependencies that are required for this change.
 
 ## Type of change
+Insert an "x" inside the brackets for relevant items (do not delete options)
+
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
@@ -22,6 +24,7 @@ Screenshots are always nice to have and can give a visual representation of the 
 If appropriate include before and after screenshot(s) to show which results are to be expected.
 
 ## Checklist:
+Insert an "x" inside the brackets for completed and relevant items (do not delete options)
 
 - [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
 - [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ List any dependencies that are required for this change.
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Deprecation of feature or functionality
 - [ ] This change requires a documentation update
 - [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
 
@@ -23,7 +24,7 @@ If appropriate include before and after screenshot(s) to show which results are 
 ## Checklist:
 
 - [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
-- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
+- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
 - [ ] New and existing e2e tests pass locally with my changes
 - [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
 - [ ] I have performed a self-review of my own code


### PR DESCRIPTION
- If we deprecate something, we should have a type of change checkbox (not every deprecation is breaking) 
- People are adding features and modules without adding them to the e2e tests