### PR TITLE
Recycle Bin Update and minor tweaks to SMBSpider

### DIFF
--- a/nxc/modules/recyclebin.py
+++ b/nxc/modules/recyclebin.py
@@ -73,25 +73,26 @@ class NXCModule:
             # And check that the filename contains $R only to prevent downloading useless stuff
             for path in paths:    
                 filename = path.split(f"{sid_directory_name}/")[1]
-                if filename.startswith("$R"):
-                    if connection.conn.listPath("C$", path)[0].is_directory():
-                        continue
-                    context.log.highlight(f"Found file: {path}")
-                    filename = filename.replace("/", "_").replace(" ", "_")[2:]
-                    if self.download:
-                        export_path = join(NXC_PATH, "modules", "recyclebin", f"{connection.host}_{username if username else sid_directory_name}")
-                        makedirs(export_path, exist_ok=True)
-                        dest_path = abspath(join(export_path, filename))
-                        with open(dest_path, "wb+") as file:
-                            try:
-                                connection.conn.getFile("C$", path, file.write)
-                                context.log.highlight(f"Writing {filename} to {export_path}")
-                            except Exception as e:
-                                if "STATUS_FILE_IS_A_DIRECTORY" in str(e):
-                                    context.log.debug("File is a directory")
-                                else:
-                                    context.log.fail(f"Failed to write recyclebin file {filename}: {e}")
-                    else:
-                        context.log.info('Use the module option "DOWNLOAD=True"')
+                if not filename.startswith("$R"):
+                    continue
+                if connection.conn.listPath("C$", path)[0].is_directory():
+                    continue
+                context.log.highlight(f"Found file: {path}")
+                filename = filename.replace("/", "_").replace(" ", "_")[2:]
+                if self.download:
+                    export_path = join(NXC_PATH, "modules", "recyclebin", f"{connection.host}_{username if username else sid_directory_name}")
+                    makedirs(export_path, exist_ok=True)
+                    dest_path = abspath(join(export_path, filename))
+                    with open(dest_path, "wb+") as file:
+                        try:
+                            connection.conn.getFile("C$", path, file.write)
+                            context.log.highlight(f"Writing {filename} to {export_path}")
+                        except Exception as e:
+                            if "STATUS_FILE_IS_A_DIRECTORY" in str(e):
+                                context.log.debug("File is a directory")
+                            else:
+                                context.log.fail(f"Failed to write recyclebin file {filename}: {e}")
+                else:
+                    context.log.info('Use the module option "DOWNLOAD=True"')
 
         remote_ops.finish()

--- a/nxc/modules/recyclebin.py
+++ b/nxc/modules/recyclebin.py
@@ -4,96 +4,94 @@ from os.path import join, abspath
 from impacket.dcerpc.v5 import rrp
 from impacket.dcerpc.v5.rrp import DCERPCSessionError
 from impacket.examples.secretsdump import RemoteOperations
+from nxc.protocols.smb.smbspider import SMBSpider
 
 
 class NXCModule:
-    # Module by @Defte_
-    # Dumps files from recycle bins
-
+    # Module by @Defte_, updated by @haytechy
+    # Dumps files from the recycle bins
     name = "recyclebin"
     description = "Lists and exports users' recycle bins"
     supported_protocols = ["smb"]
 
+    def __init__(self):
+        self.context = None
+        self.module_options = None
+        self.download = False
+
     def options(self, context, module_options):
-        """No options available"""
+        """DOWNLOAD  Download Recycle Bin Contents (True or False) Default: False"""
+        if "DOWNLOAD" in module_options and module_options["DOWNLOAD"].upper() == "TRUE":
+            self.download = True
 
     def on_admin_login(self, context, connection):
-        false_positive_users = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
-        found = 0
-        try:
-            remote_ops = RemoteOperations(connection.conn, connection.kerberos)
-            remote_ops.enableRegistry()
+        remote_ops = RemoteOperations(connection.conn, connection.kerberos)
+        remote_ops.enableRegistry()
+        context.log.display("Crawling through the Recycle Bin")
+        for sid_directory in connection.conn.listPath("C$", "$Recycle.Bin\\*"):
+            sid_directory_name = sid_directory.get_longname()
+            if sid_directory_name in (".", ".."):
+                continue
 
-            for sid_directory in connection.conn.listPath("C$", "$Recycle.Bin\\*"):
-                try:
-                    if sid_directory.get_longname() and sid_directory.get_longname() not in false_positive_users:
+            connection.args.pattern = [""]
+            connection.args.exclude_folders = []
+            paths = []
+            spidering = SMBSpider(connection, True)
+            try:
+                spidering.crawl("C$", f"$Recycle.Bin/{sid_directory_name}", None)
+                paths = spidering.paths
+            except Exception as e:
+                context.log.fail(f"Exception: {e}")
 
-                        # Extracts the username from the SID
-                        reg_handle = rrp.hOpenLocalMachine(remote_ops._RemoteOperations__rrp)["phKey"]
-                        key_handle = rrp.hBaseRegOpenKey(remote_ops._RemoteOperations__rrp, reg_handle, f"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{sid_directory.get_longname()}")["phkResult"]
-                        username = None
-                        try:
-                            _, profileimagepath = rrp.hBaseRegQueryValue(remote_ops._RemoteOperations__rrp, key_handle, "ProfileImagePath\x00")
-                            # Get username and remove embedded null byte
-                            username = profileimagepath.split("\\")[-1].rstrip("\x00")
-                        except rrp.DCERPCSessionError as e:
-                            context.log.debug(f"Couldn't get username from SID {e} on host {connection.host}")
+            username = ""
+            false_positive_users = ["Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
+            reg_handle = rrp.hOpenLocalMachine(remote_ops._RemoteOperations__rrp)["phKey"]
+            try:
+                key_handle = rrp.hBaseRegOpenKey(remote_ops._RemoteOperations__rrp, reg_handle, f"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{sid_directory_name}")["phkResult"]
+                _, profileimagepath = rrp.hBaseRegQueryValue(remote_ops._RemoteOperations__rrp, key_handle, "ProfileImagePath\x00")
+                username = profileimagepath.split("\\")[-1].rstrip("\x00")
+                if username in false_positive_users:
+                    continue
+            except DCERPCSessionError as e:
+                if "ERROR_FILE_NOT_FOUND" in str(e):
+                    continue
 
-                        # Lists for any file or directory in the recycle bin
-                        spider_folder = f"$Recycle.Bin\\{sid_directory.get_longname()}\\"
-                        paths = connection.spider(
-                            "C$",
-                            folder=spider_folder,
-                            regex=[r"(.*)"],
-                            silent=True
-                        )
+            paths = [path for path in paths if not path.endswith("desktop.ini")]
+            if not paths:
+                context.log.debug(f"No files found in the Recycle Bin for the following SID: {sid_directory_name} ({username})")
+                continue
+            if username is not None:
+                context.log.success(f"Files found in Recycle Bin for the following SID: {sid_directory_name} ({username})")
+            else:
+                context.log.success(f"Files found in Recycle Bin for the following SID: {sid_directory_name}")
 
-                        false_positive = (".", "..", "desktop.ini")
-                        filtered_file_paths = [path for path in paths if not path.endswith(false_positive)]
-                        if filtered_file_paths:
-                            if username is not None:
-                                context.log.highlight(f"CONTENT FOUND {sid_directory.get_longname()} ({username})")
-                            else:
-                                context.log.highlight(f"CONTENT FOUND {sid_directory.get_longname()}")
-
-                            for path in filtered_file_paths:
-                                # Returned path look like:
-                                # $Recycle.Bin\S-1-5-21-4140170355-2927207985-2497279808-500\/$I87021Q.txt
-                                # Or
-                                # $Recycle.Bin\S-1-5-21-4140170355-2927207985-2497279808-500\/$R87021Q.txt
-                                # $I files are metadata while $R are actual files so we split the path from the SID
-                                # And check that the filename contains $R only to prevent downloading useless stuff
-
-                                if "$R" in path.split(sid_directory.get_longname())[1] and not path.endswith(false_positive):
-                                    # Create the export path
-                                    export_path = join(NXC_PATH, "modules", "recyclebin")
-                                    makedirs(export_path, exist_ok=True)
-
-                                    # Formatting the destination filename
-                                    file_path = path.split("$")[-1].replace("/", "_")
-                                    filename = f"{connection.host}_{username if username else sid_directory.get_longname()}_recyclebin_{file_path}"
-                                    dest_path = abspath(join(export_path, filename))
-                                    try:
-                                        with open(dest_path, "wb+") as file:
-                                            connection.conn.getFile("C$", path, file.write)
-                                    except Exception as e:
-                                        if "STATUS_FILE_IS_A_DIRECTORY" in str(e):
-                                            context.log.debug(f"Couldn't open {dest_path} because of {e}")
-                                        else:
-                                            context.log.fail(f"Failed to write recyclebin file to {filename}: {e}")
-                                    else:
-                                        context.log.highlight(f"\t{dest_path}")
-                                        found += 1
-                except DCERPCSessionError as e:
-                    if "ERROR_FILE_NOT_FOUND" in str(e):
+            # Returned path look like:
+            # $Recycle.Bin\S-1-5-21-4140170355-2927207985-2497279808-500\$I87021Q.txt
+            # Or
+            # $Recycle.Bin\S-1-5-21-4140170355-2927207985-2497279808-500\$R87021Q.txt
+            # $I files are metadata while $R are actual files so we split the path from the SID
+            # And check that the filename contains $R only to prevent downloading useless stuff
+            for path in paths:    
+                filename = path.split(f"{sid_directory_name}/")[1]
+                if filename.startswith("$R"):
+                    if connection.conn.listPath("C$", path)[0].is_directory():
                         continue
+                    context.log.highlight(f"Found file: {path}")
+                    filename = filename.replace("/", "_").replace(" ", "_")[2:]
+                    if self.download:
+                        export_path = join(NXC_PATH, "modules", "recyclebin", f"{connection.host}_{username if username else sid_directory_name}")
+                        makedirs(export_path, exist_ok=True)
+                        dest_path = abspath(join(export_path, filename))
+                        with open(dest_path, "wb+") as file:
+                            try:
+                                connection.conn.getFile("C$", path, file.write)
+                                context.log.highlight(f"Writing {filename} to {export_path}")
+                            except Exception as e:
+                                if "STATUS_FILE_IS_A_DIRECTORY" in str(e):
+                                    context.log.debug("File is a directory")
+                                else:
+                                    context.log.fail(f"Failed to write recyclebin file {filename}: {e}")
                     else:
-                        context.log.fail(f"Error opening {sid_directory.get_longname()} on host {connection.host} because of {e}")
-                        continue
-            if found > 0:
-                context.log.highlight(f"Recycle bin's content downloaded to {export_path}")
-        except DCERPCSessionError as e:
-            context.log.exception(e)
-            context.log.fail(f"Error connecting to RemoteRegistry {e} on host {connection.host}")
-        finally:
-            remote_ops.finish()
+                        context.log.info('Use the module option "DOWNLOAD=True"')
+
+        remote_ops.finish()

--- a/nxc/modules/recyclebin.py
+++ b/nxc/modules/recyclebin.py
@@ -92,7 +92,6 @@ class NXCModule:
                                 context.log.debug("File is a directory")
                             else:
                                 context.log.fail(f"Failed to write recyclebin file {filename}: {e}")
-                else:
-                    context.log.info('Use the module option "DOWNLOAD=True" to download the files')
-
+        if not self.download:
+            context.log.display('Use the module option "DOWNLOAD=True" to download the files')
         remote_ops.finish()

--- a/nxc/modules/recyclebin.py
+++ b/nxc/modules/recyclebin.py
@@ -93,6 +93,6 @@ class NXCModule:
                             else:
                                 context.log.fail(f"Failed to write recyclebin file {filename}: {e}")
                 else:
-                    context.log.info('Use the module option "DOWNLOAD=True"')
+                    context.log.info('Use the module option "DOWNLOAD=True" to download the files')
 
         remote_ops.finish()

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1510,20 +1510,7 @@ class smb(connection):
         if self.args.exclude_folders is None:
             self.args.exclude_folders = []
 
-        spidering = SMBSpider(
-                self.conn,
-                self.logger,
-                self.args.spider,
-                self.args.spider_folder,
-                self.args.pattern,
-                self.args.regex,
-                self.args.exclude_folders,
-                self.args.depth,
-                self.args.content,
-                self.args.only_files,
-                self.args.only_folders,
-                self.args.spider_all
-            )
+        spidering = SMBSpider(self)
 
         self.logger.display("Started spidering")
         start_time = time()

--- a/nxc/protocols/smb/smbspider.py
+++ b/nxc/protocols/smb/smbspider.py
@@ -36,6 +36,14 @@ class SMBSpider:
                     self.logger.debug(f"Failed accessing share: {share}")
         else:
             for share in self.shares: 
+                try:
+                    self.smbconnection.listPath(share, "*")
+                except SessionError as e:
+                    if "STATUS_ACCESS_DENIED" in str(e):
+                        self.logger.fail(f"Failed accessing share: {share} (Insufficient Permissions)")
+                    elif "STATUS_BAD_NETWORK_NAME" in str(e):
+                        self.logger.fail(f"Failed accessing share: {share} (Does Not Exist)") 
+                    continue
                 self.logger.display(f"Spidering share: {share}")
                 if self.folder != "/":
                     self.logger.display(f"Spidering folder: {self.folder}")
@@ -56,8 +64,6 @@ class SMBSpider:
         except SessionError as e:
             if "STATUS_ACCESS_DENIED" in str(e):
                 self.logger.debug(f"Failed listing files on share {share} in directory {subfolder}")
-            elif "STATUS_BAD_NETWORK_NAME" in str(e):
-                self.logger.fail(f"Failed accessing {share} share") 
             elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
                 self.logger.fail(f"{self.folder} folder does not exist")
             return

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -38,6 +38,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file.txt
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file.txt --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file2.txt
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --get-file \\Windows\\Temp\\test_file.txt /tmp/test_file.txt
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --spider C$ --DEPTH 1 --only-folders 
 ##### SMB PowerShell
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method atexec
@@ -94,6 +95,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ioxidres
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M security-questions
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M remove-mic
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M backup_operator
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M recyclebin
 # currently hanging indefinitely - TODO: look into this
 #netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M keepass_discover
 #netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M keepass_trigger -o ACTION=ALL USER=LOGIN_USERNAME KEEPASS_CONFIG_PATH="C:\\Users\\LOGIN_USERNAME\\AppData\\Roaming\\KeePass\\KeePass.config.xml"


### PR DESCRIPTION
## Description

I realised the SMB Spider improvement changes I made broke the recycling bin module as it also used the old SMB Spider class to do its crawling. So I went ahead and fixed the changes and made a few minor tweaks to the spider module as well. I also added a few e2e tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Setup guide for the review
Run using poetry on the following system
```
PRETTY_NAME="Ubuntu 24.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.2 LTS (Noble Numbat)"
```

## Enhancements
-  I'm not a big fan of download by default so added an option to download if the user wishes to download the contents of the recycling bin

## Screenshots

<img width="1994" height="627" alt="image" src="https://github.com/user-attachments/assets/5753e335-fbf9-4ecd-befb-2bf24a954fc2" />


## Checklist:
- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] New and existing e2e tests pass locally with my changes
- [x] I have performed a self-review of my own code
