### PR TITLE
add guest check on recon

### DIFF
--- a/nxc/config.py
+++ b/nxc/config.py
@@ -37,7 +37,7 @@ audit_mode = nxc_config.get("nxc", "audit_mode", fallback=False)
 reveal_chars_of_pwd = int(nxc_config.get("nxc", "reveal_chars_of_pwd", fallback=0))
 config_log = nxc_config.getboolean("nxc", "log_mode", fallback=False)
 host_info_colors = literal_eval(nxc_config.get("nxc", "host_info_colors", fallback=["green", "red", "yellow", "cyan"]))
-
+check_guest_account = nxc_config.getboolean("nxc", "check_guest_account", fallback=False)
 
 if len(host_info_colors) != 4:
     nxc_logger.error("Config option host_info_colors must have 4 values! Using default values.")

--- a/nxc/data/nxc.conf
+++ b/nxc/data/nxc.conf
@@ -6,7 +6,7 @@ audit_mode =
 reveal_chars_of_pwd = 0
 log_mode = False
 host_info_colors = ["green", "red", "yellow", "cyan"]
-check_guest_account = True
+check_guest_account = False
 
 [BloodHound]
 bh_enabled = False

--- a/nxc/data/nxc.conf
+++ b/nxc/data/nxc.conf
@@ -6,6 +6,7 @@ audit_mode =
 reveal_chars_of_pwd = 0
 log_mode = False
 host_info_colors = ["green", "red", "yellow", "cyan"]
+check_guest_account = True
 
 [BloodHound]
 bh_enabled = False

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -190,7 +190,7 @@ class smb(connection):
                 self.conn.login("Guest", "")
                 self.logger.debug("Guest authentication successful")
                 self.is_guest = True
-            except Exception as e:
+            except Exception:
                 self.is_guest = False
 
         # self.domain is the attribute we authenticate with

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -37,7 +37,7 @@ from impacket.dcerpc.v5.dcom.wmi import CLSID_WbemLevel1Login, IID_IWbemLevel1Lo
 from impacket.smb3structs import FILE_SHARE_WRITE, FILE_SHARE_DELETE, SMB2_0_IOCTL_IS_FSCTL
 from impacket.dcerpc.v5 import tsts as TSTS
 
-from nxc.config import process_secret, host_info_colors
+from nxc.config import process_secret, host_info_colors, check_guest_account
 from nxc.connection import connection, sem, requires_admin, dcom_FirewallChecker
 from nxc.helpers.misc import gen_random_string, validate_ntlm
 from nxc.logger import NXCAdapter
@@ -185,6 +185,14 @@ class smb(connection):
                 self.no_ntlm = True
                 self.logger.debug("NTLM not supported")
 
+        if check_guest_account and not self.no_ntlm:
+            try:
+                self.conn.login("Guest", "")
+                self.logger.debug("Guest authentication successful")
+                self.is_guest = True
+            except Exception as e:
+                self.is_guest = False
+
         # self.domain is the attribute we authenticate with
         # self.targetDomain is the attribute which gets displayed as host domain
         if not self.no_ntlm:
@@ -295,7 +303,8 @@ class smb(connection):
         smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=["bold"]) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=["bold"])
         ntlm = colored(f" (NTLM:{not self.no_ntlm})", host_info_colors[2], attrs=["bold"]) if self.no_ntlm else ""
         null_auth = colored(f" (Null Auth:{self.null_auth})", host_info_colors[2], attrs=["bold"]) if self.null_auth else ""
-        self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.targetDomain}) ({signing}) ({smbv1}){ntlm}{null_auth}")
+        guest = colored(f" (Guest Auth:{self.is_guest})", host_info_colors[1], attrs=["bold"]) if self.is_guest else ""
+        self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.targetDomain}) ({signing}) ({smbv1}){ntlm}{null_auth}{guest}")
 
         if self.args.generate_hosts_file or self.args.generate_krb5_file:
             if self.args.generate_hosts_file:


### PR DESCRIPTION
## Description

Add a flag to check guest session by default for the recon. Not ideal for real pentest as it can be flaged but very cool for HTB and CTF :)

This pull request adds a new feature to check for the presence of a guest account during SMB enumeration, controlled by a configuration option. The change introduces a new config flag, updates the SMB protocol logic to use it, and improves host information display to include guest authentication status.

**Configuration changes:**
* Added a new `check_guest_account` option to `nxc.conf` and to the configuration loading logic in `nxc/config.py`, allowing users to enable or disable guest account checks. [[1]](diffhunk://#diff-c210f6fe6de14498d60f295f9a749650a68bb2c9f8bc1e8db16e1acbf10c3f2bR9) [[2]](diffhunk://#diff-714ea3199a6bba6a9c3a98bda6c109e2d45c1b1cc5841a194e9cba6a66e6daebL40-R40)

**SMB protocol enhancements:**
* Updated `nxc/protocols/smb.py` to import and use the new `check_guest_account` config flag.
* Modified the `enum_host_info` method to attempt guest authentication if the flag is set and NTLM is supported, recording and logging the result.
* Enhanced the `print_host_info` method to display guest authentication status in host information output.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] New feature (non-breaking change which adds functionality)

## Setup guide for the review
Please provide guidance on what setup is needed to test the introduced changes, such as your locally running machine Python version & OS, as well as the target(s) you tested against, including software versions.
In particular:
- Bug Fix: Please provide a short description on how to trigger the bug, to make the bug reproducable for the reviewer.
- Added Feature/Enhancement: Please specify what setup is needed in order to test the changes. E.g. is additional software needed? GPO changes required? Specific registry settings that need to be changed?

## Screenshots (if appropriate):
<img width="1592" height="100" alt="image" src="https://github.com/user-attachments/assets/00db36e6-78f6-4405-afdb-535d8d36246d" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] New and existing e2e tests pass locally with my changes
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
