### PR TITLE
Rework atexec and -M schtask_as to rely on a single TSCH_EXEC class

### DIFF
--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -1,5 +1,4 @@
 import os
-import contextlib
 from traceback import format_exc
 from nxc.protocols.smb.atexec import TSCH_EXEC
 

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -1,12 +1,7 @@
 import os
 import contextlib
-from time import sleep
-from datetime import datetime, timedelta
-from impacket.dcerpc.v5.dtypes import NULL
-from impacket.dcerpc.v5 import tsch, transport
-from nxc.helpers.misc import gen_random_string
-from nxc.paths import TMP_PATH
-from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
+from traceback import format_exc
+from nxc.protocols.smb.atexec import TSCH_EXEC
 
 
 class NXCModule:
@@ -31,28 +26,28 @@ class NXCModule:
         nxc smb <ip> -u <user> -p <password> -M schtask_as -o USER=Administrator CMD=whoami
         nxc smb <ip> -u <user> -p <password> -M schtask_as -o USER=Administrator CMD='bin.exe --option' BINARY=bin.exe
         """
-        self.cmd = self.binary = self.user = self.task = self.file = self.location = self.time = None
+        self.command_to_run = self.binary_to_upload = self.run_task_as = self.task_name = self.output_filename = self.output_file_location = self.time = None
         self.share = "C$"
         self.tmp_dir = "C:\\Windows\\Temp\\"
         self.tmp_share = self.tmp_dir.split(":")[1]
 
         if "CMD" in module_options:
-            self.cmd = module_options["CMD"]
+            self.command_to_run = module_options["CMD"]
 
         if "BINARY" in module_options:
-            self.binary = module_options["BINARY"]
+            self.binary_to_upload = module_options["BINARY"]
 
         if "USER" in module_options:
-            self.user = module_options["USER"]
+            self.run_task_as = module_options["USER"]
 
         if "TASK" in module_options:
-            self.task = module_options["TASK"]
+            self.task_name = module_options["TASK"]
 
         if "FILE" in module_options:
-            self.file = module_options["FILE"]
+            self.output_filename = module_options["FILE"]
 
         if "LOCATION" in module_options:
-            self.location = module_options["LOCATION"]
+            self.output_file_location = module_options["LOCATION"]
 
     name = "schtask_as"
     description = "Remotely execute a scheduled task as a logged on user"
@@ -60,33 +55,34 @@ class NXCModule:
     multiple_hosts = False
 
     def on_admin_login(self, context, connection):
+        print(vars(connection))
         self.logger = context.log
 
-        if self.cmd is None:
+        if self.command_to_run is None:
             self.logger.fail("You need to specify a CMD to run")
             return 1
 
-        if self.user is None:
+        if self.run_task_as is None:
             self.logger.fail("You need to specify a USER to run the command as")
             return 1
 
-        if self.binary:
-            if not os.path.isfile(self.binary):
-                self.logger.fail(f"Cannot find {self.binary}")
+        if self.binary_to_upload:
+            if not os.path.isfile(self.binary_to_upload):
+                self.logger.fail(f"Cannot find {self.binary_to_upload}")
                 return 1
             else:
-                self.logger.display(f"Uploading {self.binary}")
-                with open(self.binary, "rb") as binary_to_upload:
+                self.logger.display(f"Uploading {self.binary_to_upload}")
+                with open(self.binary_to_upload, "rb") as binary_to_upload:
                     try:
-                        self.binary_name = os.path.basename(self.binary)
-                        connection.conn.putFile(self.share, f"{self.tmp_share}{self.binary_name}", binary_to_upload.read)
-                        self.logger.success(f"Binary {self.binary_name} successfully uploaded in {self.tmp_share}{self.binary_name}")
+                        self.binary_to_upload_name = os.path.basename(self.binary_to_upload)
+                        connection.conn.putFile(self.share, f"{self.tmp_share}{self.binary_to_upload_name}", binary_to_upload.read)
+                        self.logger.success(f"Binary {self.binary_to_upload_name} successfully uploaded in {self.tmp_share}{self.binary_to_upload_name}")
                     except Exception as e:
                         self.logger.fail(f"Error writing file to share {self.tmp_share}: {e}")
                         return 1
 
-        # Returnes self.cmd or \Windows\temp\BinToExecute.exe depending if BINARY=BinToExecute.exe
-        self.cmd = self.cmd if not self.binary else f"{self.tmp_share}{self.cmd}"
+        # Returnes self.command_to_run or \Windows\temp\BinToExecute.exe depending if BINARY=BinToExecute.exe
+        self.command_to_run = self.command_to_run if not self.binary_to_upload else f"{self.tmp_share}{self.command_to_run}"
         self.logger.display("Connecting to the remote Service control endpoint")
         try:
             exec_method = TSCH_EXEC(
@@ -95,11 +91,6 @@ class NXCModule:
                 connection.username,
                 connection.password,
                 connection.domain,
-                self.user,
-                self.cmd,
-                self.file,
-                self.task,
-                self.location,
                 connection.kerberos,
                 connection.aesKey,
                 connection.host,
@@ -107,11 +98,16 @@ class NXCModule:
                 connection.hash,
                 self.logger,
                 connection.args.get_output_tries,
-                "C$",  # This one shouldn't be hardcoded but I don't know where to retrieve the info
+                connection.args.share,
+                self.run_task_as, 
+                self.command_to_run,
+                self.output_filename,
+                self.task_name,
+                self.output_file_location,
             )
 
-            self.logger.display(f"Executing {self.cmd} as {self.user}")
-            output = exec_method.execute(self.cmd, True)
+            self.logger.display(f"Executing {self.command_to_run} as {self.run_task_as}")
+            output = exec_method.execute(self.command_to_run, True)
 
             try:
                 if not isinstance(output, str):
@@ -123,246 +119,15 @@ class NXCModule:
                 for line in output.splitlines():
                     self.logger.highlight(line.rstrip())
 
-        except Exception as e:
-            if "SCHED_S_TASK_HAS_NOT_RUN" in str(e):
-                self.logger.fail("Task was not run, seems like the specified user has no active session on the target")
-                with contextlib.suppress(Exception):
-                    exec_method.deleteartifact()
-            else:
-                self.logger.fail(f"Failed to execute command: {e}")
+        except Exception:
+            self.logger.debug("Error executing command via atexec, traceback:")
+            self.logger.debug(format_exc())
+            with contextlib.suppress(Exception):
+                exec_method.deleteartifact()
         finally:
-            if self.binary:
+            if self.binary_to_upload:
                 try:
-                    connection.conn.deleteFile(self.share, f"{self.tmp_share}{self.binary_name}")
-                    context.log.success(f"Binary {self.binary_name} successfully deleted")
+                    connection.conn.deleteFile(self.share, f"{self.tmp_share}{self.binary_to_upload_name}")
+                    context.log.success(f"Binary {self.binary_to_upload_name} successfully deleted")
                 except Exception as e:
-                    context.log.fail(f"Error deleting {self.binary_name} on {self.share}: {e}")
-
-
-class TSCH_EXEC:
-    def __init__(self, target, share_name, username, password, domain, user, cmd, file, task, location, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None):
-        self.__target = target
-        self.__username = username
-        self.__password = password
-        self.__domain = domain
-        self.__share_name = share_name
-        self.__lmhash = ""
-        self.__nthash = ""
-        self.__outputBuffer = b""
-        self.__retOutput = False
-        self.__aesKey = aesKey
-        self.__doKerberos = doKerberos
-        self.__remoteHost = remoteHost
-        self.__kdcHost = kdcHost
-        self.__tries = tries
-        self.__output_filename = None
-        self.__share = share
-        self.logger = logger
-        self.cmd = cmd
-        self.user = user
-        self.file = file
-        self.task = task
-        self.location = location
-
-        if hashes is not None:
-            if hashes.find(":") != -1:
-                self.__lmhash, self.__nthash = hashes.split(":")
-            else:
-                self.__nthash = hashes
-
-        if self.__password is None:
-            self.__password = ""
-
-        stringbinding = f"ncacn_np:{self.__target}[\\pipe\\atsvc]"
-        self.__rpctransport = transport.DCERPCTransportFactory(stringbinding)
-        self.__rpctransport.setRemoteHost(self.__remoteHost)
-
-        if hasattr(self.__rpctransport, "set_credentials"):
-            # This method exists only for selected protocol sequences.
-            self.__rpctransport.set_credentials(
-                self.__username,
-                self.__password,
-                self.__domain,
-                self.__lmhash,
-                self.__nthash,
-                self.__aesKey,
-            )
-            self.__rpctransport.set_kerberos(self.__doKerberos, self.__kdcHost)
-
-    def deleteartifact(self):
-        dce = self.__rpctransport.get_dce_rpc()
-        if self.__doKerberos:
-            dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
-        dce.set_credentials(*self.__rpctransport.get_credentials())
-        dce.connect()
-        dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-        dce.bind(tsch.MSRPC_UUID_TSCHS)
-        self.logger.display(f"Deleting task \\{self.task}")
-        tsch.hSchRpcDelete(dce, f"\\{self.task}")
-        dce.disconnect()
-
-    def execute(self, command, output=False):
-        self.__retOutput = output
-        self.execute_handler(command)
-        return self.__outputBuffer
-
-    def output_callback(self, data):
-        self.__outputBuffer = data
-
-    def get_end_boundary(self):
-        # Get current date and time + 5 minutes
-        end_boundary = datetime.now() + timedelta(minutes=5)
-
-        # Format it to match the format in the XML: "YYYY-MM-DDTHH:MM:SS.ssssss"
-        return end_boundary.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
-
-    def gen_xml(self, command, fileless=False):
-        xml = f"""<?xml version="1.0" encoding="UTF-16"?>
-<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
-  <Triggers>
-    <RegistrationTrigger>
-      <EndBoundary>{self.get_end_boundary()}</EndBoundary>
-    </RegistrationTrigger>
-  </Triggers>
-  <Principals>
-    <Principal id="LocalSystem">
-      <UserId>{self.user}</UserId>
-      <RunLevel>HighestAvailable</RunLevel>
-    </Principal>
-  </Principals>
-  <Settings>
-    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
-    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
-    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
-    <AllowHardTerminate>true</AllowHardTerminate>
-    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
-    <IdleSettings>
-      <StopOnIdleEnd>true</StopOnIdleEnd>
-      <RestartOnIdle>false</RestartOnIdle>
-    </IdleSettings>
-    <AllowStartOnDemand>true</AllowStartOnDemand>
-    <Enabled>true</Enabled>
-    <Hidden>true</Hidden>
-    <RunOnlyIfIdle>false</RunOnlyIfIdle>
-    <WakeToRun>false</WakeToRun>
-    <ExecutionTimeLimit>P3D</ExecutionTimeLimit>
-    <Priority>7</Priority>
-  </Settings>
-  <Actions Context="LocalSystem">
-    <Exec>
-      <Command>cmd.exe</Command>
-"""
-        if self.__retOutput:
-            fileLocation = "\\Windows\\Temp\\" if self.location is None else self.location
-            if self.file is None:
-                self.__output_filename = os.path.join(fileLocation, gen_random_string(6))
-            else:
-                self.__output_filename = os.path.join(fileLocation, self.file)
-            if fileless:
-                local_ip = self.__rpctransport.get_socket().getsockname()[0]
-                argument_xml = f"      <Arguments>/C {command} &gt; \\\\{local_ip}\\{self.__share_name}\\{self.__output_filename} 2&gt;&amp;1</Arguments>"
-            else:
-                argument_xml = f"      <Arguments>/C {command} &gt; {self.__output_filename} 2&gt;&amp;1</Arguments>"
-
-        elif self.__retOutput is False:
-            argument_xml = f"      <Arguments>/C {command}</Arguments>"
-
-        self.logger.debug(f"Generated argument XML: {argument_xml}")
-        xml += argument_xml
-        xml += """
-    </Exec>
-  </Actions>
-</Task>
-"""
-        return xml
-
-    def execute_handler(self, command, fileless=False):
-        dce = self.__rpctransport.get_dce_rpc()
-
-        if self.__doKerberos:
-            dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
-
-        dce.set_credentials(*self.__rpctransport.get_credentials())
-        dce.connect()
-        # Give self.task a random string as name if not already specified
-        self.task = gen_random_string(8) if self.task is None else self.task
-        xml = self.gen_xml(command, fileless)
-
-        self.logger.info(f"Task XML: {xml}")
-        self.logger.info(f"Creating task \\{self.task}")
-        try:
-            # windows server 2003 has no MSRPC_UUID_TSCHS, if it bind, it will return abstract_syntax_not_supported
-            dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-            dce.bind(tsch.MSRPC_UUID_TSCHS)
-            tsch.hSchRpcRegisterTask(dce, f"\\{self.task}", xml, tsch.TASK_CREATE, NULL, tsch.TASK_LOGON_NONE)
-        except Exception as e:
-            if "ERROR_NONE_MAPPED" in str(e):
-                self.logger.fail(f"User {self.user} is not connected on the target, cannot run the task")
-                with contextlib.suppress(Exception):
-                    tsch.hSchRpcDelete(dce, f"\\{self.task}")
-            elif e.error_code and hex(e.error_code) == "0x80070005":
-                self.logger.fail("Create schedule task got blocked.")
-                with contextlib.suppress(Exception):
-                    tsch.hSchRpcDelete(dce, f"\\{self.task}")
-            elif "ERROR_TRUSTED_DOMAIN_FAILURE" in str(e):
-                self.logger.fail(f"User {self.user} does not exist in the domain.")
-                with contextlib.suppress(Exception):
-                    tsch.hSchRpcDelete(dce, f"\\{self.task}")
-            elif "SCHED_S_TASK_HAS_NOT_RUN" in str(e):
-                with contextlib.suppress(Exception):
-                    tsch.hSchRpcDelete(dce, f"\\{self.task}")
-            elif "ERROR_ALREADY_EXISTS" in str(e):
-                self.logger.fail(f"Create schedule task failed: {e}")
-            else:
-                self.logger.fail(f"Create schedule task failed: {e}")
-                with contextlib.suppress(Exception):
-                    tsch.hSchRpcDelete(dce, f"\\{self.task}")
-            return
-
-        done = False
-        while not done:
-            self.logger.debug(f"Calling SchRpcGetLastRunInfo for \\{self.task}")
-            resp = tsch.hSchRpcGetLastRunInfo(dce, f"\\{self.task}")
-            if resp["pLastRuntime"]["wYear"] != 0:
-                done = True
-            else:
-                sleep(2)
-
-        self.logger.info(f"Deleting task \\{self.task}")
-        tsch.hSchRpcDelete(dce, f"\\{self.task}")
-
-        if self.__retOutput:
-            if fileless:
-                while True:
-                    try:
-                        with open(os.path.join(TMP_PATH, self.__output_filename)) as output:
-                            self.output_callback(output.read())
-                        break
-                    except OSError:
-                        sleep(2)
-            else:
-                smbConnection = self.__rpctransport.get_smb_connection()
-                tries = 1
-                while True:
-                    try:
-                        self.logger.info(f"Attempting to read {self.__share}\\{self.__output_filename}")
-                        smbConnection.getFile(self.__share, self.__output_filename, self.output_callback)
-                        break
-                    except Exception as e:
-                        if tries >= self.__tries:
-                            self.logger.fail("Schtask_as: Could not retrieve output file, it may have been detected by AV. Please increase the number of tries with the option '--get-output-tries'.")
-                            break
-                        if "STATUS_BAD_NETWORK_NAME" in str(e):
-                            self.logger.fail(f"Schtask_as: Getting the output file failed - target has blocked access to the share: {self.__share} (but the command may have executed!)")
-                            break
-                        if "SHARING" in str(e) or "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
-                            sleep(3)
-                            tries += 1
-                        else:
-                            self.logger.debug(str(e))
-
-                if self.__outputBuffer:
-                    self.logger.debug(f"Deleting file {self.__share}\\{self.__output_filename}")
-                    smbConnection.deleteFile(self.__share, self.__output_filename)
-
-        dce.disconnect()
+                    context.log.fail(f"Error deleting {self.binary_to_upload_name} on {self.share}: {e}")

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -121,8 +121,6 @@ class NXCModule:
         except Exception:
             self.logger.debug("Error executing command via atexec, traceback:")
             self.logger.debug(format_exc())
-            with contextlib.suppress(Exception):
-                exec_method.deleteartifact()
         finally:
             if self.binary_to_upload:
                 try:

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -55,7 +55,6 @@ class NXCModule:
     multiple_hosts = False
 
     def on_admin_login(self, context, connection):
-        print(vars(connection))
         self.logger = context.log
 
         if self.command_to_run is None:

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -177,7 +177,6 @@ class TSCH_EXEC:
         tsch.hSchRpcDelete(dce, f"\\{self.task_name}")
 
         if self.__retOutput:
-            ":".join(map(str, self.__rpctransport.get_socket().getpeername()))
             smbConnection = self.__rpctransport.get_smb_connection()
 
             tries = 1

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -1,15 +1,19 @@
 import os
+from textwrap import dedent
 from impacket.dcerpc.v5 import tsch, transport
 from impacket.dcerpc.v5.dtypes import NULL
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from nxc.helpers.misc import gen_random_string
-from nxc.paths import TMP_PATH
 from time import sleep
 from datetime import datetime, timedelta
 
 
 class TSCH_EXEC:
-    def __init__(self, target, share_name, username, password, domain, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None):
+    def __init__(self, target, share_name, username, password, domain, doKerberos=False, aesKey=None, remoteHost=None, 
+                 kdcHost=None, hashes=None, logger=None, tries=None, share=None,
+                 # These options are used by the schtask_as module, except the run_task_as 
+                 # that defaults to NT AUTHORITY\System user (SID S-1-5-18) if not specified
+                 run_task_as="S-1-5-18", run_cmd=None, output_filename=None, task_name=None, output_file_location=None):
         self.__target = target
         self.__username = username
         self.__password = password
@@ -27,6 +31,12 @@ class TSCH_EXEC:
         self.__output_filename = None
         self.__share = share
         self.logger = logger
+
+        self.task_name = task_name if task_name else gen_random_string(8)
+        self.run_task_as = run_task_as
+        self.run_cmd = run_cmd
+        self.output_filename = output_filename
+        self.output_file_location = output_file_location
 
         if hashes is not None:
             # This checks to see if we didn't provide the LM Hash
@@ -69,49 +79,49 @@ class TSCH_EXEC:
         # Format it to match the format in the XML: "YYYY-MM-DDTHH:MM:SS.ssssss"
         return end_boundary.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
 
-    def gen_xml(self, command, fileless=False):
+    def gen_xml(self, command):
         xml = f"""<?xml version="1.0" encoding="UTF-16"?>
-<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
-  <Triggers>
-    <RegistrationTrigger>
-      <EndBoundary>{self.get_end_boundary()}</EndBoundary>
-    </RegistrationTrigger>
-  </Triggers>
-  <Principals>
-    <Principal id="LocalSystem">
-      <UserId>S-1-5-18</UserId>
-      <RunLevel>HighestAvailable</RunLevel>
-    </Principal>
-  </Principals>
-  <Settings>
-    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
-    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
-    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
-    <AllowHardTerminate>true</AllowHardTerminate>
-    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
-    <IdleSettings>
-      <StopOnIdleEnd>true</StopOnIdleEnd>
-      <RestartOnIdle>false</RestartOnIdle>
-    </IdleSettings>
-    <AllowStartOnDemand>true</AllowStartOnDemand>
-    <Enabled>true</Enabled>
-    <Hidden>true</Hidden>
-    <RunOnlyIfIdle>false</RunOnlyIfIdle>
-    <WakeToRun>false</WakeToRun>
-    <ExecutionTimeLimit>P3D</ExecutionTimeLimit>
-    <Priority>7</Priority>
-  </Settings>
-  <Actions Context="LocalSystem">
-    <Exec>
-      <Command>cmd.exe</Command>
-"""
+        <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+        <Triggers>
+            <RegistrationTrigger>
+            <EndBoundary>{self.get_end_boundary()}</EndBoundary>
+            </RegistrationTrigger>
+        </Triggers>
+        <Principals>
+            <Principal id="LocalSystem">
+            <UserId>{self.run_task_as}</UserId>
+            <RunLevel>HighestAvailable</RunLevel>
+            </Principal>
+        </Principals>
+        <Settings>
+            <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+            <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+            <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+            <AllowHardTerminate>true</AllowHardTerminate>
+            <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+            <IdleSettings>
+            <StopOnIdleEnd>true</StopOnIdleEnd>
+            <RestartOnIdle>false</RestartOnIdle>
+            </IdleSettings>
+            <AllowStartOnDemand>true</AllowStartOnDemand>
+            <Enabled>true</Enabled>
+            <Hidden>true</Hidden>
+            <RunOnlyIfIdle>false</RunOnlyIfIdle>
+            <WakeToRun>false</WakeToRun>
+            <ExecutionTimeLimit>P3D</ExecutionTimeLimit>
+            <Priority>7</Priority>
+        </Settings>
+        <Actions Context="LocalSystem">
+            <Exec>
+            <Command>cmd.exe</Command>
+        """
         if self.__retOutput:
-            self.__output_filename = "\\Windows\\Temp\\" + gen_random_string(6)
-            if fileless:
-                local_ip = self.__rpctransport.get_socket().getsockname()[0]
-                argument_xml = f"      <Arguments>/C {command} &gt; \\\\{local_ip}\\{self.__share_name}\\{self.__output_filename} 2&gt;&amp;1</Arguments>"
+            fileLocation = "\\Windows\\Temp\\" if self.output_file_location is None else self.output_file_location
+            if self.output_filename is None:
+                self.__output_filename = os.path.join(fileLocation, gen_random_string(6))
             else:
-                argument_xml = f"      <Arguments>/C {command} &gt; {self.__output_filename} 2&gt;&amp;1</Arguments>"
+                self.__output_filename = os.path.join(fileLocation, self.output_filename)
+            argument_xml = f"      <Arguments>/C {command} &gt; {self.__output_filename} 2&gt;&amp;1</Arguments>"
 
         elif self.__retOutput is False:
             argument_xml = f"      <Arguments>/C {command}</Arguments>"
@@ -120,13 +130,15 @@ class TSCH_EXEC:
         xml += argument_xml
 
         xml += """
-    </Exec>
-  </Actions>
-</Task>
-"""
-        return xml
+            </Exec>
+        </Actions>
+        </Task>
+        """
 
-    def execute_handler(self, command, fileless=False):
+        # Removing identation for the final XML file
+        return dedent(xml)
+
+    def execute_handler(self, command):
         dce = self.__rpctransport.get_dce_rpc()
         if self.__doKerberos:
             dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
@@ -134,86 +146,77 @@ class TSCH_EXEC:
         dce.set_credentials(*self.__rpctransport.get_credentials())
         dce.connect()
 
-        tmpName = gen_random_string(8)
-
-        xml = self.gen_xml(command, fileless)
+        xml = self.gen_xml(command)
 
         self.logger.debug(f"Task XML: {xml}")
-        self.logger.info(f"Creating task \\{tmpName}")
+        self.logger.info(f"Creating task \\{self.task_name}")
         try:
-            # windows server 2003 has no MSRPC_UUID_TSCHS, if it bind, it will return abstract_syntax_not_supported
+            # Windows server 2003 has no MSRPC_UUID_TSCHS, if it bind, it will return abstract_syntax_not_supported
             dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
             dce.bind(tsch.MSRPC_UUID_TSCHS)
-            tsch.hSchRpcRegisterTask(dce, f"\\{tmpName}", xml, tsch.TASK_CREATE, NULL, tsch.TASK_LOGON_NONE)
+            tsch.hSchRpcRegisterTask(dce, f"\\{self.task_name}", xml, tsch.TASK_CREATE, NULL, tsch.TASK_LOGON_NONE)
         except Exception as e:
             if e.error_code and hex(e.error_code) == "0x80070005":
-                self.logger.fail("ATEXEC: Create schedule task got blocked.")
+                self.logger.fail("Task scheduling was blocked.")
+            elif e.error_code and hex(e.error_code) == "0x80070534":
+                self.logger.fail(f"User {self.run_task_as} does not have a valid winstation, cannot run the task on its behalf.")
             else:
                 self.logger.fail(str(e))
             return
 
         done = False
         while not done:
-            self.logger.debug(f"Calling SchRpcGetLastRunInfo for \\{tmpName}")
-            resp = tsch.hSchRpcGetLastRunInfo(dce, f"\\{tmpName}")
+            self.logger.debug(f"Calling SchRpcGetLastRunInfo for \\{self.task_name}")
+            resp = tsch.hSchRpcGetLastRunInfo(dce, f"\\{self.task_name}")
             if resp["pLastRuntime"]["wYear"] != 0:
                 done = True
             else:
                 sleep(2)
 
-        self.logger.info(f"Deleting task \\{tmpName}")
-        tsch.hSchRpcDelete(dce, f"\\{tmpName}")
+        self.logger.info(f"Deleting task \\{self.task_name}")
+        tsch.hSchRpcDelete(dce, f"\\{self.task_name}")
 
         if self.__retOutput:
-            if fileless:
-                while True:
-                    try:
-                        with open(os.path.join(TMP_PATH, self.__output_filename)) as output:
-                            self.output_callback(output.read())
-                        break
-                    except OSError:
-                        sleep(2)
-            else:
-                ":".join(map(str, self.__rpctransport.get_socket().getpeername()))
-                smbConnection = self.__rpctransport.get_smb_connection()
+            ":".join(map(str, self.__rpctransport.get_socket().getpeername()))
+            smbConnection = self.__rpctransport.get_smb_connection()
 
-                tries = 1
-                # Give the command a bit of time to execute before we try to read the output, 0.4 seconds was good in testing
-                sleep(0.4)
-                while True:
-                    try:
-                        self.logger.info(f"Attempting to read {self.__share}\\{self.__output_filename}")
-                        smbConnection.getFile(self.__share, self.__output_filename, self.output_callback)
-                        break
-                    except Exception as e:
-                        if tries >= self.__tries:
-                            self.logger.fail("ATEXEC: Could not retrieve output file, it may have been detected by AV. Please increase the number of tries with the option '--get-output-tries'. If it is still failing, try the 'wmi' protocol or another exec method")
-                            break
-                        if "STATUS_BAD_NETWORK_NAME" in str(e):
-                            self.logger.fail(f"ATEXEC: Getting the output file failed - target has blocked access to the share: {self.__share} (but the command may have executed!)")
-                            break
-                        elif "STATUS_VIRUS_INFECTED" in str(e):
-                            self.logger.fail("Command did not run because a virus was detected")
-                            break
-                        # When executing powershell and the command is still running, we get a sharing violation
-                        # We can use that information to wait longer than if the file is not found (probably av or something)
-                        if "STATUS_SHARING_VIOLATION" in str(e):
-                            self.logger.info(f"File {self.__share}\\{self.__output_filename} is still in use with {self.__tries - tries} tries left, retrying...")
-                            tries += 1
-                            sleep(1)
-                        elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
-                            self.logger.info(f"File {self.__share}\\{self.__output_filename} not found with {self.__tries - tries} tries left, deducting 10 tries and retrying...")
-                            tries += 10
-                            sleep(1)
-                        else:
-                            self.logger.debug(f"Exception when trying to read output file: {e!s}. {self.__tries - tries} tries left, retrying...")
-                            tries += 1
-                            sleep(1)
-
+            tries = 1
+            # Give the command a bit of time to execute before we try to read the output, 0.4 seconds was good in testing
+            sleep(0.4)
+            while True:
                 try:
-                    self.logger.debug(f"Deleting file {self.__share}\\{self.__output_filename}")
-                    smbConnection.deleteFile(self.__share, self.__output_filename)
-                except Exception:
-                    pass
+                    self.logger.info(f"Attempting to read {self.__share}\\{self.__output_filename}")
+                    smbConnection.getFile(self.__share, self.__output_filename, self.output_callback)
+                    break
+                except Exception as e:
+                    if tries >= self.__tries:
+                        self.logger.fail("ATEXEC: Could not retrieve output file, it may have been detected by AV. Please increase the number of tries with the option '--get-output-tries'. If it is still failing, try the 'wmi' protocol or another exec method")
+                        break
+                    if "STATUS_BAD_NETWORK_NAME" in str(e):
+                        self.logger.fail(f"ATEXEC: Getting the output file failed - target has blocked access to the share: {self.__share} (but the command may have executed!)")
+                        break
+                    elif "STATUS_VIRUS_INFECTED" in str(e):
+                        self.logger.fail("Command did not run because a virus was detected")
+                        break
+                    # When executing PowerShell and the command is still running, we get a sharing violation
+                    # We can use that information to wait longer than if the file is not found (probably av or something)
+                    if "STATUS_SHARING_VIOLATION" in str(e):
+                        self.logger.info(f"File {self.__share}\\{self.__output_filename} is still in use with {self.__tries - tries} tries left, retrying...")
+                        tries += 1
+                        sleep(1)
+                    elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
+                        self.logger.info(f"File {self.__share}\\{self.__output_filename} not found with {self.__tries - tries} tries left, deducting 10 tries and retrying...")
+                        tries += 10
+                        sleep(1)
+                    else:
+                        self.logger.debug(f"Exception when trying to read output file: {e!s}. {self.__tries - tries} tries left, retrying...")
+                        tries += 1
+                        sleep(1)
+
+            try:
+                self.logger.debug(f"Deleting file {self.__share}\\{self.__output_filename}")
+                smbConnection.deleteFile(self.__share, self.__output_filename)
+            except Exception:
+                pass
 
         dce.disconnect()

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -9,8 +9,7 @@ from datetime import datetime, timedelta
 
 
 class TSCH_EXEC:
-    def __init__(self, target, share_name, username, password, domain, doKerberos=False, aesKey=None, remoteHost=None, 
-                 kdcHost=None, hashes=None, logger=None, tries=None, share=None,
+    def __init__(self, target, share_name, username, password, domain, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None,
                  # These options are used by the schtask_as module, except the run_task_as 
                  # that defaults to NT AUTHORITY\System user (SID S-1-5-18) if not specified
                  run_task_as="S-1-5-18", run_cmd=None, output_filename=None, task_name=None, output_file_location=None):
@@ -32,6 +31,7 @@ class TSCH_EXEC:
         self.__share = share
         self.logger = logger
 
+        # Optional args for finetuning the task execution, e.g. used in nxc/modules/schtask_as.py
         self.task_name = task_name if task_name else gen_random_string(8)
         self.run_task_as = run_task_as
         self.run_cmd = run_cmd
@@ -116,11 +116,11 @@ class TSCH_EXEC:
             <Command>cmd.exe</Command>
         """
         if self.__retOutput:
-            fileLocation = "\\Windows\\Temp\\" if self.output_file_location is None else self.output_file_location
+            file_location = "\\Windows\\Temp\\" if self.output_file_location is None else self.output_file_location
             if self.output_filename is None:
-                self.__output_filename = os.path.join(fileLocation, gen_random_string(6))
+                self.__output_filename = os.path.join(file_location, gen_random_string(6))
             else:
-                self.__output_filename = os.path.join(fileLocation, self.output_filename)
+                self.__output_filename = os.path.join(file_location, self.output_filename)
             argument_xml = f"      <Arguments>/C {command} &gt; {self.__output_filename} 2&gt;&amp;1</Arguments>"
 
         elif self.__retOutput is False:


### PR DESCRIPTION
## Description

As discussed, this PR reworks the atexec TSCH_EXEC class so that a single class gets used when calling both:
* --exec-method atexec: 

<img width="1087" height="144" alt="image" src="https://github.com/user-attachments/assets/908729ad-dae6-4544-b1ec-12fe2e588c1c" />

* -M schtask_as:

<img width="1042" height="159" alt="image" src="https://github.com/user-attachments/assets/59776f28-707f-440e-ad2b-9f9c8ea81eb3" />

Note that schtask_as parameters are implemented as well:

```
 python3 nxc/netexec.py smb 192.168.56.11 -u admin -p Defte@WF -M schtask_as -o USER="WHITEFLAG\administrateur" CMD=whoami FILE=test.txt TASK=hello LOCATION='\Windows\' --debug
```

<img width="1145" height="866" alt="image" src="https://github.com/user-attachments/assets/cf4241a4-3b2a-436e-a303-427466699bbd" />

To do so, I have added the following optionnal parameters:

```
class TSCH_EXEC:
    def __init__(self, target, share_name, username, password, domain, doKerberos=False, aesKey=None, remoteHost=None, 
                 kdcHost=None, hashes=None, logger=None, tries=None, share=None,
                 # These options are used by the schtask_as module, except the run_task_as 
                 # that defaults to NT AUTHORITY\System user (SID S-1-5-18) if not specified
                 run_task_as="S-1-5-18", run_cmd=None, output_filename=None, task_name=None, output_file_location=None):
        self.__target = target
        self.__username = username
        self.__password = password
        self.__domain = domain
        self.__share_name = share_name
        self.__lmhash = ""
        self.__nthash = ""
        self.__outputBuffer = b""
        self.__retOutput = False
        self.__aesKey = aesKey
        self.__doKerberos = doKerberos
        self.__remoteHost = remoteHost
        self.__kdcHost = kdcHost
        self.__tries = tries
        self.__output_filename = None
        self.__share = share
        self.logger = logger

        self.task_name = task_name if task_name else gen_random_string(8)
        self.run_task_as = run_task_as
        self.run_cmd = run_cmd
        self.output_filename = output_filename
        self.output_file_location = output_file_location
```

I have also removed the entire fileless code since it was never used and we removed the integrated SMB server as well. Last, I added identation to the XML file so that it's easier to read it and I added the following error code 0x80070534 that is returned if a task to run as someone who's doesn't have a valid windows station session is launched.

I haven't touched the all "upload_binary" stuff which I kept in the schtask_as module. I might add that as a core option later :)!