### PR TITLE
Add ldap parsing to daclread

### DIFF
--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -1,17 +1,18 @@
 import binascii
 import codecs
 import json
-import re
 import datetime
 from enum import Enum
 from impacket.ldap import ldaptypes
 from impacket.uuid import bin_to_string
 from nxc.helpers.msada_guids import SCHEMA_OBJECTS, EXTENDED_RIGHTS
+from nxc.parsers.ldap_results import parse_result_attributes
 from ldap3.protocol.formatters.formatters import format_sid
 from ldap3.utils.conv import escape_filter_chars
 from ldap3.protocol.microsoft import security_descriptor_control
 import sys
 import traceback
+from os.path import isfile
 
 OBJECT_TYPES_GUID = {}
 OBJECT_TYPES_GUID.update(SCHEMA_OBJECTS)
@@ -228,12 +229,12 @@ class NXCModule:
 
         if module_options and "TARGET" in module_options:
             context.log.debug("There is a target specified!")
-            if re.search(r"^(.+)\/([^\/]+)$", module_options["TARGET"]) is not None:
+            if isfile(module_options["TARGET"]):
                 try:
                     self.target_file = open(module_options["TARGET"])  # noqa: SIM115
                     self.target_sAMAccountName = None
                 except Exception:
-                    context.log.fail("The file doesn't exist or cannot be openned.")
+                    context.log.fail("The file doesn't exist or cannot be opened.")
             else:
                 context.log.debug(f"Setting target_sAMAccountName to {module_options['TARGET']}")
                 self.target_sAMAccountName = module_options["TARGET"]

--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -7,7 +7,6 @@ from impacket.ldap import ldaptypes
 from impacket.uuid import bin_to_string
 from nxc.helpers.msada_guids import SCHEMA_OBJECTS, EXTENDED_RIGHTS
 from nxc.parsers.ldap_results import parse_result_attributes
-from ldap3.protocol.formatters.formatters import format_sid
 from ldap3.utils.conv import escape_filter_chars
 from ldap3.protocol.microsoft import security_descriptor_control
 import sys
@@ -375,19 +374,6 @@ class NXCModule:
             json.dump(backup, outfile)
         context.log.highlight("DACL backed up to %s", self.filename)
         self.filename = None
-
-    def get_user_info(self, context, sAMAccountName):
-        """Retrieves the SID and Distinguished Name from a sAMAccountName."""
-        try:
-            resp = self.connection.search(
-                searchFilter=f"(sAMAccountName={escape_filter_chars(sAMAccountName)})",
-                attributes=["distinguishedName", "objectSid"],
-            )
-            resp_parsed = parse_result_attributes(resp)[0]
-            return resp_parsed["distinguishedName"], resp_parsed["objectSid"]
-        except Exception:
-            context.log.fail(f"User not found in LDAP: {sAMAccountName}")
-            return False
 
     def resolveSID(self, sid):
         """Resolves a SID to its corresponding sAMAccountName."""

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -694,7 +694,7 @@ class ldap(connection):
         t /= 10000000
         return t
 
-    def search(self, searchFilter, attributes, sizeLimit=0, baseDN=None) -> list:
+    def search(self, searchFilter, attributes, sizeLimit=0, baseDN=None, searchControls=None) -> list:
         if baseDN is None and self.args.base_dn is not None:
             baseDN = self.args.base_dn
         elif baseDN is None:
@@ -712,7 +712,7 @@ class ldap(connection):
                     searchFilter=searchFilter,
                     attributes=attributes,
                     sizeLimit=sizeLimit,
-                    searchControls=paged_search_control,
+                    searchControls=searchControls if searchControls else paged_search_control,
                 )
         except ldap_impacket.LDAPSearchError as e:
             if "sizeLimitExceeded" in str(e):


### PR DESCRIPTION
## Description

Added our ldap parsing to a bunch of places in the daclread module, hopfully fixing encoding issues reported on discord.
There is still a lot to do in that module, but this PR is a starting point of fixing the code.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)


## Screenshots (if appropriate):
Still working as expected:
<img width="1575" height="262" alt="image" src="https://github.com/user-attachments/assets/61dbc917-b230-46a1-b6c1-f9e46b6a67ac" />
