### PR TITLE
Rework schtask_as and --exec-method atexec

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -805,7 +805,7 @@ class smb(connection):
                     self.logger.debug("Error executing command via mmcexec, traceback:")
                     self.logger.debug(format_exc())
                     continue
-            elif method == "atexec":               
+            elif method == "atexec":
                 try:
                     exec_method = TSCH_EXEC(
                         self.host if not self.kerberos else self.hostname + "." + self.domain,

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -805,18 +805,7 @@ class smb(connection):
                     self.logger.debug("Error executing command via mmcexec, traceback:")
                     self.logger.debug(format_exc())
                     continue
-            elif method == "atexec":
-                # This is the default NT Authority SYSTEM account
-                run_task_as = "S-1-5-18"
-                # Check if a task should be run by another user
-                if getattr(self.args, "run_task_as", False):
-                    run_task_as = self.args.run_task_as
-
-                # Generates the task name randomly or from supplied argument
-                task_name = gen_random_string(8)
-                if getattr(self.args, "task_name", False):
-                    task_name = self.args.task_name
-
+            elif method == "atexec":               
                 try:
                     exec_method = TSCH_EXEC(
                         self.host if not self.kerberos else self.hostname + "." + self.domain,
@@ -824,8 +813,9 @@ class smb(connection):
                         self.username,
                         self.password,
                         self.domain,
-                        task_name,
-                        run_task_as,
+                        self.args.task_name,
+                        self.args.run_task_as,
+                        self.args.upload_task_binary,
                         self.kerberos,
                         self.aesKey,
                         self.host,
@@ -892,6 +882,7 @@ class smb(connection):
                 if output:
                     for line in output.split("\n"):
                         self.logger.highlight(line)
+
             return output
         else:
             self.logger.fail(f"Execute command failed with {current_method}")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -806,6 +806,11 @@ class smb(connection):
                     self.logger.debug(format_exc())
                     continue
             elif method == "atexec":
+                # This is the default NT Authority SYSTEM account
+                run_task_as = "S-1-5-18"
+                # Check if a task should be run by another user
+                if getattr(self.args, "run_task_as", False):
+                    run_task_as = self.args.run_task_as
                 try:
                     exec_method = TSCH_EXEC(
                         self.host if not self.kerberos else self.hostname + "." + self.domain,
@@ -813,6 +818,7 @@ class smb(connection):
                         self.username,
                         self.password,
                         self.domain,
+                        run_task_as,
                         self.kerberos,
                         self.aesKey,
                         self.host,

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -811,6 +811,12 @@ class smb(connection):
                 # Check if a task should be run by another user
                 if getattr(self.args, "run_task_as", False):
                     run_task_as = self.args.run_task_as
+
+                # Generates the task name randomly or from supplied argument
+                task_name = gen_random_string(8)
+                if getattr(self.args, "task_name", False):
+                    task_name = self.args.task_name
+
                 try:
                     exec_method = TSCH_EXEC(
                         self.host if not self.kerberos else self.hostname + "." + self.domain,
@@ -818,6 +824,7 @@ class smb(connection):
                         self.username,
                         self.password,
                         self.domain,
+                        task_name,
                         run_task_as,
                         self.kerberos,
                         self.aesKey,

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -4,7 +4,6 @@ from impacket.dcerpc.v5 import tsch, transport
 from impacket.dcerpc.v5.dtypes import NULL
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from nxc.helpers.misc import gen_random_string
-from nxc.paths import TMP_PATH
 from time import sleep
 from datetime import datetime, timedelta
 
@@ -32,6 +31,7 @@ class TSCH_EXEC:
         self.__output_filename = None
         self.__share = share
         self.logger = logger
+        self.smbConnection = None
         self.upload_task_binary = upload_task_binary
         # Specifies that the task should be run as SYSTEM (S-1-5-18) or the run_task_as username
         self.run_task_as = "S-1-5-18" if run_task_as is None else run_task_as
@@ -82,7 +82,7 @@ class TSCH_EXEC:
         # Format it to match the format in the XML: "YYYY-MM-DDTHH:MM:SS.ssssss"
         return end_boundary.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
 
-    def gen_xml(self, command, fileless=False):
+    def gen_xml(self, command):
         xml = f"""<?xml version="1.0" encoding="UTF-16"?>
         <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
         <Triggers>
@@ -120,11 +120,7 @@ class TSCH_EXEC:
         """
         if self.__retOutput:
             self.__output_filename = f"{self.temp_dir}\{gen_random_string(6)}"
-            if fileless:
-                local_ip = self.__rpctransport.get_socket().getsockname()[0]
-                argument_xml = f"      <Arguments>/C {command} &gt; \\\\{local_ip}\\{self.__share_name}\\{self.__output_filename} 2&gt;&amp;1</Arguments>"
-            else:
-                argument_xml = f"      <Arguments>/C {command} &gt; {self.__output_filename} 2&gt;&amp;1</Arguments>"
+            argument_xml = f"      <Arguments>/C {command} &gt; {self.__output_filename} 2&gt;&amp;1</Arguments>"
 
         elif self.__retOutput is False:
             argument_xml = f"      <Arguments>/C {command}</Arguments>"
@@ -140,7 +136,7 @@ class TSCH_EXEC:
         # Removing identation in the final computed XML file
         return dedent(xml)
 
-    def execute_handler(self, command, fileless=False):
+    def execute_handler(self, command):
         dce = self.__rpctransport.get_dce_rpc()
         if self.__doKerberos:
             dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
@@ -149,7 +145,7 @@ class TSCH_EXEC:
         dce.connect()
 
         # Creates a fully working SMB connection used to upload/delete files
-        smbConnection = self.__rpctransport.get_smb_connection()
+        self.smbConnection = self.__rpctransport.get_smb_connection()
 
         # Uploads the binary that will be run via the scheduled task
         if self.upload_task_binary is not None:
@@ -160,16 +156,15 @@ class TSCH_EXEC:
                 binary_name = os.path.basename(upload_task_binary)
                 # Uploads the file to \\Windows\Temp\binary.exe
                 with open(upload_task_binary, "rb") as binary_content:
-                    smbConnection.putFile(self.__share, f"{self.temp_dir}{binary_name}", binary_content.read)
+                    self.smbConnection.putFile(self.__share, f"{self.temp_dir}{binary_name}", binary_content.read)
                 # Modifies the command to run to include full path
                 command = f"{self.temp_dir}{command}"
             else:
                 self.logger.fail(f"Cannot open {self.upload_task_binary}, canceling task creation")
                 return
 
-        xml = self.gen_xml(command, fileless)
-        self.logger.debug(f"Task XML: {xml}")
-        self.logger.info(f"Creating task \\{self.task_name}")
+        xml = self.gen_xml(command)
+        self.logger.debug(f"Creating task \\{self.task_name} with XML: {xml}")
         try:
             # windows server 2003 has no MSRPC_UUID_TSCHS, if it bind, it will return abstract_syntax_not_supported
             dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
@@ -198,63 +193,52 @@ class TSCH_EXEC:
         tsch.hSchRpcDelete(dce, f"\\{self.task_name}")
 
         if self.__retOutput:
-            if fileless:
-                while True:
-                    try:
-                        with open(os.path.join(TMP_PATH, self.__output_filename)) as output:
-                            self.output_callback(output.read())
-                        break
-                    except OSError:
-                        sleep(2)
-            else:
-                ":".join(map(str, self.__rpctransport.get_socket().getpeername()))
-                smbConnection = self.__rpctransport.get_smb_connection()
-
-                tries = 1
-                # Give the command a bit of time to execute before we try to read the output, 0.4 seconds was good in testing
-                sleep(0.4)
-                while True:
-                    try:
-                        self.logger.info(f"Attempting to read {self.__share}\\{self.__output_filename}")
-                        smbConnection.getFile(self.__share, self.__output_filename, self.output_callback)
-                        break
-                    except Exception as e:
-                        if tries >= self.__tries:
-                            self.logger.fail("ATEXEC: Could not retrieve output file, it may have been detected by AV. Please increase the number of tries with the option '--get-output-tries'. If it is still failing, try the 'wmi' protocol or another exec method")
-                            break
-                        if "STATUS_BAD_NETWORK_NAME" in str(e):
-                            self.logger.fail(f"ATEXEC: Getting the output file failed - target has blocked access to the share: {self.__share} (but the command may have executed!)")
-                            break
-                        elif "STATUS_VIRUS_INFECTED" in str(e):
-                            self.logger.fail("Command did not run because a virus was detected")
-                            break
-                        # When executing powershell and the command is still running, we get a sharing violation
-                        # We can use that information to wait longer than if the file is not found (probably av or something)
-                        if "STATUS_SHARING_VIOLATION" in str(e):
-                            self.logger.info(f"File {self.__share}\\{self.__output_filename} is still in use with {self.__tries - tries} tries left, retrying...")
-                            tries += 1
-                            sleep(1)
-                        elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
-                            self.logger.info(f"File {self.__share}\\{self.__output_filename} not found with {self.__tries - tries} tries left, deducting 10 tries and retrying...")
-                            tries += 10
-                            sleep(1)
-                        else:
-                            self.logger.debug(f"Exception when trying to read output file: {e!s}. {self.__tries - tries} tries left, retrying...")
-                            tries += 1
-                            sleep(1)
-
+            tries = 1
+            # Give the command a bit of time to execute before we try to read the output, 0.4 seconds was good in testing
+            sleep(0.4)
+            while True:
                 try:
-                    self.logger.debug(f"Deleting file {self.__share}\\{self.__output_filename}")
-                    smbConnection.deleteFile(self.__share, self.__output_filename)
+                    self.logger.info(f"Attempting to read {self.__share}\\{self.__output_filename}")
+                    self.smbConnection.getFile(self.__share, self.__output_filename, self.output_callback)
+                    break
                 except Exception as e:
-                    self.logger.fail(f"Error while deleting file {self.__share}\\{self.__output_filename}: {e}")
+                    if tries >= self.__tries:
+                        self.logger.fail("ATEXEC: Could not retrieve output file, it may have been detected by AV. Please increase the number of tries with the option '--get-output-tries'. If it is still failing, try the 'wmi' protocol or another exec method")
+                        break
+                    if "STATUS_BAD_NETWORK_NAME" in str(e):
+                        self.logger.fail(f"ATEXEC: Getting the output file failed - target has blocked access to the share: {self.__share} (but the command may have executed!)")
+                        break
+                    elif "STATUS_VIRUS_INFECTED" in str(e):
+                        self.logger.fail("Command did not run because a virus was detected")
+                        break
+                    # When executing powershell and the command is still running, we get a sharing violation
+                    # We can use that information to wait longer than if the file is not found (probably av or something)
+                    if "STATUS_SHARING_VIOLATION" in str(e):
+                        self.logger.info(f"File {self.__share}\\{self.__output_filename} is still in use with {self.__tries - tries} tries left, retrying...")
+                        tries += 1
+                        sleep(1)
+                    elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
+                        self.logger.info(f"File {self.__share}\\{self.__output_filename} not found with {self.__tries - tries} tries left, deducting 10 tries and retrying...")
+                        tries += 10
+                        sleep(1)
+                    else:
+                        self.logger.debug(f"Exception when trying to read output file: {e!s}. {self.__tries - tries} tries left, retrying...")
+                        tries += 1
+                        sleep(1)
 
-                # Removes the uploaded binary that was run via the scheduled task
-                if self.upload_task_binary is not None:
-                    try:
-                        self.logger.success(f"Binary {self.temp_dir}{binary_name} successfully deleted")
-                        smbConnection.deleteFile(self.__share, f"{self.temp_dir}{binary_name}")
-                    except Exception as e:
-                        self.logger.fail(f"Couldn't remove {self.temp_dir}{binary_name}: {e}")
+            # Removes the output response file
+            try:
+                self.logger.debug(f"Deleting file {self.__share}\\{self.__output_filename}")
+                self.smbConnection.deleteFile(self.__share, self.__output_filename)
+            except Exception as e:
+                self.logger.fail(f"Error while deleting file {self.__share}\{self.__output_filename}: {e}")
+
+            # Removes the uploaded binary that was run via the scheduled task
+            if self.upload_task_binary is not None:
+                try:
+                    self.logger.success(f"Binary {self.temp_dir}{binary_name} successfully deleted")
+                    self.smbConnection.deleteFile(self.__share, f"{self.temp_dir}{binary_name}")
+                except Exception as e:
+                    self.logger.fail(f"Couldn't remove {self.temp_dir}{binary_name}: {e}")
 
         dce.disconnect()

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -80,6 +80,8 @@ def proto_args(parser, parents):
     cmd_exec_group = smb_parser.add_argument_group("Command Execution", "Options for executing commands")
     cmd_exec_group.add_argument("--exec-method", "--em", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
     cmd_exec_group.add_argument("--run-task-as", "--rta", help="Specify the username to run the scheduled tasks as", type=str, dest="run_task_as")
+    cmd_exec_group.add_argument("--task-name", "--tn", help="Specify the name of the scheduled task to create", type=str, dest="task_name")
+
     cmd_exec_group.add_argument("--dcom-timeout", help="DCOM connection timeout", type=int, default=5)
     cmd_exec_group.add_argument("--get-output-tries", help="Number of times atexec/smbexec/mmcexec tries to get results", type=int, default=10)
     cmd_exec_group.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -79,6 +79,7 @@ def proto_args(parser, parents):
 
     cmd_exec_group = smb_parser.add_argument_group("Command Execution", "Options for executing commands")
     cmd_exec_group.add_argument("--exec-method", "--em", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
+    cmd_exec_group.add_argument("--run-task-as", "--rta", help="Specify the username to run the scheduled tasks as", type=str, dest="run_task_as")
     cmd_exec_group.add_argument("--dcom-timeout", help="DCOM connection timeout", type=int, default=5)
     cmd_exec_group.add_argument("--get-output-tries", help="Number of times atexec/smbexec/mmcexec tries to get results", type=int, default=10)
     cmd_exec_group.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -78,7 +78,7 @@ def proto_args(parser, parents):
     files_group.add_argument("--append-host", action="store_true", help="append the host to the get-file filename")
 
     cmd_exec_group = smb_parser.add_argument_group("Command Execution", "Options for executing commands")
-    cmd_exec_group.add_argument("--exec-method", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
+    cmd_exec_group.add_argument("--exec-method", "--em", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
     cmd_exec_group.add_argument("--dcom-timeout", help="DCOM connection timeout", type=int, default=5)
     cmd_exec_group.add_argument("--get-output-tries", help="Number of times atexec/smbexec/mmcexec tries to get results", type=int, default=10)
     cmd_exec_group.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -81,12 +81,11 @@ def proto_args(parser, parents):
     cmd_exec_group.add_argument("--exec-method", "--em", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
     cmd_exec_group.add_argument("--run-task-as", "--rta", help="Specify the username to run the scheduled tasks as", type=str, dest="run_task_as")
     cmd_exec_group.add_argument("--task-name", "--tn", help="Specify the name of the scheduled task to create", type=str, dest="task_name")
-
+    cmd_exec_group.add_argument("--upload-binary", "--ub", help="Binary to upload before running the scheduled task", type=str, dest="upload_task_binary")
     cmd_exec_group.add_argument("--dcom-timeout", help="DCOM connection timeout", type=int, default=5)
     cmd_exec_group.add_argument("--get-output-tries", help="Number of times atexec/smbexec/mmcexec tries to get results", type=int, default=10)
     cmd_exec_group.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     cmd_exec_group.add_argument("--no-output", action="store_true", help="do not retrieve command output")
-
     cmd_exec_method_group = cmd_exec_group.add_mutually_exclusive_group()
     cmd_exec_method_group.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified CMD command")
     cmd_exec_method_group.add_argument("-X", metavar="PS_COMMAND", dest="ps_execute", help="execute the specified PowerShell command")

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -29,6 +29,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sccm
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sccm wmi
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method atexec
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method atexec --run-task-as Admin
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method smbexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method mmcexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file.txt
@@ -37,6 +38,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --get-file 
 ##### SMB PowerShell
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method atexec
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method atexec --run-task-as Admin
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method smbexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method mmcexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --force-ps32

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -29,7 +29,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sccm
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sccm wmi
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method atexec
-netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method atexec --run-task-as Admin
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method atexec --run-task-as administrator
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method smbexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method mmcexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file.txt
@@ -38,7 +38,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --get-file 
 ##### SMB PowerShell
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method atexec
-netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method atexec --run-task-as Admin
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method atexec --run-task-as administrator
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method smbexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method mmcexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --force-ps32


### PR DESCRIPTION
This PR is a work in progress to merge the schtask_as module with the core execution method atexec:

By default the task is run via the NT SYSTEM account:
<img width="1054" height="123" alt="image" src="https://github.com/user-attachments/assets/5ba15298-77ac-4287-8d6f-6af302ffa859" />

And we can also specify the username we want to run the task:
<img width="1083" height="119" alt="image" src="https://github.com/user-attachments/assets/049ccceb-8960-46cd-aebd-fddf2f0f6dd1" />

Allowing full impersonation.

I still have to add the following options from the module:
* log file path
* task name
* binary upload before execution and deletion

(Note that I also shortened the option name so we can use --exec-method as well as --em and --run-task-as as well as -rta)