### PR TITLE
Add --database option to MSSQL protocol

### DIFF
--- a/nxc/protocols/mssql/proto_args.py
+++ b/nxc/protocols/mssql/proto_args.py
@@ -6,7 +6,10 @@ def proto_args(parser, parents):
     mssql_parser.add_argument("-H", "--hash", metavar="HASH", dest="hash", nargs="+", default=[], help="NTLM hash(es) or file(s) containing NTLM hashes")
     mssql_parser.add_argument("--port", default=1433, type=int, metavar="PORT", help="MSSQL port")
     mssql_parser.add_argument("--mssql-timeout", help="SQL server connection timeout", type=int, default=5)
-    mssql_parser.add_argument("-q", "--query", dest="mssql_query", metavar="QUERY", type=str, help="execute the specified query against the MSSQL DB")
+    
+    qgroup = mssql_parser.add_mutually_exclusive_group()
+    qgroup.add_argument("-q", "--query", dest="mssql_query", metavar="SQL", type=str, help="execute the specified query against the mssql db")
+    qgroup.add_argument("--database", nargs="?", const=True, metavar="NAME", help="list databases or list tables for NAME")
 
     dgroup = mssql_parser.add_mutually_exclusive_group()
     dgroup.add_argument("-d", metavar="DOMAIN", dest="domain", type=str, help="domain name")


### PR DESCRIPTION
## Description
This mini-addition; Adds a single MSSQL flag:
- `--database` (no value): list databases with owners  
- `--database NAME`: list tables in the specified database along with last modified date

I often use these queries with the `-q` flag, and this just standardises that process instead of manually typing the SQL each time for ease.  (I’d rather make a pull request for this than memorise SQL statements lol)

Minimum change; reuses existing helpers; no behaviour changes outside MSSQL enum. Matches current output style.  

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change  
- [ ] Deprecation  
- [ ] Third-party update required

## Setup guide for the review
Run:
 ```bash
nxc mssql <target> -u <user> -p <pass> --database
nxc mssql <target> -u <user> -p <pass> --database database_name
```

## Screenshots (if appropriate)
<img width="1392" height="467" alt="image" src="https://github.com/user-attachments/assets/c3eaa0a3-b810-4421-94e9-cdb595852ffd" />
<img width="1402" height="409" alt="image" src="https://github.com/user-attachments/assets/e24d0ea7-9330-4077-a4bb-3eda047fc635" />
