### PR TITLE
Fix NFS Network Value

### DIFF
--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -203,7 +203,7 @@ class nfs(connection):
         for node in export_nodes:
 
             # Collect the names of the groups associated with this export node
-            group_names = self.group_names(node.ex_groups)
+            group_names = self.group_names(node.ex_groups) or ["Everyone"]
             networks.append(group_names)
 
             # If there are more export nodes, process them recursively. More than one share.


### PR DESCRIPTION
## Description

On Windows based NFS shares, network values return "No network". Checked other NFS mount tools, if `ex_groups` returns null or empty, it means "everyone". I didnt found real documentation about that but other tools using with that. And so far, that is correct.

References:

1-) https://github.com/kouril/nfs-utils/blob/master/utils/showmount/showmount.c
      line 227-246

2-) https://github.com/Supermathie/nfsshell/blob/master/nfsshell.c
      line 1577-1590

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots (if appropriate):

Before

<img width="1263" height="368" alt="image" src="https://github.com/user-attachments/assets/99054e20-0206-4e14-b63d-e57b79e974f3" />

After

<img width="1249" height="370" alt="image" src="https://github.com/user-attachments/assets/32b6a601-c6ad-4749-aa5c-87ffe5efc1d7" />


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] New and existing e2e tests pass locally with my changes
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
