### PR TITLE
Removing the horrible multiple hosts option

### DIFF
--- a/nxc/loaders/moduleloader.py
+++ b/nxc/loaders/moduleloader.py
@@ -33,9 +33,6 @@ class ModuleLoader:
         elif not hasattr(module, "supported_protocols"):
             self.logger.fail(f"{module_path} missing the supported_protocols variable")
             module_error = True
-        elif not hasattr(module, "multiple_hosts"):
-            self.logger.fail(f"{module_path} missing the multiple_hosts variable")
-            module_error = True
         elif not hasattr(module, "options"):
             self.logger.fail(f"{module_path} missing the options function")
             module_error = True
@@ -95,7 +92,6 @@ class ModuleLoader:
                     "description": module_spec.description,
                     "options": module_spec.options.__doc__,
                     "supported_protocols": module_spec.supported_protocols,
-                    "multiple_hosts": module_spec.multiple_hosts,
                     "requires_admin": bool(hasattr(module_spec, "on_admin_login") and callable(module_spec.on_admin_login)),
                 }
             }

--- a/nxc/modules/adcs.py
+++ b/nxc/modules/adcs.py
@@ -13,7 +13,6 @@ class NXCModule:
     name = "adcs"
     description = "Find PKI Enrollment Services in Active Directory and Certificate Templates Names"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/add-computer.py
+++ b/nxc/modules/add-computer.py
@@ -17,7 +17,6 @@ class NXCModule:
     description = "Adds or deletes a domain computer"
     supported_protocols = ["smb"]
 
-
     def options(self, context, module_options):
         """
         add-computer: Specify add-computer to call the module using smb

--- a/nxc/modules/add-computer.py
+++ b/nxc/modules/add-computer.py
@@ -16,7 +16,7 @@ class NXCModule:
     name = "add-computer"
     description = "Adds or deletes a domain computer"
     supported_protocols = ["smb"]
-    multiple_hosts = False
+
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/aws-credentials.py
+++ b/nxc/modules/aws-credentials.py
@@ -8,7 +8,6 @@ class NXCModule:
     name = "aws-credentials"
     description = "Search for aws credentials files."
     supported_protocols = ["ssh", "smb", "winrm"]
-    multiple_hosts = True
 
     def __init__(self):
         self.search_path_linux = "'/home/' '/tmp/'"

--- a/nxc/modules/backup_operator.py
+++ b/nxc/modules/backup_operator.py
@@ -13,7 +13,6 @@ class NXCModule:
     name = "backup_operator"
     description = "Exploit user in backup operator group to dump NTDS @mpgn_x64"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/badsuccessor.py
+++ b/nxc/modules/badsuccessor.py
@@ -79,7 +79,6 @@ class NXCModule:
     name = "badsuccessor"
     description = "Check if vulnerable to bad successor attack (DMSA)"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/bitlocker.py
+++ b/nxc/modules/bitlocker.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "bitlocker"
     description = "Enumerating BitLocker Status on target(s) If it is enabled or disabled."
     supported_protocols = ["smb", "wmi"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/change-password.py
+++ b/nxc/modules/change-password.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "change-password"
     description = "Change or reset user passwords via various protocols"
     supported_protocols = ["smb"]
-    multiple_hosts = False
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/coerce_plus.py
+++ b/nxc/modules/coerce_plus.py
@@ -11,7 +11,6 @@ class NXCModule:
     name = "coerce_plus"
     description = "Module to check if the Target is vulnerable to any coerce vulns. Set LISTENER IP for coercion."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -200,7 +200,6 @@ class NXCModule:
     description = "Read and backup the Discretionary Access Control List of objects. Be careful, this module cannot read the DACLS recursively, see more explanation in the options."
     supported_protocols = ["ldap"]
 
-
     def __init__(self, context=None, module_options=None):
         self.context = context
         self.module_options = module_options

--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -199,7 +199,7 @@ class NXCModule:
     name = "daclread"
     description = "Read and backup the Discretionary Access Control List of objects. Be careful, this module cannot read the DACLS recursively, see more explanation in the options."
     supported_protocols = ["ldap"]
-    multiple_hosts = False
+
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/dfscoerce.py
+++ b/nxc/modules/dfscoerce.py
@@ -2,7 +2,6 @@ class NXCModule:
     name = "dfscoerce"
     description = "[REMOVED] Module to check if the DC is vulnerable to DFSCoerce, credit to @filip_dragovic/@Wh04m1001 and @topotam"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/dpapi_hash.py
+++ b/nxc/modules/dpapi_hash.py
@@ -10,7 +10,6 @@ class NXCModule:
     name = "dpapi_hash"
     description = "Remotely dump Dpapi hash based on masterkeys"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """OUTPUTFILE       Output file to write hashes"""

--- a/nxc/modules/drop-sc.py
+++ b/nxc/modules/drop-sc.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "drop-sc"
     description = "Drop a searchConnector-ms file on each writable share"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/dump-computers.py
+++ b/nxc/modules/dump-computers.py
@@ -5,7 +5,7 @@ class NXCModule:
     name = "dump-computers"
     description = "Dumps all computers in the domain"
     supported_protocols = ["ldap"]
-    multiple_hosts = False
+
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/dump-computers.py
+++ b/nxc/modules/dump-computers.py
@@ -6,7 +6,6 @@ class NXCModule:
     description = "Dumps all computers in the domain"
     supported_protocols = ["ldap"]
 
-
     def options(self, context, module_options):
         """
         TYPE        Only dump NETBIOS or FQDN instead of 'FQDN (OS Version)'

--- a/nxc/modules/efsr_spray.py
+++ b/nxc/modules/efsr_spray.py
@@ -27,7 +27,6 @@ class NXCModule:
     name = "efsr_spray"
     description = "Tries to activate the EFSR service by creating a file with the encryption attribute on some available share."
     supported_protocols = ["smb"]
-    multiple_hosts = True  # Does the module support multiple hosts?
     excluded_shares = ["SYSVOL"]
 
     def options(self, context: Context, module_options: dict[str, str]):

--- a/nxc/modules/empire_exec.py
+++ b/nxc/modules/empire_exec.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "empire_exec"
     description = "Uses Empire's RESTful API to generate a launcher for the specified listener and executes it"
     supported_protocols = ["smb", "mssql"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/enable_cmdshell.py
+++ b/nxc/modules/enable_cmdshell.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "enable_cmdshell"
     description = "Enable or disable xp_cmdshell in MSSQL Server"
     supported_protocols = ["mssql"]
-    multiple_hosts = True
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/entra-id.py
+++ b/nxc/modules/entra-id.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "entra-id"
     description = "Find the Entra ID sync server"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/entra-sync-creds.py
+++ b/nxc/modules/entra-sync-creds.py
@@ -14,7 +14,6 @@ class NXCModule:
     description = "Extract Entra ID sync credentials from the target host"
     supported_protocols = ["smb"]
     opsec_safe = True
-    multiple_hosts = True
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/enum_av.py
+++ b/nxc/modules/enum_av.py
@@ -18,7 +18,6 @@ class NXCModule:
     name = "enum_av"
     description = "Gathers information on all endpoint protection solutions installed on the the remote host(s) via LsarLookupNames (no privilege needed)"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/enum_ca.py
+++ b/nxc/modules/enum_ca.py
@@ -24,7 +24,7 @@ class NXCModule:
     name = "enum_ca"
     description = "Anonymously uses RPC endpoints to hunt for ADCS CAs"
     supported_protocols = ["smb"]  # Example: ['smb', 'mssql']
-    multiple_hosts = True  # Does it make sense to run this module on multiple hosts at a time?
+
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/enum_ca.py
+++ b/nxc/modules/enum_ca.py
@@ -25,7 +25,6 @@ class NXCModule:
     description = "Anonymously uses RPC endpoints to hunt for ADCS CAs"
     supported_protocols = ["smb"]  # Example: ['smb', 'mssql']
 
-
     def __init__(self, context=None, module_options=None):
         self.context = context
         self.module_options = module_options

--- a/nxc/modules/enum_dns.py
+++ b/nxc/modules/enum_dns.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "enum_dns"
     description = "Uses WMI to dump DNS from an AD DNS Server"
     supported_protocols = ["smb", "wmi"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/enum_impersonate.py
+++ b/nxc/modules/enum_impersonate.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "enum_impersonate"
     description = "Enumerate users with impersonation privileges"
     supported_protocols = ["mssql"]
-    multiple_hosts = True
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/enum_links.py
+++ b/nxc/modules/enum_links.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "enum_links"
     description = "Enumerate linked SQL Servers and their login configurations."
     supported_protocols = ["mssql"]
-    multiple_hosts = True
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/enum_logins.py
+++ b/nxc/modules/enum_logins.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "enum_logins"
     description = "Enumerate SQL Server logins (SQL, Domain, Local users)"
     supported_protocols = ["mssql"]
-    multiple_hosts = True
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/enum_trusts.py
+++ b/nxc/modules/enum_trusts.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "enum_trusts"
     description = "[REMOVED] Extract all Trust Relationships, Trusting Direction, and Trust Transitivity"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         pass

--- a/nxc/modules/eventlog_creds.py
+++ b/nxc/modules/eventlog_creds.py
@@ -13,7 +13,7 @@ class NXCModule:
     name = "eventlog_creds"
     description = "Extracting Credentials From Windows Logs (Event ID: 4688 and SYSMON)"
     supported_protocols = ["smb"]  # Example: ['smb', 'mssql']
-    multiple_hosts = True  # Does it make sense to run this module on multiple hosts at a time?
+
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/eventlog_creds.py
+++ b/nxc/modules/eventlog_creds.py
@@ -14,7 +14,6 @@ class NXCModule:
     description = "Extracting Credentials From Windows Logs (Event ID: 4688 and SYSMON)"
     supported_protocols = ["smb"]  # Example: ['smb', 'mssql']
 
-
     def __init__(self):
         self.context = None
         self.module_options = None

--- a/nxc/modules/example_module.py
+++ b/nxc/modules/example_module.py
@@ -9,7 +9,7 @@ class NXCModule:
     name = "example module"
     description = "I do something"
     supported_protocols = []  # Example: ['smb', 'mssql']
-    multiple_hosts = True  # Does it make sense to run this module on multiple hosts at a time?
+
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/example_module.py
+++ b/nxc/modules/example_module.py
@@ -10,7 +10,6 @@ class NXCModule:
     description = "I do something"
     supported_protocols = []  # Example: ['smb', 'mssql']
 
-
     def __init__(self):
         self.context = None
         self.module_options = None

--- a/nxc/modules/exec_on_link.py
+++ b/nxc/modules/exec_on_link.py
@@ -7,7 +7,7 @@ class NXCModule:
     name = "exec_on_link"
     description = "Execute commands on a SQL Server linked server"
     supported_protocols = ["mssql"]
-    multiple_hosts = False
+
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/exec_on_link.py
+++ b/nxc/modules/exec_on_link.py
@@ -8,7 +8,6 @@ class NXCModule:
     description = "Execute commands on a SQL Server linked server"
     supported_protocols = ["mssql"]
 
-
     def __init__(self):
         self.mssql_conn = None
         self.context = None

--- a/nxc/modules/find-computer.py
+++ b/nxc/modules/find-computer.py
@@ -17,7 +17,6 @@ class NXCModule:
     description = "Finds computers in the domain via the provided text"
     supported_protocols = ["ldap"]
 
-
     def options(self, context, module_options):
         """
         find-computer: Specify find-computer to call the module

--- a/nxc/modules/find-computer.py
+++ b/nxc/modules/find-computer.py
@@ -16,7 +16,7 @@ class NXCModule:
     name = "find-computer"
     description = "Finds computers in the domain via the provided text"
     supported_protocols = ["ldap"]
-    multiple_hosts = False
+
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/firefox.py
+++ b/nxc/modules/firefox.py
@@ -12,7 +12,7 @@ class NXCModule:
     name = "firefox"
     description = "[REMOVED] Dump credentials from Firefox"
     supported_protocols = ["smb"]
-    multiple_hosts = True  # Does it make sense to run this module on multiple hosts at a time?
+
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/firefox.py
+++ b/nxc/modules/firefox.py
@@ -13,7 +13,6 @@ class NXCModule:
     description = "[REMOVED] Dump credentials from Firefox"
     supported_protocols = ["smb"]
 
-
     def options(self, context, module_options):
         """
         [REMOVED] use the --dpapi flag instead of the module firefox.

--- a/nxc/modules/get-desc-users.py
+++ b/nxc/modules/get-desc-users.py
@@ -13,7 +13,7 @@ class NXCModule:
     name = "get-desc-users"
     description = "Get description of the users. May contained password"
     supported_protocols = ["ldap"]
-    multiple_hosts = True  # Does it make sense to run this module on multiple hosts at a time?
+
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/get-desc-users.py
+++ b/nxc/modules/get-desc-users.py
@@ -14,7 +14,6 @@ class NXCModule:
     description = "Get description of the users. May contained password"
     supported_protocols = ["ldap"]
 
-
     def options(self, context, module_options):
         """
         FILTER    Apply the FILTER (grep-like) (default: '')

--- a/nxc/modules/get-info-users.py
+++ b/nxc/modules/get-info-users.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "get-info-users"
     description = "Get the info field of all users. May contain password"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """FILTER    Apply the FILTER (grep-like) (default: '')"""

--- a/nxc/modules/get-network.py
+++ b/nxc/modules/get-network.py
@@ -84,7 +84,6 @@ class NXCModule:
     name = "get-network"
     description = "Query all DNS records with the corresponding IP from the domain."
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/get-unixUserPassword.py
+++ b/nxc/modules/get-unixUserPassword.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "get-unixUserPassword"
     description = "Get unixUserPassword attribute from all users in ldap"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/get-userPassword.py
+++ b/nxc/modules/get-userPassword.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "get-userPassword"
     description = "Get userPassword attribute from all users in ldap"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/get_netconnections.py
+++ b/nxc/modules/get_netconnections.py
@@ -14,7 +14,6 @@ class NXCModule:
     name = "get_netconnections"
     description = "Uses WMI to query network connections."
     supported_protocols = ["smb", "wmi"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """No options available"""

--- a/nxc/modules/gpp_autologin.py
+++ b/nxc/modules/gpp_autologin.py
@@ -11,7 +11,6 @@ class NXCModule:
     name = "gpp_autologin"
     description = "Searches the domain controller for registry.xml to find autologon information and returns the username and password."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/gpp_password.py
+++ b/nxc/modules/gpp_password.py
@@ -14,7 +14,6 @@ class NXCModule:
     name = "gpp_password"
     description = "Retrieves the plaintext password and other information for accounts pushed through Group Policy Preferences."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/gpp_privileges.py
+++ b/nxc/modules/gpp_privileges.py
@@ -13,7 +13,6 @@ class NXCModule:
     name = "gpp_privileges"
     description = "Extracts privileges assigned via GPOs and resolves SIDs via LDAP."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     WELL_KNOWN_SIDS = {
         "S-1-0": "Null Authority",

--- a/nxc/modules/group-mem.py
+++ b/nxc/modules/group-mem.py
@@ -13,7 +13,7 @@ class NXCModule:
     name = "group-mem"
     description = "[REMOVED] Retrieves all the members within a Group"
     supported_protocols = ["ldap"]
-    multiple_hosts = False
+
     primaryGroupID = ""
     answers = []
 

--- a/nxc/modules/groupmembership.py
+++ b/nxc/modules/groupmembership.py
@@ -15,7 +15,6 @@ class NXCModule:
     name = "groupmembership"
     description = "Query the groups to which a user belongs."
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """USER	Choose a username to query group membership"""

--- a/nxc/modules/handlekatz.py
+++ b/nxc/modules/handlekatz.py
@@ -14,7 +14,6 @@ class NXCModule:
     name = "handlekatz"
     description = "Get lsass dump using handlekatz64 and parse the result with pypykatz"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/hash_spider.py
+++ b/nxc/modules/hash_spider.py
@@ -130,7 +130,6 @@ class NXCModule:
     name = "hash_spider"
     description = "Dump lsass recursively from a given hash using BH to find local admins"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/hyperv-host.py
+++ b/nxc/modules/hyperv-host.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "hyperv-host"
     description = "Performs a registry query on the VM to lookup its HyperV Host"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/iis.py
+++ b/nxc/modules/iis.py
@@ -8,7 +8,6 @@ class NXCModule:
     name = "iis"
     description = "Checks for credentials in IIS Application Pool configuration files using appcmd.exe"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self):
         pass

--- a/nxc/modules/impersonate.py
+++ b/nxc/modules/impersonate.py
@@ -14,7 +14,6 @@ class NXCModule:
     name = "impersonate"
     description = "List and impersonate tokens to run command as locally logged on users"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/install_elevated.py
+++ b/nxc/modules/install_elevated.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "install_elevated"
     description = "Checks for AlwaysInstallElevated"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/ioxidresolver.py
+++ b/nxc/modules/ioxidresolver.py
@@ -13,7 +13,6 @@ class NXCModule:
     name = "ioxidresolver"
     description = "This module helps you to identify hosts that have additional active interfaces"
     supported_protocols = ["smb", "wmi"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """DIFFERENT show only ip address if different from target ip (Default: False)"""

--- a/nxc/modules/keepass_discover.py
+++ b/nxc/modules/keepass_discover.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "keepass_discover"
     description = "Search for KeePass-related files and process."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self):
         self.search_type = "ALL"

--- a/nxc/modules/keepass_trigger.py
+++ b/nxc/modules/keepass_trigger.py
@@ -25,7 +25,6 @@ class NXCModule:
     # some EDR like Trend Micro flag base64-encoded powershell as malicious
     # the option PSH_EXEC_METHOD can be used to avoid such execution, and will drop scripts on the target
 
-
     def __init__(self):
         # module options
         self.action = None

--- a/nxc/modules/keepass_trigger.py
+++ b/nxc/modules/keepass_trigger.py
@@ -24,7 +24,7 @@ class NXCModule:
     # while the module only executes legit powershell commands on the target (search and edit files)
     # some EDR like Trend Micro flag base64-encoded powershell as malicious
     # the option PSH_EXEC_METHOD can be used to avoid such execution, and will drop scripts on the target
-    multiple_hosts = False
+
 
     def __init__(self):
         # module options

--- a/nxc/modules/laps.py
+++ b/nxc/modules/laps.py
@@ -17,7 +17,7 @@ class NXCModule:
     name = "laps"
     description = "Retrieves all LAPS passwords which the account has read permissions for."
     supported_protocols = ["ldap"]
-    multiple_hosts = False
+
 
     def options(self, context, module_options):
         """COMPUTER    Computer name or wildcard ex: WIN-S10, WIN-* etc. Default: *"""

--- a/nxc/modules/laps.py
+++ b/nxc/modules/laps.py
@@ -18,7 +18,6 @@ class NXCModule:
     description = "Retrieves all LAPS passwords which the account has read permissions for."
     supported_protocols = ["ldap"]
 
-
     def options(self, context, module_options):
         """COMPUTER    Computer name or wildcard ex: WIN-S10, WIN-* etc. Default: *"""
         self.computer = None

--- a/nxc/modules/ldap-checker.py
+++ b/nxc/modules/ldap-checker.py
@@ -25,7 +25,6 @@ class NXCModule:
     name = "ldap-checker"
     description = "[REMOVED] Checks whether LDAP signing and channel binding are required and / or enforced"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """No options available."""

--- a/nxc/modules/link_enable_cmdshell.py
+++ b/nxc/modules/link_enable_cmdshell.py
@@ -8,7 +8,6 @@ class NXCModule:
     description = "Enable or disable xp_cmdshell on a linked MSSQL server"
     supported_protocols = ["mssql"]
 
-
     def __init__(self):
         self.action = None
         self.linked_server = None

--- a/nxc/modules/link_enable_cmdshell.py
+++ b/nxc/modules/link_enable_cmdshell.py
@@ -7,7 +7,7 @@ class NXCModule:
     name = "link_enable_cmdshell"
     description = "Enable or disable xp_cmdshell on a linked MSSQL server"
     supported_protocols = ["mssql"]
-    multiple_hosts = False
+
 
     def __init__(self):
         self.action = None

--- a/nxc/modules/link_xpcmd.py
+++ b/nxc/modules/link_xpcmd.py
@@ -7,7 +7,7 @@ class NXCModule:
     name = "link_xpcmd"
     description = "Run xp_cmdshell commands on a linked SQL server"
     supported_protocols = ["mssql"]
-    multiple_hosts = False
+
 
     def __init__(self):
         self.linked_server = None

--- a/nxc/modules/link_xpcmd.py
+++ b/nxc/modules/link_xpcmd.py
@@ -8,7 +8,6 @@ class NXCModule:
     description = "Run xp_cmdshell commands on a linked SQL server"
     supported_protocols = ["mssql"]
 
-
     def __init__(self):
         self.linked_server = None
         self.command = None

--- a/nxc/modules/lsassy.py
+++ b/nxc/modules/lsassy.py
@@ -16,7 +16,6 @@ class NXCModule:
     name = "lsassy"
     description = "Dump lsass and parse the result remotely with lsassy"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -20,7 +20,6 @@ class NXCModule:
     description = "Retrieves the MachineAccountQuota domain-level attribute"
     supported_protocols = ["ldap"]
 
-
     def on_login(self, context, connection):
         context.log.display("Getting the MachineAccountQuota")
         result = connection.search("(objectClass=*)", ["ms-DS-MachineAccountQuota"])

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -19,7 +19,7 @@ class NXCModule:
     name = "maq"
     description = "Retrieves the MachineAccountQuota domain-level attribute"
     supported_protocols = ["ldap"]
-    multiple_hosts = False
+
 
     def on_login(self, context, connection):
         context.log.display("Getting the MachineAccountQuota")

--- a/nxc/modules/masky.py
+++ b/nxc/modules/masky.py
@@ -6,7 +6,6 @@ class NXCModule:
     name = "masky"
     description = "Remotely dump domain user credentials via an ADCS and a KDC"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/met_inject.py
+++ b/nxc/modules/met_inject.py
@@ -10,7 +10,6 @@ class NXCModule:
     name = "met_inject"
     description = "Downloads the Meterpreter stager and injects it into memory"
     supported_protocols = ["smb", "mssql"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.rand = None

--- a/nxc/modules/mobaxterm.py
+++ b/nxc/modules/mobaxterm.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "mobaxterm"
     description = "Remotely dump MobaXterm credentials via RemoteRegistry or NTUSER.dat export"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/mremoteng.py
+++ b/nxc/modules/mremoteng.py
@@ -26,7 +26,6 @@ class NXCModule:
     name = "mremoteng"
     description = "Dump mRemoteNG Passwords in AppData and in Desktop / Documents folders (digging recursively in them) "
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.false_positive = (

--- a/nxc/modules/ms17-010.py
+++ b/nxc/modules/ms17-010.py
@@ -54,7 +54,6 @@ class NXCModule:
     name = "ms17-010"
     description = "MS17-010 - EternalBlue - NOT TESTED OUTSIDE LAB ENVIRONMENT"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/msol.py
+++ b/nxc/modules/msol.py
@@ -11,7 +11,6 @@ class NXCModule:
     name = "msol"
     description = "Dump MSOL cleartext password and Entra ID credentials from the localDB on the Entra ID Connect Server"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/mssql_coerce.py
+++ b/nxc/modules/mssql_coerce.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "mssql_coerce"
     description = "Execute arbitrary SQL commands on the target MSSQL server"
     supported_protocols = ["mssql"]
-    multiple_hosts = True
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/mssql_priv.py
+++ b/nxc/modules/mssql_priv.py
@@ -23,7 +23,6 @@ class NXCModule:
     name = "mssql_priv"
     description = "Enumerate and exploit MSSQL privileges"
     supported_protocols = ["mssql"]
-    multiple_hosts = True
 
     def __init__(self):
         self.admin_privs = None

--- a/nxc/modules/nanodump.py
+++ b/nxc/modules/nanodump.py
@@ -16,7 +16,6 @@ class NXCModule:
     name = "nanodump"
     description = "Get lsass dump using nanodump and parse the result with pypykatz"
     supported_protocols = ["smb", "mssql"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.connection = None

--- a/nxc/modules/nopac.py
+++ b/nxc/modules/nopac.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "nopac"
     description = "Check if the DC is vulnerable to CVE-2021-42278 and CVE-2021-42287 to impersonate DA from standard domain user"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/notepad++.py
+++ b/nxc/modules/notepad++.py
@@ -11,7 +11,6 @@ class NXCModule:
     name = "notepad++"
     description = "Extracts notepad++ unsaved files."
     supported_protocols = ["smb"]
-    multiple_hosts = True
     false_positive = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
 
     def options(self, context, module_options):

--- a/nxc/modules/notepad.py
+++ b/nxc/modules/notepad.py
@@ -28,7 +28,6 @@ class NXCModule:
     name = "notepad"
     description = "Extracts content from Windows Notepad tab state binary files."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None):
         self.context = context

--- a/nxc/modules/ntdsutil.py
+++ b/nxc/modules/ntdsutil.py
@@ -19,7 +19,7 @@ class NXCModule:
     name = "ntdsutil"
     description = "Dump NTDS with ntdsutil"
     supported_protocols = ["smb"]
-    multiple_hosts = False
+
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/ntdsutil.py
+++ b/nxc/modules/ntdsutil.py
@@ -20,7 +20,6 @@ class NXCModule:
     description = "Dump NTDS with ntdsutil"
     supported_protocols = ["smb"]
 
-
     def options(self, context, module_options):
         """
         Dump NTDS with ntdsutil

--- a/nxc/modules/ntlmv1.py
+++ b/nxc/modules/ntlmv1.py
@@ -13,7 +13,6 @@ class NXCModule:
     name = "ntlmv1"
     description = "Detect if lmcompatibilitylevel on the target is set to lower than 3 (which means ntlmv1 is enabled)"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         self.output = "NTLMv1 allowed on: {} - LmCompatibilityLevel = {}"

--- a/nxc/modules/obsolete.py
+++ b/nxc/modules/obsolete.py
@@ -13,7 +13,6 @@ class NXCModule:
     name = "obsolete"
     description = "Extract all obsolete operating systems from LDAP"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def ldap_time_to_datetime(self, ldap_time):
         """Convert an LDAP timestamp to a datetime object."""

--- a/nxc/modules/petitpotam.py
+++ b/nxc/modules/petitpotam.py
@@ -2,7 +2,6 @@ class NXCModule:
     name = "petitpotam"
     description = "[REMOVED] Module to check if the DC is vulnerable to PetitPotam, credit to @topotam"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/pi.py
+++ b/nxc/modules/pi.py
@@ -14,7 +14,6 @@ class NXCModule:
     name = "pi"
     description = "Run command as logged on users via Process Injection"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -11,7 +11,6 @@ class NXCModule:
     name = "powershell_history"
     description = "Extracts PowerShell history for all users and looks for sensitive commands."
     supported_protocols = ["smb"]
-    multiple_hosts = True
     false_positive = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
     sensitive_keywords = [
         "password", "passw", "secret", "credential", "key",

--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -16,7 +16,7 @@ class NXCModule:
     name = "pre2k"
     description = "Identify pre-created computer accounts, save the results to a file, and obtain TGTs for each"
     supported_protocols = ["ldap"]
-    multiple_hosts = False
+
 
     def options(self, context, module_options):
         pass

--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -17,7 +17,6 @@ class NXCModule:
     description = "Identify pre-created computer accounts, save the results to a file, and obtain TGTs for each"
     supported_protocols = ["ldap"]
 
-
     def options(self, context, module_options):
         pass
 

--- a/nxc/modules/presence.py
+++ b/nxc/modules/presence.py
@@ -15,7 +15,6 @@ class NXCModule:
     name = "presence"
     description = "Traces Domain and Enterprise Admin presence in the target over SMB"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """There are no module options."""

--- a/nxc/modules/printerbug.py
+++ b/nxc/modules/printerbug.py
@@ -2,7 +2,6 @@ class NXCModule:
     name = "printerbug"
     description = "[REMOVED] Module to check if the Target is vulnerable to PrinterBug. Set LISTENER IP for coercion."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/printnightmare.py
+++ b/nxc/modules/printnightmare.py
@@ -22,7 +22,6 @@ class NXCModule:
     name = "printnightmare"
     description = "Check if host vulnerable to printnightmare"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/procdump.py
+++ b/nxc/modules/procdump.py
@@ -15,7 +15,6 @@ class NXCModule:
     name = "procdump"
     description = "Get lsass dump using procdump64 and parse the result with pypykatz"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/pso.py
+++ b/nxc/modules/pso.py
@@ -12,7 +12,6 @@ class NXCModule:
     description = "Module to get the Fine Grained Password Policy/PSOs"
     supported_protocols = ["ldap"]
 
-
     def __init__(self, context=None, module_options=None):
         self.context = context
         self.module_options = module_options

--- a/nxc/modules/pso.py
+++ b/nxc/modules/pso.py
@@ -11,7 +11,7 @@ class NXCModule:
     name = "pso"
     description = "Module to get the Fine Grained Password Policy/PSOs"
     supported_protocols = ["ldap"]
-    multiple_hosts = False
+
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/putty.py
+++ b/nxc/modules/putty.py
@@ -17,7 +17,6 @@ class NXCModule:
     name = "putty"
     description = "Query the registry for users who saved ssh private keys in PuTTY. Download the private keys if found."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/rdcman.py
+++ b/nxc/modules/rdcman.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "rdcman"
     description = "Remotely dump Remote Desktop Connection Manager (sysinternals) credentials"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/rdp.py
+++ b/nxc/modules/rdp.py
@@ -15,7 +15,6 @@ class NXCModule:
     name = "rdp"
     description = "Enables/Disables RDP"
     supported_protocols = ["smb", "wmi"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/recent_files.py
+++ b/nxc/modules/recent_files.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "recent_files"
     description = "Extracts recently modified files"
     supported_protocols = ["smb"]
-    multiple_hosts = True
     false_positive = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
 
     def options(self, context, module_options):

--- a/nxc/modules/recyclebin.py
+++ b/nxc/modules/recyclebin.py
@@ -13,7 +13,6 @@ class NXCModule:
     name = "recyclebin"
     description = "Lists and exports users' recycle bins"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """No options available"""

--- a/nxc/modules/reg-query.py
+++ b/nxc/modules/reg-query.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "reg-query"
     description = "Performs a registry query on the machine"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/reg-winlogon.py
+++ b/nxc/modules/reg-winlogon.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "reg-winlogon"
     description = "Collect autologon credential stored in the registry"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/remote-uac.py
+++ b/nxc/modules/remote-uac.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "remote-uac"
     description = "Enable or disable remote UAC"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/remove-mic.py
+++ b/nxc/modules/remove-mic.py
@@ -25,7 +25,6 @@ class NXCModule:
     name = "remove-mic"
     description = "Check if host vulnerable to CVE-2019-1040"
     supported_protocols = ["smb"]
-    multiple_hosts = False
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/runasppl.py
+++ b/nxc/modules/runasppl.py
@@ -8,7 +8,6 @@ class NXCModule:
     name = "runasppl"
     description = "Check if the registry value RunAsPPL is set or not"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/sccm.py
+++ b/nxc/modules/sccm.py
@@ -22,7 +22,6 @@ class NXCModule:
     name = "sccm"
     description = "Find a SCCM infrastructure in the Active Directory"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def __init__(self):
         self.sccm_site_servers = []     # List of dns host names of the SCCM site servers

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -57,7 +57,6 @@ class NXCModule:
     name = "schtask_as"
     description = "Remotely execute a scheduled task as a logged on user"
     supported_protocols = ["smb"]
-    multiple_hosts = False
 
     def on_admin_login(self, context, connection):
         self.logger = context.log

--- a/nxc/modules/scuffy.py
+++ b/nxc/modules/scuffy.py
@@ -13,7 +13,6 @@ class NXCModule:
     name = "scuffy"
     description = "Creates and dumps an arbitrary .scf file with the icon property containing a UNC path to the declared SMB server against all writeable shares"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/security-questions.py
+++ b/nxc/modules/security-questions.py
@@ -17,7 +17,6 @@ class NXCModule:
     name = "security-questions"
     description = "Gets security questions and answers for users on computer"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module):
         pass

--- a/nxc/modules/shadowcoerce.py
+++ b/nxc/modules/shadowcoerce.py
@@ -2,7 +2,6 @@ class NXCModule:
     name = "shadowcoerce"
     description = "[REMOVED] Module to check if the target is vulnerable to ShadowCoerce, credit to @Shutdown and @topotam"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/shadowrdp.py
+++ b/nxc/modules/shadowrdp.py
@@ -8,7 +8,6 @@ class NXCModule:
     name = "shadowrdp"
     description = "Enables or disables shadow RDP"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/slinky.py
+++ b/nxc/modules/slinky.py
@@ -14,7 +14,6 @@ class NXCModule:
     name = "slinky"
     description = "Creates windows shortcuts with the icon attribute containing a URI to the specified  server (default SMB) in all shares with write permissions"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self):
         self.server = None

--- a/nxc/modules/smbghost.py
+++ b/nxc/modules/smbghost.py
@@ -15,7 +15,6 @@ class NXCModule:
     name = "smbghost"
     description = "Module to check for the SMB dialect 3.1.1 and compression capability of the host, which is an indicator for the SMBGhost vulnerability (CVE-2020-0796)."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/snipped.py
+++ b/nxc/modules/snipped.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "snipped"
     description = "Downloads screenshots taken by the (new) Snipping Tool."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/spider_plus.py
+++ b/nxc/modules/spider_plus.py
@@ -472,7 +472,6 @@ class NXCModule:
     name = "spider_plus"
     description = "List files recursively and save a JSON share-file metadata to the 'OUTPUT_FOLDER'. See module options for finer configuration."
     supported_protocols = ["smb"]
-    multiple_hosts = True  # Does the module support multiple hosts?
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/spooler.py
+++ b/nxc/modules/spooler.py
@@ -24,7 +24,6 @@ class NXCModule:
     name = "spooler"
     description = "Detect if print spooler is enabled or not"
     supported_protocols = ["smb", "wmi"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/subnets.py
+++ b/nxc/modules/subnets.py
@@ -36,7 +36,6 @@ class NXCModule:
     name = "subnets"
     description = "Retrieves the different Sites and Subnets of an Active Directory"
     supported_protocols = ["ldap"]
-    multiple_hosts = False
 
     def on_login(self, context, connection):
         dn = connection.args.base_dn if connection.args.base_dn else connection.ldap_connection._baseDN

--- a/nxc/modules/teams_localdb.py
+++ b/nxc/modules/teams_localdb.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "teams_localdb"
     description = "Retrieves the cleartext ssoauthcookie from the local Microsoft Teams database, if teams is open we kill all Teams process"
     supported_protocols = ["smb"]
-    multiple_hosts = False
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/test_connection.py
+++ b/nxc/modules/test_connection.py
@@ -10,7 +10,6 @@ class NXCModule:
     name = "test_connection"
     description = "Pings a host"
     supported_protocols = ["smb", "mssql"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """HOST      Host to ping"""

--- a/nxc/modules/timeroast.py
+++ b/nxc/modules/timeroast.py
@@ -23,7 +23,6 @@ class NXCModule:
     name = "timeroast"
     description = "Timeroasting exploits Windows NTP authentication to request password hashes of any computer or trust account"
     supported_protocols = ["smb"]
-    multiple_hosts = False
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/uac.py
+++ b/nxc/modules/uac.py
@@ -7,7 +7,6 @@ class NXCModule:
     name = "uac"
     description = "Checks UAC status"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/user-desc.py
+++ b/nxc/modules/user-desc.py
@@ -16,7 +16,6 @@ class NXCModule:
     name = "user-desc"
     description = "Get user descriptions stored in Active Directory"
     supported_protocols = ["ldap"]
-    multiple_hosts = True
 
     def __init__(self, context=None, multiple_options=None):
         self.keywords = None

--- a/nxc/modules/veeam.py
+++ b/nxc/modules/veeam.py
@@ -15,7 +15,6 @@ class NXCModule:
     name = "veeam"
     description = "Extracts credentials from local Veeam SQL Database"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self):
         with open(get_ps_script("veeam_dump_module/veeam_dump_mssql.ps1")) as psFile:

--- a/nxc/modules/vnc.py
+++ b/nxc/modules/vnc.py
@@ -24,7 +24,6 @@ class NXCModule:
     name = "vnc"
     description = "Loot Passwords from VNC server and client configurations"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/wam.py
+++ b/nxc/modules/wam.py
@@ -11,7 +11,6 @@ class NXCModule:
     name = "wam"
     description = "Dump access token from Token Broker Cache. More info here https://blog.xpnsec.com/wam-bam/. Module by zblurx"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/wcc.py
+++ b/nxc/modules/wcc.py
@@ -87,7 +87,6 @@ class NXCModule:
     name = "wcc"
     description = "Check various security configuration items on Windows machines"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/wdigest.py
+++ b/nxc/modules/wdigest.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "wdigest"
     description = "Creates/Deletes the 'UseLogonCredential' registry key enabling WDigest cred dumping on Windows >= 8.1"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ACTION  Create/Delete the registry key (choices: enable, disable, check)"""

--- a/nxc/modules/web_delivery.py
+++ b/nxc/modules/web_delivery.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "web_delivery"
     description = "Kicks off a Metasploit Payload using the exploit/multi/script/web_delivery module"
     supported_protocols = ["smb", "mssql"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/webdav.py
+++ b/nxc/modules/webdav.py
@@ -15,7 +15,6 @@ class NXCModule:
     name = "webdav"
     description = "Checks whether the WebClient service is running on the target"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """MSG     Info message when the WebClient service is running. '{}' is replaced by the target."""

--- a/nxc/modules/whoami.py
+++ b/nxc/modules/whoami.py
@@ -11,7 +11,6 @@ class NXCModule:
     name = "whoami"
     description = "Get details of provided user"
     supported_protocols = ["ldap"]
-    multiple_hosts = True  # Does it make sense to run this module on multiple hosts at a time?
 
     def options(self, context, module_options):
         """USER  Enumerate information about a different SamAccountName"""

--- a/nxc/modules/wifi.py
+++ b/nxc/modules/wifi.py
@@ -9,7 +9,6 @@ class NXCModule:
     name = "wifi"
     description = "Get key of all wireless interfaces"
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/winscp.py
+++ b/nxc/modules/winscp.py
@@ -21,7 +21,6 @@ class NXCModule:
     name = "winscp"
     description = "Looks for WinSCP.ini files in the registry and default locations and tries to extract credentials."
     supported_protocols = ["smb"]
-    multiple_hosts = True
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/zerologon.py
+++ b/nxc/modules/zerologon.py
@@ -14,7 +14,6 @@ class NXCModule:
     name = "zerologon"
     description = "Module to check if the DC is vulnerable to Zerologon aka CVE-2020-1472"
     supported_protocols = ["smb", "wmi"]
-    multiple_hosts = False
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -190,11 +190,6 @@ def main():
             nxc_logger.debug(f"Loading module for sanity check {m} at path {modules[m]['path']}")
             module = loader.init_module(modules[m]["path"])
 
-            if not module.multiple_hosts and len(targets) > 1:
-                ans = input(highlight("[!] Running this module on multiple hosts doesn't really make any sense, are you sure you want to continue? [Y/n] ", "red"))
-                if ans.lower() not in ["y", "yes", ""]:
-                    exit(1)
-
             # Add modules paths to the protocol object so it can load them itself
             proto_module_paths.append(modules[m]["path"])
         protocol_object.module_paths = proto_module_paths


### PR DESCRIPTION
## Description

Removing the horrible multiple hosts option

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] New and existing e2e tests pass locally with my changes
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
