### PR TITLE
Fix dpapi

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -122,6 +122,7 @@ class smb(connection):
         self.signing = False
         self.smb_share_name = smb_share_name
         self.pvkbytes = None
+        self.no_da = None
         self.no_ntlm = False
         self.null_auth = False
         self.protocol = "SMB"


### PR DESCRIPTION
## Description

I removed the `self.no_da` variable in 49e80169fdb6378c3de53b0310d76d8320303bb1 because i thought it was unused. Turns out it is used in the dpapi section of the protocol, which leads to a crash if the domain backup key is not available and we try to dump dpapi with local admin.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Remove database and run `nxc smb <ip> --local-auth --dpapi`

## Screenshots (if appropriate):
Before:
<img width="1564" height="1116" alt="image" src="https://github.com/user-attachments/assets/6aaff39b-0324-408a-8207-392fe5c86d41" />
Afrer:
<img width="1462" height="109" alt="image" src="https://github.com/user-attachments/assets/7959fe24-d6b7-4a1e-9dfd-885fd1745a2f" />
