### PR TITLE
added `DUMP_TICKETS` flag to lsassy module

### DIFF
--- a/nxc/modules/lsassy.py
+++ b/nxc/modules/lsassy.py
@@ -33,14 +33,14 @@ class NXCModule:
     def options(self, context, module_options):
         """
         METHOD              Method to use to dump lsass.exe with lsassy
-        DUMP_TICKETS        If set, will dump Kerberos tickets
+        DUMP_TICKETS        If set, will dump Kerberos tickets (Default: True)
         SAVE_DIR            Directory to save dumped tickets
-        SAVE_TYPE           Type of ticket to save, either 'kirbi' or 'ccache'. Default is 'ccache'.
+        SAVE_TYPE           Type of ticket to save, either 'kirbi' or 'ccache' (Default: 'ccache')
         """
         self.method = "comsvcs"
         if "METHOD" in module_options:
             self.method = module_options["METHOD"]
-        
+
         if "DUMP_TICKETS" in module_options:
             self.dump_tickets = module_options["DUMP_TICKETS"].lower() in ["true"]
 


### PR DESCRIPTION
## Description

Adds the `DUMP_TICKETS`, `SAVE_DIR` and `SAVE_TYPE` flags to the lsassy module as per #826, these flags will expose the ability to save dumped Kerberos tickets to a specified directory.

The `SAVE_TYPE` flag can be used to save these tickets as either `.kirbi` or `.ccache` format.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

Local administrator access to a machine with at least one cached Kerberos ticket from an interactive process, such that the lsassy module can dump them

## Screenshots (if appropriate):

When using the `DUMP_TICKETS` option, the `SAVE_DIR` option must also be specified.

<img width="1397" height="497" alt="ebc5d814dd8f7ae3dfa688de3f07a8a3" src="https://github.com/user-attachments/assets/1f5dec4b-91bd-4c60-baac-4b5ccf5c9c72" />

The default save type as exposed by lsassy is `.kirbi`, this can be converted to a kerberos cache by specifying `SAVE_TYPE`; this option allows `kirbi` and `ccache`

![c66034c774c922b6a10c0f93464b884b](https://github.com/user-attachments/assets/7f4b4cc4-6528-427d-8169-044c1cccef5c)

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
