### PR TITLE
Fixing the bug report issue template, currently not present on github

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,3 @@
-# ❗❗❗ Before filing this bug report, MAKE SURE you have already downloaded the newest version of NetExec from GitHub and installed it! Many issues have already been reported and fixed, _especially_ if you are running the native Kali version! Please delete this line before submitting your issue if you have done so.❗❗❗
-
 ---
 name: Bug report
 about: Create a report to help us improve
@@ -8,6 +6,8 @@ labels: ''
 assignees: ''
 
 ---
+
+# ❗❗❗ Before filing this bug report, MAKE SURE you have already downloaded the newest version of NetExec from GitHub and installed it! Many issues have already been reported and fixed, _especially_ if you are running the native Kali version! Please delete this line before submitting your issue if you have done so.❗❗❗
 
 
 


### PR DESCRIPTION
## Description

The current bug report issue template is not visible on github, probably due to the header not being at the top of the file. This should be fixed now

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Create a new issue

## Screenshots (if appropriate):
<img width="2105" height="385" alt="image" src="https://github.com/user-attachments/assets/b127e6b6-b914-4cd5-8f61-3724f835ae23" />