### PR TITLE
Refactor WMI protocol execution

### DIFF
--- a/nxc/protocols/wmi.py
+++ b/nxc/protocols/wmi.py
@@ -208,7 +208,7 @@ class wmi(connection):
             username = ccache.credentials[0].header["client"].prettyPrint().decode().split("@")[0]
             self.username = username
         used_ccache = " from ccache" if useCache else f":{process_secret(kerb_pass)}"
-        
+
         try:
             self.logger.debug(f"Attempting to connect via WMI to {self.host}")
             self.conn.set_credentials(username=username, password=password, domain=domain, lmhash=lmhash, nthash=nthash, aesKey=self.aesKey)
@@ -369,7 +369,7 @@ class wmi(connection):
     @requires_admin
     def wmi(self, wql=None, namespace=None):
         """Execute WQL syntax via WMI
-        
+
         This is done via the --wmi flag
         """
         records = []

--- a/nxc/protocols/wmi.py
+++ b/nxc/protocols/wmi.py
@@ -435,14 +435,11 @@ class wmi(connection):
             output = exec_method.execute(command, get_output)
 
         self.conn.disconnect()
-        if output == "" and get_output:
-            self.logger.fail("Execute command failed, probabaly got detection by AV.")
-            return ""
-        elif self.args.execute and get_output:
+        if self.args.execute and get_output:
             self.logger.success(f'Executed command: "{command}" via {self.args.exec_method}')
             buf = StringIO(output).readlines()
             for line in buf:
                 self.logger.highlight(line.strip())
             return output
-        elif get_output:
+        else:
             return output

--- a/nxc/protocols/wmi.py
+++ b/nxc/protocols/wmi.py
@@ -458,7 +458,7 @@ class wmi(connection):
             self.logger.success(f'Executed PowerShell command: "{command}" via {self.args.exec_method}')
             buf = StringIO(output).readlines()
             for line in buf:
-                if line.strip().rstrip("\ufeff"):
+                if line.strip():
                     self.logger.highlight(line.strip())
             return output
         else:

--- a/nxc/protocols/wmi/proto_args.py
+++ b/nxc/protocols/wmi/proto_args.py
@@ -16,6 +16,7 @@ def proto_args(parser, parents):
     cgroup = wmi_parser.add_argument_group("Command Execution", "Options for executing commands")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", type=str, help="Creates a new cmd process and executes the specified command with output")
+    cgroup.add_argument("-X", metavar="COMMAND", dest="execute_psh", type=str, help="Creates a new PowerShell process and executes the specified command with output")
     cgroup.add_argument("--exec-method", choices={"wmiexec", "wmiexec-event"}, default="wmiexec", help="method to execute the command. (default: wmiexec). [wmiexec (win32_process + StdRegProv)]: get command results over registry instead of using smb connection. [wmiexec-event (T1546.003)]: this method is not very stable, highly recommend use this method in single host, using on multiple hosts may crash (just try again if it crashed).")
     cgroup.add_argument("--exec-timeout", default=2, metavar="exec_timeout", dest="exec_timeout", type=int, help="Set timeout (in seconds) when executing a command, minimum 5 seconds is recommended. Default: %(default)s")
     cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output (default: utf-8). If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")

--- a/nxc/protocols/wmi/proto_args.py
+++ b/nxc/protocols/wmi/proto_args.py
@@ -17,7 +17,7 @@ def proto_args(parser, parents):
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", type=str, help="Creates a new cmd process and executes the specified command with output")
     cgroup.add_argument("--exec-method", choices={"wmiexec", "wmiexec-event"}, default="wmiexec", help="method to execute the command. (default: wmiexec). [wmiexec (win32_process + StdRegProv)]: get command results over registry instead of using smb connection. [wmiexec-event (T1546.003)]: this method is not very stable, highly recommend use this method in single host, using on multiple hosts may crash (just try again if it crashed).")
-    cgroup.add_argument("--exec-timeout", default=3, metavar="exec_timeout", dest="exec_timeout", type=int, help="Set timeout (in seconds) when executing a command, minimum 5 seconds is recommended. Default: %(default)s")
+    cgroup.add_argument("--exec-timeout", default=2, metavar="exec_timeout", dest="exec_timeout", type=int, help="Set timeout (in seconds) when executing a command, minimum 5 seconds is recommended. Default: %(default)s")
     cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output (default: utf-8). If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     return parser
 

--- a/nxc/protocols/wmi/wmiexec.py
+++ b/nxc/protocols/wmi/wmiexec.py
@@ -125,8 +125,7 @@ class WMIEXEC:
                 self.logger.debug(f"Retrieving chunk: {chunk_name}")
                 outputBuffer_b64 += descriptor.GetStringValue(0x80000002, self.__registry_Path, chunk_name).sValue
             self.__outputBuffer = base64.b64decode(outputBuffer_b64).decode(self.__codec, errors="replace").rstrip("\r\n")
-        except Exception as e:
-            print(e)
+        except Exception:
             self.logger.fail("WMIEXEC: Could not retrieve output file! Either command timed out or AV killed the process. Please try increasing the timeout: '--exec-timeout 10'")
 
     def clean_up(self, result_output, result_output_b64):

--- a/nxc/protocols/wmi/wmiexec.py
+++ b/nxc/protocols/wmi/wmiexec.py
@@ -77,7 +77,7 @@ class WMIEXEC:
 
         commands = [
             f"{self.__shell} {command} 1> {result_output} 2>&1",
-            f"{self.__shell} certutil -encodehex -f {result_output} {result_output_b64} 0x40000001",
+            f'{self.__shell} powershell -Command "[Convert]::ToBase64String([IO.File]::ReadAllBytes(\'{result_output}\')) | Out-File -Encoding ASCII \'{result_output_b64}\'"',
             f'{self.__shell} for /F "usebackq" %G in ("{result_output_b64}") do reg add HKLM\\{self.__registry_Path} /v {keyName} /t REG_SZ /d "%G" /f',
             f"{self.__shell} del /q /f /s {result_output} {result_output_b64}",
         ]

--- a/nxc/protocols/wmi/wmiexec.py
+++ b/nxc/protocols/wmi/wmiexec.py
@@ -51,9 +51,17 @@ class WMIEXEC:
         iWbemLevel1Login.RemRelease()
         self.__win32Process, _ = self.__iWbemServices.GetObject("Win32_Process")
 
-    def execute(self, command, output=False):
+    def execute(self, command, output=False, use_powershell=False):
+        """Execute a command on the remote host using WMI.
+        Options:
+        - No output
+        - Output with bash (limited to ~1MB)
+        - Output with PowerShell (recommended for larger outputs)
+        """
         if output:
             self.execute_WithOutput(command)
+        elif output and use_powershell:
+            self.execute_WithOutput_psh(command)
         else:
             command = self.__shell + command
             self.execute_remote(command)
@@ -80,13 +88,54 @@ class WMIEXEC:
         self.logger.info(f"Waiting {self.__exec_timeout}s for command to complete.")
         time.sleep(self.__exec_timeout)
 
+        # 2. Base64 encode the file
+        self.execute_remote(f"{self.__shell} certutil -encodehex -f {result_output} {result_output_b64} 0x40000001")
+        time.sleep(0.5)
+
+        # 3. Store content in registry
+        self.execute_remote(f'{self.__shell} for /F "usebackq" %G in ("{result_output_b64}") do reg add HKLM\\{self.__registry_Path} /v {keyName} /t REG_SZ /d "%G" /f')
+        time.sleep(0.1)
+
+        self.queryRegistry(keyName)
+        self.clean_up(result_output, result_output_b64)
+
+    def queryRegistry(self, keyName):
+        try:
+            # Spawn an instance of StdRegProv to access the registry
+            self.logger.debug(f"Retrieving output from: HKLM\\{self.__registry_Path}")
+            descriptor, _ = self.__iWbemServices.GetObject("StdRegProv")
+            descriptor = descriptor.SpawnInstance()
+
+            # Retrieve the base64 content from the registry
+            for _ in range(10):
+                self.logger.debug(f"Retrieving key: {keyName}")
+                outputBuffer_b64 = descriptor.GetStringValue(0x80000002, self.__registry_Path, keyName).sValue
+                if outputBuffer_b64 is not None:
+                    break
+                time.sleep(1)
+            self.__outputBuffer = base64.b64decode(outputBuffer_b64).decode(self.__codec, errors="replace").rstrip("\r\n")
+        except Exception:
+            self.logger.fail("WMIEXEC: Could not retrieve output file! Either command timed out or AV killed the process. Please try increasing the timeout: '--exec-timeout 10'")
+
+    def execute_WithOutput_psh(self, command):
+        """Same functionality as execute_WithOutput, but uses PowerShell to handle larger outputs by splitting the base64 content into chunks and storing it in the registry."""
+        result_output = f"C:\\windows\\temp\\{uuid.uuid4()!s}.txt"
+        result_output_b64 = f"C:\\windows\\temp\\{uuid.uuid4()!s}.txt"
+        keyName = str(uuid.uuid4())
+        self.__registry_Path = f"Software\\Classes\\test_nxc_{gen_random_string(6)}"
+
+        # 1. Run the command and write output to file
+        self.execute_remote(f'powershell {command} 1> "{result_output}" 2>&1')
+        self.logger.info(f"Waiting {self.__exec_timeout}s for command to complete.")
+        time.sleep(self.__exec_timeout)
+
         # 2. Base64 encode the file using PowerShell
-        self.execute_remote(f'{self.__shell} powershell -Command "[Convert]::ToBase64String([IO.File]::ReadAllBytes(\'{result_output}\')) | Out-File -Encoding ASCII \'{result_output_b64}\'"')
+        self.execute_remote(f'powershell -Command "[Convert]::ToBase64String([IO.File]::ReadAllBytes(\'{result_output}\')) | Out-File -Encoding ASCII \'{result_output_b64}\'"')
         time.sleep(0.5)
 
         # 3. Use PowerShell to split base64 content into 16KB chunks and store in registry
         self.execute_remote(
-            f'{self.__shell} powershell -Command "$b64 = Get-Content -Raw \'{result_output_b64}\'; '
+            f'powershell -Command "$b64 = Get-Content -Raw \'{result_output_b64}\'; '
             f'$chunksize = 16000; '
             f'$count = [math]::Ceiling($b64.Length / $chunksize); '
             f'for ($i = 0; $i -lt $count; $i++) {{ '
@@ -97,10 +146,10 @@ class WMIEXEC:
         )
         time.sleep(0.1)
 
-        self.queryRegistry(keyName)
+        self.queryRegistry_psh(keyName)
         self.clean_up(result_output, result_output_b64)
 
-    def queryRegistry(self, keyName):
+    def queryRegistry_psh(self, keyName):
         try:
             # Spawn an instance of StdRegProv to access the registry
             self.logger.debug(f"Retrieving output from: HKLM\\{self.__registry_Path}")

--- a/nxc/protocols/wmi/wmiexec.py
+++ b/nxc/protocols/wmi/wmiexec.py
@@ -58,7 +58,7 @@ class WMIEXEC:
         - Output with bash (limited to ~1MB)
         - Output with PowerShell (recommended for larger outputs)
         """
-        if output:
+        if output and not use_powershell:
             self.execute_WithOutput(command)
         elif output and use_powershell:
             self.execute_WithOutput_psh(command)
@@ -125,7 +125,7 @@ class WMIEXEC:
         self.__registry_Path = f"Software\\Classes\\test_nxc_{gen_random_string(6)}"
 
         # 1. Run the command and write output to file
-        self.execute_remote(f'powershell {command} 1> "{result_output}" 2>&1')
+        self.execute_remote(f'powershell -Command {command} 1> "{result_output}" 2>&1')
         self.logger.info(f"Waiting {self.__exec_timeout}s for command to complete.")
         time.sleep(self.__exec_timeout)
 
@@ -173,7 +173,7 @@ class WMIEXEC:
                 chunk_name = f"{keyName}_chunk_{i}"
                 self.logger.debug(f"Retrieving chunk: {chunk_name}")
                 outputBuffer_b64 += descriptor.GetStringValue(0x80000002, self.__registry_Path, chunk_name).sValue
-            self.__outputBuffer = base64.b64decode(outputBuffer_b64).decode(self.__codec, errors="replace").rstrip("\r\n")
+            self.__outputBuffer = base64.b64decode(outputBuffer_b64).decode("utf-16le", errors="replace").rstrip("\r\n")
         except Exception:
             self.logger.fail("WMIEXEC: Could not retrieve output file! Either command timed out or AV killed the process. Please try increasing the timeout: '--exec-timeout 10'")
 

--- a/nxc/protocols/wmi/wmiexec.py
+++ b/nxc/protocols/wmi/wmiexec.py
@@ -81,7 +81,7 @@ class WMIEXEC:
         result_output = f"C:\\windows\\temp\\{uuid.uuid4()!s}.txt"
         result_output_b64 = f"C:\\windows\\temp\\{uuid.uuid4()!s}.txt"
         keyName = str(uuid.uuid4())
-        self.__registry_Path = f"Software\\Classes\\test_nxc_{gen_random_string(6)}"
+        self.__registry_Path = f"Software\\Classes\\{gen_random_string(8)}"
 
         # 1. Run the command and write output to file
         self.execute_remote(f'{self.__shell} {command} 1> "{result_output}" 2>&1')
@@ -122,7 +122,7 @@ class WMIEXEC:
         result_output = f"C:\\windows\\temp\\{uuid.uuid4()!s}.txt"
         result_output_b64 = f"C:\\windows\\temp\\{uuid.uuid4()!s}.txt"
         keyName = str(uuid.uuid4())
-        self.__registry_Path = f"Software\\Classes\\{gen_random_string(6)}"
+        self.__registry_Path = f"Software\\Classes\\{gen_random_string(8)}"
 
         # 1. Run the command and write output to file
         if not command.lower().startswith("powershell"):

--- a/nxc/protocols/wmi/wmiexec_event.py
+++ b/nxc/protocols/wmi/wmiexec_event.py
@@ -57,9 +57,11 @@ class WMIEXEC_EVENT:
         self.__iWbemServices = iWbemLevel1Login.NTLMLogin("//./root/subscription", NULL, NULL)
         iWbemLevel1Login.RemRelease()
 
-    def execute(self, command, output=False):
+    def execute(self, command, output=False, use_powershell=False):
         if "'" in command:
             command = command.replace("'", r'"')
+        if use_powershell:
+            command = f"powershell.exe -Command {command}"
         self.__retOutput = output
         self.execute_handler(command)
 


### PR DESCRIPTION
## Description

The main problem with wmi execution is that it extracts the data via the registry, which has a data Limit of ~16KB (see [here](https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-element-size-limits)). Therefore, i refactored the wmi execution and added powershell, so for each 16KB chunk a new registry is added and read. Therefore execution over psh with wmi you can extract unlimited amounts of data.

The other benefits introduced by the refactor:
- To get the output value, every second (up to 10 times) we read the registry instead of one time after x seconds of waiting -> much more reliable
- Introduced a `-X` flag similar to the one in SMB for direct powershell execution
- Much faster command execution (down to ~4s from ~6s)

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Test the `ntds_dump_raw` with the new psh execution (will be a separat PR).
Test powershell: `-X 'Get-TimeZone'`

## Screenshots (if appropriate):
Powershell command execution:
<img width="1200" height="392" alt="image" src="https://github.com/user-attachments/assets/16c4f6ba-8942-45fe-a4a9-a00297c899df" />

Faster command execution:
<img width="1198" height="576" alt="image" src="https://github.com/user-attachments/assets/a310c842-7e67-4021-a8bc-cc19e3d79928" />


Now possible to use the `ntds_dump_raw` module (will PR the addition in a separate one):
<img width="1522" height="812" alt="image" src="https://github.com/user-attachments/assets/276fc225-9e31-4905-b442-24081bd84a48" />
