### PR TITLE
added support for `--store-st` flag

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -353,7 +353,7 @@ class smb(connection):
             if self.args.delegate:
                 kerb_pass = ""
                 self.username = self.args.delegate
-                serverName = Principal(f"cifs/{self.hostname}", type=constants.PrincipalNameType.NT_SRV_INST.value)
+                serverName = Principal(f"cifs/{self.hostname}.{self.domain}", type=constants.PrincipalNameType.NT_SRV_INST.value)
                 tgs, sk = kerberos_login_with_S4U(domain, self.hostname, username, password, nthash, lmhash, aesKey, kdcHost, self.args.delegate, serverName, useCache, no_s4u2proxy=self.args.no_s4u2proxy)
                 self.logger.debug(f"Got TGS for {self.args.delegate} through S4U")
                 if self.args.store_st:

--- a/nxc/protocols/smb/kerberos.py
+++ b/nxc/protocols/smb/kerberos.py
@@ -275,4 +275,4 @@ def kerberos_login_with_S4U(domain, hostname, username, password, nthash, lmhash
     tgs_formated["KDC_REP"] = r
     tgs_formated["cipher"] = cipher
     tgs_formated["sessionKey"] = new_session_key
-    return tgs_formated
+    return tgs_formated, session_key

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -1,4 +1,4 @@
-from argparse import _StoreTrueAction
+from argparse import _StoreTrueAction, _StoreAction
 from nxc.helpers.args import DisplayDefaultsNotNone, DefaultTrackingAction
 
 
@@ -7,6 +7,7 @@ def proto_args(parser, parents):
     smb_parser.add_argument("-H", "--hash", metavar="HASH", dest="hash", nargs="+", default=[], help="NTLM hash(es) or file(s) containing NTLM hashes")
 
     delegate_arg = smb_parser.add_argument("--delegate", action="store", help="Impersonate user with S4U2Self + S4U2Proxy")
+    store_st = smb_parser.add_argument("--store-st", dest="store_st", action=get_conditional_action(_StoreAction), make_required=[], help="Store the S4U Service Ticket in the specified file", type=str)
     self_delegate_arg = smb_parser.add_argument("--self", dest="no_s4u2proxy", action=get_conditional_action(_StoreTrueAction), make_required=[], help="Only do S4U2Self, no S4U2Proxy (use with delegate)")
 
     dgroup = smb_parser.add_mutually_exclusive_group()
@@ -24,6 +25,7 @@ def proto_args(parser, parents):
     smb_parser.add_argument("--generate-krb5-file", type=str, help="Generate a krb5 file like from a range of IP")
     smb_parser.add_argument("--generate-tgt", type=str, help="Generate a tgt ticket")
     self_delegate_arg.make_required = [delegate_arg]
+    store_st.make_required = [delegate_arg]
 
     cred_gathering_group = smb_parser.add_argument_group("Credential Gathering", "Options for gathering credentials")
     cred_gathering_group.add_argument("--sam", choices={"regdump", "secdump"}, nargs="?", const="regdump", help="dump SAM hashes from target systems")


### PR DESCRIPTION
## Description

1. Adds the `--store-st` [https://github.com/Pennyw0rth/NetExec/issues/809](https://github.com/Pennyw0rth/NetExec/issues/809) flag when doing RBCD (or CD) with `--delegate`, opted not to use `--generate-tgt` as suggested by @NeffIsBack as the resultant ticket is not a `TGT` and would probably cause some confusion.

2. Fixed a minor bug in forming the `Principal` object for the delegation, modified to use the `FQDN` of the target instead of just the hostname

```python
# serverName = Principal(f"cifs/{self.hostname}", type=constants.PrincipalNameType.NT_SRV_INST.value)
serverName = Principal(f"cifs/{self.hostname}.{self.domain}", type=constants.PrincipalNameType.NT_SRV_INST.value)
```

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

A machine that is configured with either Constrained Delegation, or Resource-Based Constrained Delegation on another machine. 

## Screenshots (if appropriate):

`FS01$` is allowed to act on behalf of any user to `DC02$` on any protocol (RBCD)

<img width="1357" height="262" alt="a205413ee7da0729269635f69acccd15" src="https://github.com/user-attachments/assets/719bc574-46ba-442a-a906-ca159d45aa54" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
