### PR TITLE
Fix command execution in wmi

### DIFF
--- a/nxc/protocols/wmi.py
+++ b/nxc/protocols/wmi.py
@@ -411,19 +411,20 @@ class wmi(connection):
     @requires_admin
     def execute(self, command=None, get_output=False):
         output = ""
-        if not command:
-            command = self.args.execute
 
-        if not self.args.no_output:
-            get_output = True
+        # Execution via -x
+        if not command and self.args.execute:
+            command = self.args.execute
+            if not self.args.no_output:
+                get_output = True
 
         if "systeminfo" in command and self.args.exec_timeout < 10:
             self.logger.fail("Execute 'systeminfo' must set the interval time higher than 10 seconds")
-            return False
+            return ""
 
         if self.server_os is not None and "NT 5" in self.server_os:
             self.logger.fail("Execute command failed, not support current server os (version < NT 6)")
-            return False
+            return ""
 
         if self.args.exec_method == "wmiexec":
             exec_method = wmiexec.WMIEXEC(self.remoteName, self.username, self.password, self.domain, self.lmhash, self.nthash, self.doKerberos, self.kdcHost, self.host, self.aesKey, self.logger, self.args.exec_timeout, self.args.codec)
@@ -436,10 +437,12 @@ class wmi(connection):
         self.conn.disconnect()
         if output == "" and get_output:
             self.logger.fail("Execute command failed, probabaly got detection by AV.")
-            return False
-        else:
+            return ""
+        elif self.args.execute and get_output:
             self.logger.success(f'Executed command: "{command}" via {self.args.exec_method}')
             buf = StringIO(output).readlines()
             for line in buf:
                 self.logger.highlight(line.strip())
+            return output
+        elif get_output:
             return output

--- a/nxc/protocols/wmi/proto_args.py
+++ b/nxc/protocols/wmi/proto_args.py
@@ -17,7 +17,7 @@ def proto_args(parser, parents):
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", type=str, help="Creates a new cmd process and executes the specified command with output")
     cgroup.add_argument("--exec-method", choices={"wmiexec", "wmiexec-event"}, default="wmiexec", help="method to execute the command. (default: wmiexec). [wmiexec (win32_process + StdRegProv)]: get command results over registry instead of using smb connection. [wmiexec-event (T1546.003)]: this method is not very stable, highly recommend use this method in single host, using on multiple hosts may crash (just try again if it crashed).")
-    cgroup.add_argument("--exec-timeout", default=5, metavar="exec_timeout", dest="exec_timeout", type=int, help="Set timeout (in seconds) when executing a command, minimum 5 seconds is recommended. Default: %(default)s")
+    cgroup.add_argument("--exec-timeout", default=3, metavar="exec_timeout", dest="exec_timeout", type=int, help="Set timeout (in seconds) when executing a command, minimum 5 seconds is recommended. Default: %(default)s")
     cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output (default: utf-8). If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     return parser
 


### PR DESCRIPTION
## Description

Due to the chained command in the wmiexec.py with `&&` if one previous command would fail, the rest would not execute which results in the output files being not deleted when e.g. adding the output into the registry failed.
Now this loops through the commands, making them independently from each other (files are now deleted regardless of the previous commands failing).

Also fixed that if `getOutput` was set to `True` but called from a module the output isn't printed.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Execute a command that fails (e.g. `dir C:\\something`) and check the output files in `C:\\Windows\\Temp\\`

## Screenshots (if appropriate):
<img width="1576" height="324" alt="image" src="https://github.com/user-attachments/assets/8d54fbee-ec1e-4e53-b189-49e1734c762f" />

