### PR TITLE
Fix veeam script if there is no salt reg key

### DIFF
--- a/nxc/modules/veeam.py
+++ b/nxc/modules/veeam.py
@@ -117,7 +117,7 @@ class NXCModule:
             credentials = self.executePsPostgreSql(connection, PostgreSqlExec, PostgresUserForWindowsAuth, SqlDatabaseName, salt)
             self.printCreds(context, credentials)
 
-    def get_salt(self, context, remoteOps, regHandle):
+    def get_salt(self, context, remoteOps, regHandle) -> str:
         try:
             keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, "SOFTWARE\\Veeam\\Veeam Backup and Replication\\Data")["phkResult"]
             return rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "EncryptionSalt")[1].split("\x00")[:-1][0]
@@ -127,6 +127,7 @@ class NXCModule:
         except Exception as e:
             context.log.fail(f"UNEXPECTED ERROR: {e}")
             context.log.debug(traceback.format_exc())
+        return ""
 
     def executePsMssql(self, connection, SqlDatabase, SqlInstance, SqlServer, salt):
         self.psScriptMssql = self.psScriptMssql.replace("REPLACE_ME_SqlDatabase", SqlDatabase)


### PR DESCRIPTION
## Description

Only in new Veeam versions the passwords are encrypted with salts. While the powershell script respects the old way of decrypting veeam passwords without salts, the python script accidently returns `None` instead of an empty string. This results in a crash because python tries to replace the SALT string in the powershell script with `None` instead of an empty string.

Should fix #806, will turn into a normal PR when confirmed. Confirmed that it works.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Run script against an older version of Veeam where salts aren't used yet.

## Screenshots (if appropriate):
Don't have the setup currently to test it, but the fix should pretty sure resolve the issue.