### PR TITLE
Add module categories

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -76,7 +76,7 @@ def gen_cli_args():
     mgroup = module_parser.add_argument_group("Modules", "Options for nxc modules")
     mgroup.add_argument("-M", "--module", choices=get_module_names(), action="append", metavar="MODULE", help="module to use")
     mgroup.add_argument("-o", metavar="MODULE_OPTION", nargs="+", default=[], dest="module_options", help="module options")
-    mgroup.add_argument("-L", "--list-modules", action="store_true", help="list available modules")
+    mgroup.add_argument("-L", "--list-modules", nargs="?", type=str, const="", help="list available modules")
     mgroup.add_argument("--options", dest="show_module_options", action="store_true", help="display module options")
 
     subparsers = parser.add_subparsers(title="Available Protocols", dest="protocol")

--- a/nxc/helpers/misc.py
+++ b/nxc/helpers/misc.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import random
 import string
 import re
@@ -145,3 +146,9 @@ def detect_if_ip(target):
         return True
     except Exception:
         return False
+
+
+class CATEGORY(Enum):
+    ENUMERATION = "Enumeration"
+    CREDENTIAL_DUMPING = "Credential Dumping"
+    PRIVILEGE_ESCALATION = "Privilege Escalation"

--- a/nxc/loaders/moduleloader.py
+++ b/nxc/loaders/moduleloader.py
@@ -30,6 +30,9 @@ class ModuleLoader:
         elif not hasattr(module, "description"):
             self.logger.fail(f"{module_path} missing the description variable")
             module_error = True
+        elif not hasattr(module, "category"):
+            self.logger.fail(f"{module_path} missing the category variable")
+            module_error = True
         elif not hasattr(module, "supported_protocols"):
             self.logger.fail(f"{module_path} missing the supported_protocols variable")
             module_error = True
@@ -92,6 +95,7 @@ class ModuleLoader:
                     "description": module_spec.description,
                     "options": module_spec.options.__doc__,
                     "supported_protocols": module_spec.supported_protocols,
+                    "category": module_spec.category,
                     "requires_admin": bool(hasattr(module_spec, "on_admin_login") and callable(module_spec.on_admin_login)),
                 }
             }

--- a/nxc/modules/adcs.py
+++ b/nxc/modules/adcs.py
@@ -15,6 +15,7 @@ class NXCModule:
     name = "adcs"
     description = "Find PKI Enrollment Services in Active Directory and Certificate Templates Names"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/adcs.py
+++ b/nxc/modules/adcs.py
@@ -2,6 +2,8 @@ import re
 from impacket.ldap import ldap, ldapasn1
 from impacket.ldap.ldap import LDAPSearchError
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """

--- a/nxc/modules/add-computer.py
+++ b/nxc/modules/add-computer.py
@@ -4,6 +4,8 @@ import sys
 from impacket.dcerpc.v5 import samr, epm, transport
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -16,6 +18,7 @@ class NXCModule:
     name = "add-computer"
     description = "Adds or deletes a domain computer"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/aws-credentials.py
+++ b/nxc/modules/aws-credentials.py
@@ -1,3 +1,6 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Search for aws credentials files on linux and windows machines
@@ -8,6 +11,7 @@ class NXCModule:
     name = "aws-credentials"
     description = "Search for aws credentials files."
     supported_protocols = ["ssh", "smb", "winrm"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self):
         self.search_path_linux = "'/home/' '/tmp/'"

--- a/nxc/modules/backup_operator.py
+++ b/nxc/modules/backup_operator.py
@@ -6,6 +6,7 @@ from impacket.examples.secretsdump import SAMHashes, LSASecrets, LocalOperations
 from impacket.smbconnection import SessionError
 from impacket.dcerpc.v5 import transport, rrp
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 
 
@@ -13,6 +14,7 @@ class NXCModule:
     name = "backup_operator"
     description = "Exploit user in backup operator group to dump NTDS @mpgn_x64"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/badsuccessor.py
+++ b/nxc/modules/badsuccessor.py
@@ -1,4 +1,5 @@
 from impacket.ldap import ldaptypes
+from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 from ldap3.protocol.microsoft import security_descriptor_control
 
@@ -79,6 +80,7 @@ class NXCModule:
     name = "badsuccessor"
     description = "Check if vulnerable to bad successor attack (DMSA)"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/bitlocker.py
+++ b/nxc/modules/bitlocker.py
@@ -4,11 +4,14 @@ from impacket.dcerpc.v5.dtypes import NULL
 from impacket.dcerpc.v5.dcomrt import DCOMConnection
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     name = "bitlocker"
     description = "Enumerating BitLocker Status on target(s) If it is enabled or disabled."
     supported_protocols = ["smb", "wmi"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/change-password.py
+++ b/nxc/modules/change-password.py
@@ -2,6 +2,8 @@ import sys
 from impacket.dcerpc.v5 import samr, epm, transport
 from impacket.dcerpc.v5.rpcrt import DCERPCException
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -12,6 +14,7 @@ class NXCModule:
     name = "change-password"
     description = "Change or reset user passwords via various protocols"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/coerce_plus.py
+++ b/nxc/modules/coerce_plus.py
@@ -6,11 +6,14 @@ from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVE
 
 from impacket.uuid import uuidtup_to_bin
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     name = "coerce_plus"
     description = "Module to check if the Target is vulnerable to any coerce vulns. Set LISTENER IP for coercion."
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -4,6 +4,7 @@ import datetime
 from enum import Enum
 from impacket.ldap import ldaptypes
 from impacket.uuid import bin_to_string
+from nxc.helpers.misc import CATEGORY
 from nxc.helpers.msada_guids import SCHEMA_OBJECTS, EXTENDED_RIGHTS
 from nxc.parsers.ldap_results import parse_result_attributes
 from ldap3.utils.conv import escape_filter_chars
@@ -205,6 +206,7 @@ class NXCModule:
     name = "daclread"
     description = "Read and backup the Discretionary Access Control List of objects. Be careful, this module cannot read the DACLS recursively, see more explanation in the options."
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/dfscoerce.py
+++ b/nxc/modules/dfscoerce.py
@@ -1,7 +1,11 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     name = "dfscoerce"
     description = "[REMOVED] Module to check if the DC is vulnerable to DFSCoerce, credit to @filip_dragovic/@Wh04m1001 and @topotam"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/dpapi_hash.py
+++ b/nxc/modules/dpapi_hash.py
@@ -1,6 +1,7 @@
 from dploot.lib.target import Target
 from dploot.triage.masterkeys import MasterkeysTriage
 
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.dpapi import upgrade_to_dploot_connection
 
 # Based on dpapimk2john, original work by @fist0urs
@@ -10,6 +11,7 @@ class NXCModule:
     name = "dpapi_hash"
     description = "Remotely dump Dpapi hash based on masterkeys"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """OUTPUTFILE       Output file to write hashes"""

--- a/nxc/modules/drop-sc.py
+++ b/nxc/modules/drop-sc.py
@@ -1,6 +1,8 @@
 import ntpath
 import tempfile
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -12,6 +14,7 @@ class NXCModule:
     name = "drop-sc"
     description = "Drop a searchConnector-ms file on each writable share"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/dump-computers.py
+++ b/nxc/modules/dump-computers.py
@@ -1,3 +1,4 @@
+from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
 
@@ -5,6 +6,7 @@ class NXCModule:
     name = "dump-computers"
     description = "Dumps all computers in the domain"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/efsr_spray.py
+++ b/nxc/modules/efsr_spray.py
@@ -1,5 +1,5 @@
 import ntpath
-from nxc.helpers.misc import gen_random_string
+from nxc.helpers.misc import CATEGORY, gen_random_string
 from nxc.context import Context
 from impacket.smb3structs import FILE_SHARE_WRITE, FILE_SHARE_DELETE, FILE_ATTRIBUTE_ENCRYPTED
 from impacket.smbconnection import SessionError, SMBConnection
@@ -28,6 +28,7 @@ class NXCModule:
     description = "Tries to activate the EFSR service by creating a file with the encryption attribute on some available share."
     supported_protocols = ["smb"]
     excluded_shares = ["SYSVOL"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context: Context, module_options: dict[str, str]):
         """

--- a/nxc/modules/empire_exec.py
+++ b/nxc/modules/empire_exec.py
@@ -2,6 +2,8 @@ import sys
 import requests
 from requests import ConnectionError
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -12,6 +14,7 @@ class NXCModule:
     name = "empire_exec"
     description = "Uses Empire's RESTful API to generate a launcher for the specified listener and executes it"
     supported_protocols = ["smb", "mssql"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/enable_cmdshell.py
+++ b/nxc/modules/enable_cmdshell.py
@@ -1,3 +1,6 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Enables or disables xp_cmdshell in MSSQL Server.
@@ -7,6 +10,7 @@ class NXCModule:
     name = "enable_cmdshell"
     description = "Enable or disable xp_cmdshell in MSSQL Server"
     supported_protocols = ["mssql"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/entra-id.py
+++ b/nxc/modules/entra-id.py
@@ -2,6 +2,7 @@
 import re
 
 from termcolor import colored
+from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 from nxc.config import host_info_colors
 
@@ -12,6 +13,7 @@ class NXCModule:
     name = "entra-id"
     description = "Find the Entra ID sync server"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/entra-sync-creds.py
+++ b/nxc/modules/entra-sync-creds.py
@@ -1,5 +1,6 @@
 
 from base64 import b64encode
+from nxc.helpers.misc import CATEGORY
 from nxc.helpers.powershell import get_ps_script
 
 
@@ -14,6 +15,7 @@ class NXCModule:
     description = "Extract Entra ID sync credentials from the target host"
     supported_protocols = ["smb"]
     opsec_safe = True
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/enum_av.py
+++ b/nxc/modules/enum_av.py
@@ -8,6 +8,8 @@ from impacket.dcerpc.v5.dtypes import NULL, MAXIMUM_ALLOWED, RPC_UNICODE_STRING
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 import pathlib
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -18,6 +20,7 @@ class NXCModule:
     name = "enum_av"
     description = "Gathers information on all endpoint protection solutions installed on the the remote host(s) via LsarLookupNames (no privilege needed)"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/enum_ca.py
+++ b/nxc/modules/enum_ca.py
@@ -7,6 +7,8 @@ from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 from impacket import uuid
 import requests
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -23,7 +25,8 @@ class NXCModule:
 
     name = "enum_ca"
     description = "Anonymously uses RPC endpoints to hunt for ADCS CAs"
-    supported_protocols = ["smb"]  # Example: ['smb', 'mssql']
+    supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/enum_dns.py
+++ b/nxc/modules/enum_dns.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from nxc.helpers.logger import write_log
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 
 
@@ -12,6 +13,7 @@ class NXCModule:
     name = "enum_dns"
     description = "Uses WMI to dump DNS from an AD DNS Server"
     supported_protocols = ["smb", "wmi"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/enum_impersonate.py
+++ b/nxc/modules/enum_impersonate.py
@@ -1,3 +1,6 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Enumerate SQL Server users with impersonation rights
@@ -7,6 +10,7 @@ class NXCModule:
     name = "enum_impersonate"
     description = "Enumerate users with impersonation privileges"
     supported_protocols = ["mssql"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/enum_interfaces.py
+++ b/nxc/modules/enum_interfaces.py
@@ -5,6 +5,8 @@ from impacket.examples.secretsdump import RemoteOperations
 from impacket.dcerpc.v5 import rrp
 from impacket.dcerpc.v5.rpcrt import DCERPCException
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -17,6 +19,7 @@ class NXCModule:
     description = "Retrieve the list of network interfaces info (Name, IP Address, Subnet Mask, Default Gateway) from remote Windows registry (formerly --interfaces)"
     supported_protocols = ["smb"]
     opsec_safe = False
+    category = CATEGORY.ENUMERATION
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/enum_links.py
+++ b/nxc/modules/enum_links.py
@@ -1,3 +1,6 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Enumerate SQL Server linked servers
@@ -7,6 +10,7 @@ class NXCModule:
     name = "enum_links"
     description = "Enumerate linked SQL Servers and their login configurations."
     supported_protocols = ["mssql"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/enum_logins.py
+++ b/nxc/modules/enum_logins.py
@@ -1,3 +1,6 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Enumerate SQL Server logins (SQL, Domain, Local users)
@@ -7,6 +10,7 @@ class NXCModule:
     name = "enum_logins"
     description = "Enumerate SQL Server logins (SQL, Domain, Local users)"
     supported_protocols = ["mssql"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/enum_trusts.py
+++ b/nxc/modules/enum_trusts.py
@@ -1,5 +1,8 @@
 
 
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Extract all Trust Relationships, Trusting Direction, and Trust Transitivity
@@ -9,6 +12,7 @@ class NXCModule:
     name = "enum_trusts"
     description = "[REMOVED] Extract all Trust Relationships, Trusting Direction, and Trust Transitivity"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         pass

--- a/nxc/modules/eventlog_creds.py
+++ b/nxc/modules/eventlog_creds.py
@@ -3,6 +3,7 @@ from impacket.dcerpc.v5 import transport, even6
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from impacket.dcerpc.v5.epm import hept_map
 from nxc.helpers.even6_parser import ResultSet
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
@@ -12,7 +13,8 @@ class NXCModule:
     """
     name = "eventlog_creds"
     description = "Extracting Credentials From Windows Logs (Event ID: 4688 and SYSMON)"
-    supported_protocols = ["smb"]  # Example: ['smb', 'mssql']
+    supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/example_module.py
+++ b/nxc/modules/example_module.py
@@ -1,3 +1,5 @@
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -9,6 +11,7 @@ class NXCModule:
     name = "example module"
     description = "I do something"
     supported_protocols = []  # Example: ['smb', 'mssql']
+    category = CATEGORY.ENUMERATION  # Must be one of "Enumeration", "Privilege Escalation" or "Credential Dumping". Use what fits best.
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/exec_on_link.py
+++ b/nxc/modules/exec_on_link.py
@@ -1,3 +1,6 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Execute commands on linked servers
@@ -7,6 +10,7 @@ class NXCModule:
     name = "exec_on_link"
     description = "Execute commands on a SQL Server linked server"
     supported_protocols = ["mssql"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/find-computer.py
+++ b/nxc/modules/find-computer.py
@@ -1,3 +1,4 @@
+from nxc.helpers.misc import CATEGORY
 from nxc.logger import nxc_logger
 from impacket.ldap.ldap import LDAPSearchError
 from impacket.ldap.ldapasn1 import SearchResultEntry
@@ -15,6 +16,7 @@ class NXCModule:
     name = "find-computer"
     description = "Finds computers in the domain via the provided text"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/firefox.py
+++ b/nxc/modules/firefox.py
@@ -1,4 +1,5 @@
 from dploot.lib.target import Target
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.firefox import FirefoxCookie, FirefoxData, FirefoxTriage
 
 
@@ -12,6 +13,7 @@ class NXCModule:
     name = "firefox"
     description = "[REMOVED] Dump credentials from Firefox"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/get-desc-users.py
+++ b/nxc/modules/get-desc-users.py
@@ -1,5 +1,6 @@
 from impacket.ldap import ldap as ldap_impacket
 import re
+from nxc.helpers.misc import CATEGORY
 from nxc.logger import nxc_logger
 from nxc.parsers.ldap_results import parse_result_attributes
 
@@ -11,8 +12,9 @@ class NXCModule:
     """
 
     name = "get-desc-users"
-    description = "Get description of the users. May contained password"
+    description = "Get description of the users. May contain password"
     supported_protocols = ["ldap"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/get-info-users.py
+++ b/nxc/modules/get-info-users.py
@@ -1,3 +1,4 @@
+from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
 
@@ -9,6 +10,7 @@ class NXCModule:
     name = "get-info-users"
     description = "Get the info field of all users. May contain password"
     supported_protocols = ["ldap"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """FILTER    Apply the FILTER (grep-like) (default: '')"""

--- a/nxc/modules/get-network.py
+++ b/nxc/modules/get-network.py
@@ -10,6 +10,7 @@ from struct import unpack
 from impacket.structure import Structure
 from ldap3 import LEVEL
 from os.path import expanduser
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 from nxc.parsers.ldap_results import parse_result_attributes
 
@@ -68,6 +69,7 @@ class NXCModule:
     name = "get-network"
     description = "Query all DNS records with the corresponding IP from the domain."
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/get-unixUserPassword.py
+++ b/nxc/modules/get-unixUserPassword.py
@@ -1,4 +1,5 @@
 from impacket.ldap import ldap as ldap_impacket
+from nxc.helpers.misc import CATEGORY
 from nxc.logger import nxc_logger
 from nxc.parsers.ldap_results import parse_result_attributes
 
@@ -12,6 +13,7 @@ class NXCModule:
     name = "get-unixUserPassword"
     description = "Get unixUserPassword attribute from all users in ldap"
     supported_protocols = ["ldap"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/get-userPassword.py
+++ b/nxc/modules/get-userPassword.py
@@ -1,4 +1,5 @@
 from impacket.ldap import ldap as ldap_impacket
+from nxc.helpers.misc import CATEGORY
 from nxc.logger import nxc_logger
 from nxc.parsers.ldap_results import parse_result_attributes
 
@@ -12,6 +13,7 @@ class NXCModule:
     name = "get-userPassword"
     description = "Get userPassword attribute from all users in ldap"
     supported_protocols = ["ldap"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/get_netconnections.py
+++ b/nxc/modules/get_netconnections.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from nxc.helpers.logger import write_log
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 import json
 
@@ -14,6 +15,7 @@ class NXCModule:
     name = "get_netconnections"
     description = "Uses WMI to query network connections."
     supported_protocols = ["smb", "wmi"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """No options available"""

--- a/nxc/modules/gpp_autologin.py
+++ b/nxc/modules/gpp_autologin.py
@@ -1,6 +1,8 @@
 import xml.etree.ElementTree as ET
 from io import BytesIO
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -11,6 +13,7 @@ class NXCModule:
     name = "gpp_autologin"
     description = "Searches the domain controller for registry.xml to find autologon information and returns the username and password."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/gpp_password.py
+++ b/nxc/modules/gpp_password.py
@@ -4,6 +4,8 @@ from base64 import b64decode
 from binascii import unhexlify
 from io import BytesIO
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -14,6 +16,7 @@ class NXCModule:
     name = "gpp_password"
     description = "Retrieves the plaintext password and other information for accounts pushed through Group Policy Preferences."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/gpp_privileges.py
+++ b/nxc/modules/gpp_privileges.py
@@ -3,6 +3,8 @@ import ldap3
 import re
 from io import BytesIO
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -13,6 +15,7 @@ class NXCModule:
     name = "gpp_privileges"
     description = "Extracts privileges assigned via GPOs and resolves SIDs via LDAP."
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     WELL_KNOWN_SIDS = {
         "S-1-0": "Null Authority",

--- a/nxc/modules/group-mem.py
+++ b/nxc/modules/group-mem.py
@@ -1,6 +1,8 @@
 from impacket.ldap import ldapasn1 as ldapasn1_impacket
 import sys
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -13,6 +15,7 @@ class NXCModule:
     name = "group-mem"
     description = "[REMOVED] Retrieves all the members within a Group"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     primaryGroupID = ""
     answers = []

--- a/nxc/modules/groupmembership.py
+++ b/nxc/modules/groupmembership.py
@@ -2,6 +2,8 @@ from impacket.ldap import ldapasn1 as ldapasn1_impacket
 from impacket.ldap import ldap as ldap_impacket
 import sys
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -15,6 +17,7 @@ class NXCModule:
     name = "groupmembership"
     description = "Query the groups to which a user belongs."
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """USER	Choose a username to query group membership"""

--- a/nxc/modules/handlekatz.py
+++ b/nxc/modules/handlekatz.py
@@ -7,6 +7,7 @@ import re
 import sys
 from datetime import datetime
 from nxc.helpers.bloodhound import add_user_bh
+from nxc.helpers.misc import CATEGORY
 from pypykatz.pypykatz import pypykatz
 
 
@@ -14,6 +15,7 @@ class NXCModule:
     name = "handlekatz"
     description = "Get lsass dump using handlekatz64 and parse the result with pypykatz"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/hash_spider.py
+++ b/nxc/modules/hash_spider.py
@@ -9,6 +9,8 @@ from lsassy.parser import Parser
 from lsassy.session import Session
 from lsassy.impacketfile import ImpacketFile
 
+from nxc.helpers.misc import CATEGORY
+
 credentials_data = []
 found_users = []
 reported_da = []
@@ -130,6 +132,7 @@ class NXCModule:
     name = "hash_spider"
     description = "Dump lsass recursively from a given hash using BH to find local admins"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/hyperv-host.py
+++ b/nxc/modules/hyperv-host.py
@@ -1,6 +1,7 @@
 from impacket.dcerpc.v5.rpcrt import DCERPCException
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
@@ -9,6 +10,7 @@ class NXCModule:
     name = "hyperv-host"
     description = "Performs a registry query on the VM to lookup its HyperV Host"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/iis.py
+++ b/nxc/modules/iis.py
@@ -1,3 +1,6 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Checks for credentials in IIS Application Pool configuration files using appcmd.exe.
@@ -8,12 +11,10 @@ class NXCModule:
     name = "iis"
     description = "Checks for credentials in IIS Application Pool configuration files using appcmd.exe"
     supported_protocols = ["smb"]
-
-    def __init__(self):
-        pass
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
-        pass
+        """No options available"""
 
     def on_admin_login(self, context, connection):
         self.check_appcmd(context, connection)

--- a/nxc/modules/impersonate.py
+++ b/nxc/modules/impersonate.py
@@ -7,6 +7,7 @@ from base64 import b64decode
 from os import path
 import sys
 from datetime import datetime
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import DATA_PATH
 
 
@@ -14,6 +15,7 @@ class NXCModule:
     name = "impersonate"
     description = "List and impersonate tokens to run command as locally logged on users"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/install_elevated.py
+++ b/nxc/modules/install_elevated.py
@@ -1,12 +1,14 @@
 from impacket.dcerpc.v5 import rrp
 from impacket.dcerpc.v5 import scmr
 from impacket.examples.secretsdump import RemoteOperations
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
     name = "install_elevated"
     description = "Checks for AlwaysInstallElevated"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/ioxidresolver.py
+++ b/nxc/modules/ioxidresolver.py
@@ -7,12 +7,14 @@ from ipaddress import ip_address
 from impacket.dcerpc.v5 import transport
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_NONE, DCERPCException
 from impacket.dcerpc.v5.dcomrt import IObjectExporter
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
     name = "ioxidresolver"
     description = "This module helps you to identify hosts that have additional active interfaces"
     supported_protocols = ["smb", "wmi"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """DIFFERENT show only ip address if different from target ip (Default: False)"""

--- a/nxc/modules/keepass_discover.py
+++ b/nxc/modules/keepass_discover.py
@@ -1,4 +1,5 @@
 from csv import reader
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
@@ -12,6 +13,7 @@ class NXCModule:
     name = "keepass_discover"
     description = "Search for KeePass-related files and process."
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self):
         self.search_type = "ALL"

--- a/nxc/modules/keepass_trigger.py
+++ b/nxc/modules/keepass_trigger.py
@@ -5,6 +5,7 @@ from csv import reader
 from base64 import b64encode
 from io import BytesIO, StringIO
 from xml.etree import ElementTree as ET
+from nxc.helpers.misc import CATEGORY
 from nxc.helpers.powershell import get_ps_script
 from nxc.paths import TMP_PATH
 
@@ -21,6 +22,7 @@ class NXCModule:
     name = "keepass_trigger"
     description = "Set up a malicious KeePass trigger to export the database in cleartext."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
     # while the module only executes legit powershell commands on the target (search and edit files)
     # some EDR like Trend Micro flag base64-encoded powershell as malicious
     # the option PSH_EXEC_METHOD can be used to avoid such execution, and will drop scripts on the target

--- a/nxc/modules/laps.py
+++ b/nxc/modules/laps.py
@@ -1,6 +1,7 @@
 import json
 
 from impacket.ldap import ldapasn1 as ldapasn1_impacket
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.ldap.laps import LAPSv2Extract
 
 
@@ -17,6 +18,7 @@ class NXCModule:
     name = "laps"
     description = "Retrieves all LAPS passwords which the account has read permissions for."
     supported_protocols = ["ldap"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """COMPUTER    Computer name or wildcard ex: WIN-S10, WIN-* etc. Default: *"""

--- a/nxc/modules/ldap-checker.py
+++ b/nxc/modules/ldap-checker.py
@@ -14,6 +14,8 @@ from asyauth.common.credentials.kerberos import KerberosCredential
 from asysocks.unicomm.common.target import UniTarget, UniProto
 import contextlib
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -25,6 +27,7 @@ class NXCModule:
     name = "ldap-checker"
     description = "[REMOVED] Checks whether LDAP signing and channel binding are required and / or enforced"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """No options available."""

--- a/nxc/modules/link_enable_cmdshell.py
+++ b/nxc/modules/link_enable_cmdshell.py
@@ -1,3 +1,6 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Enable or disable xp_cmdshell on a linked MSSQL server
@@ -7,6 +10,7 @@ class NXCModule:
     name = "link_enable_cmdshell"
     description = "Enable or disable xp_cmdshell on a linked MSSQL server"
     supported_protocols = ["mssql"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self):
         self.action = None

--- a/nxc/modules/link_xpcmd.py
+++ b/nxc/modules/link_xpcmd.py
@@ -1,3 +1,6 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     """
     Run xp_cmdshell commands on a linked SQL server
@@ -7,6 +10,7 @@ class NXCModule:
     name = "link_xpcmd"
     description = "Run xp_cmdshell commands on a linked SQL server"
     supported_protocols = ["mssql"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self):
         self.linked_server = None

--- a/nxc/modules/lsassy.py
+++ b/nxc/modules/lsassy.py
@@ -14,6 +14,7 @@ from lsassy.session import Session
 from impacket.krb5.ccache import CCache
 
 from nxc.helpers.bloodhound import add_user_bh
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 
 
@@ -21,6 +22,7 @@ class NXCModule:
     name = "lsassy"
     description = "Dump lsass and parse the result remotely with lsassy"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -1,4 +1,5 @@
 from pyasn1.error import PyAsn1Error
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
@@ -14,11 +15,12 @@ class NXCModule:
     """
 
     def options(self, context, module_options):
-        pass
+        """No options available"""
 
     name = "maq"
     description = "Retrieves the MachineAccountQuota domain-level attribute"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def on_login(self, context, connection):
         context.log.display("Getting the MachineAccountQuota")

--- a/nxc/modules/masky.py
+++ b/nxc/modules/masky.py
@@ -1,11 +1,13 @@
 from masky import Masky
 from nxc.helpers.bloodhound import add_user_bh
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
     name = "masky"
     description = "Remotely dump domain user credentials via an ADCS and a KDC"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/met_inject.py
+++ b/nxc/modules/met_inject.py
@@ -1,4 +1,5 @@
 from sys import exit
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
@@ -10,6 +11,7 @@ class NXCModule:
     name = "met_inject"
     description = "Downloads the Meterpreter stager and injects it into memory"
     supported_protocols = ["smb", "mssql"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.rand = None

--- a/nxc/modules/mobaxterm.py
+++ b/nxc/modules/mobaxterm.py
@@ -2,6 +2,7 @@ from dploot.triage.mobaxterm import MobaXtermTriage, MobaXtermCredential, MobaXt
 from dploot.lib.target import Target
 
 from nxc.helpers.logger import highlight
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.dpapi import collect_masterkeys_from_target, get_domain_backup_key, upgrade_to_dploot_connection
 
 
@@ -9,9 +10,10 @@ class NXCModule:
     name = "mobaxterm"
     description = "Remotely dump MobaXterm credentials via RemoteRegistry or NTUSER.dat export"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
-        """ """
+        """No options available"""
 
     def on_admin_login(self, context, connection):
         username = connection.username

--- a/nxc/modules/mremoteng.py
+++ b/nxc/modules/mremoteng.py
@@ -6,6 +6,7 @@ from base64 import b64decode
 import hashlib
 from dataclasses import dataclass
 
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.dpapi import upgrade_to_dploot_connection
 
 
@@ -26,6 +27,7 @@ class NXCModule:
     name = "mremoteng"
     description = "Dump mRemoteNG Passwords in AppData and in Desktop / Documents folders (digging recursively in them) "
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self, context=None, module_options=None):
         self.false_positive = (

--- a/nxc/modules/ms17-010.py
+++ b/nxc/modules/ms17-010.py
@@ -5,6 +5,7 @@
 from ctypes import c_uint8, c_uint16, c_uint32, c_uint64, Structure
 import socket
 import struct
+from nxc.helpers.misc import CATEGORY
 from nxc.logger import nxc_logger
 
 
@@ -54,6 +55,7 @@ class NXCModule:
     name = "ms17-010"
     description = "MS17-010 - EternalBlue - NOT TESTED OUTSIDE LAB ENVIRONMENT"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/msol.py
+++ b/nxc/modules/msol.py
@@ -3,6 +3,7 @@
 # Based on the article : https://blog.xpnsec.com/azuread-connect-for-redteam/
 # Fully rewritten by @NeffIsBack
 from base64 import b64encode
+from nxc.helpers.misc import CATEGORY
 from nxc.helpers.powershell import get_ps_script
 
 
@@ -11,6 +12,7 @@ class NXCModule:
     name = "msol"
     description = "Dump MSOL cleartext password and Entra ID credentials from the localDB on the Entra ID Connect Server"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/mssql_coerce.py
+++ b/nxc/modules/mssql_coerce.py
@@ -1,5 +1,7 @@
 import sys
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """Execute arbitrary SQL commands on the target MSSQL server"""
@@ -7,6 +9,7 @@ class NXCModule:
     name = "mssql_coerce"
     description = "Execute arbitrary SQL commands on the target MSSQL server"
     supported_protocols = ["mssql"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self):
         self.mssql_conn = None

--- a/nxc/modules/mssql_priv.py
+++ b/nxc/modules/mssql_priv.py
@@ -1,6 +1,7 @@
 # Author:
 #  Romain de Reydellet (@pentest_soka)
 from nxc.helpers.logger import highlight
+from nxc.helpers.misc import CATEGORY
 
 
 class User:
@@ -23,6 +24,7 @@ class NXCModule:
     name = "mssql_priv"
     description = "Enumerate and exploit MSSQL privileges"
     supported_protocols = ["mssql"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self):
         self.admin_privs = None

--- a/nxc/modules/nanodump.py
+++ b/nxc/modules/nanodump.py
@@ -9,6 +9,7 @@ from pypykatz.pypykatz import pypykatz
 import tempfile
 from datetime import datetime
 from nxc.helpers.bloodhound import add_user_bh
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.mssql.mssqlexec import MSSQLEXEC
 
 
@@ -16,6 +17,7 @@ class NXCModule:
     name = "nanodump"
     description = "Get lsass dump using nanodump and parse the result with pypykatz"
     supported_protocols = ["smb", "mssql"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self, context=None, module_options=None):
         self.connection = None

--- a/nxc/modules/nopac.py
+++ b/nxc/modules/nopac.py
@@ -7,14 +7,17 @@ from impacket.krb5.kerberosv5 import getKerberosTGT
 from impacket.krb5 import constants
 from impacket.krb5.types import Principal
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     name = "nopac"
     description = "Check if the DC is vulnerable to CVE-2021-42278 and CVE-2021-42287 to impersonate DA from standard domain user"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
-        """ """
+        """No options available"""
 
     def on_login(self, context, connection):
         user_name = Principal(connection.username, type=constants.PrincipalNameType.NT_PRINCIPAL.value)

--- a/nxc/modules/notepad++.py
+++ b/nxc/modules/notepad++.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 from os import makedirs
 from os.path import join, abspath
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 
 
@@ -11,6 +12,7 @@ class NXCModule:
     name = "notepad++"
     description = "Extracts notepad++ unsaved files."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
     false_positive = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
 
     def options(self, context, module_options):

--- a/nxc/modules/notepad.py
+++ b/nxc/modules/notepad.py
@@ -3,6 +3,7 @@ from os import makedirs
 from os.path import join, abspath
 import re
 import time
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 from impacket.smbconnection import SessionError
 
@@ -28,6 +29,7 @@ class NXCModule:
     name = "notepad"
     description = "Extracts content from Windows Notepad tab state binary files."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self, context=None):
         self.context = context

--- a/nxc/modules/ntds-dump-raw.py
+++ b/nxc/modules/ntds-dump-raw.py
@@ -11,7 +11,7 @@ import random
 import gzip
 from io import BytesIO
 from impacket.examples.secretsdump import LocalOperations, NTDSHashes, SAMHashes, LSASecrets
-from nxc.helpers.misc import validate_ntlm
+from nxc.helpers.misc import CATEGORY, validate_ntlm
 from nxc.helpers.powershell import get_ps_script
 import sys
 
@@ -20,6 +20,9 @@ class NXCModule:
     name = "ntds-dump-raw"
     description = "Extracting the ntds.dit, SAM, and SYSTEM files from DC by accessing the raw hard drive."
     supported_protocols = ["smb", "wmi", "winrm"]
+    category = CATEGORY.CREDENTIAL_DUMPING
+
+    # Module constants
     NTFS_LOCATION = 0
     MFT_LOCATION = 0
     context = None

--- a/nxc/modules/ntdsutil.py
+++ b/nxc/modules/ntdsutil.py
@@ -6,7 +6,7 @@ import time
 from impacket.examples.secretsdump import LocalOperations, NTDSHashes
 
 from nxc.helpers.logger import highlight
-from nxc.helpers.misc import validate_ntlm
+from nxc.helpers.misc import CATEGORY, validate_ntlm
 
 
 class NXCModule:
@@ -19,6 +19,7 @@ class NXCModule:
     name = "ntdsutil"
     description = "Dump NTDS with ntdsutil"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/ntlmv1.py
+++ b/nxc/modules/ntlmv1.py
@@ -2,6 +2,8 @@ from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 from impacket.dcerpc.v5.rrp import DCERPCSessionError
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -13,6 +15,7 @@ class NXCModule:
     name = "ntlmv1"
     description = "Detect if lmcompatibilitylevel on the target is set to lower than 3 (which means ntlmv1 is enabled)"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         self.output = "NTLMv1 allowed on: {} - LmCompatibilityLevel = {}"

--- a/nxc/modules/obsolete.py
+++ b/nxc/modules/obsolete.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from datetime import datetime, timedelta
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 import socket
 
@@ -13,6 +14,7 @@ class NXCModule:
     name = "obsolete"
     description = "Extract all obsolete operating systems from LDAP"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def ldap_time_to_datetime(self, ldap_time):
         """Convert an LDAP timestamp to a datetime object."""

--- a/nxc/modules/petitpotam.py
+++ b/nxc/modules/petitpotam.py
@@ -1,7 +1,11 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     name = "petitpotam"
     description = "[REMOVED] Module to check if the DC is vulnerable to PetitPotam, credit to @topotam"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/pi.py
+++ b/nxc/modules/pi.py
@@ -2,6 +2,7 @@ from base64 import b64decode
 from sys import exit
 from os.path import abspath, join, isfile
 from datetime import datetime
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import DATA_PATH, TMP_PATH
 
 
@@ -14,6 +15,7 @@ class NXCModule:
     name = "pi"
     description = "Run command as logged on users via Process Injection"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/powershell_history.py
+++ b/nxc/modules/powershell_history.py
@@ -1,5 +1,6 @@
 from os import makedirs
 from os.path import join, abspath
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 from io import BytesIO
 
@@ -11,6 +12,7 @@ class NXCModule:
     name = "powershell_history"
     description = "Extracts PowerShell history for all users and looks for sensitive commands."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
     false_positive = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
     sensitive_keywords = [
         "password", "passw", "secret", "credential", "key",

--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -4,6 +4,7 @@ from impacket.krb5.ccache import CCache
 from impacket.krb5.types import Principal
 from impacket.krb5 import constants
 
+from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 from nxc.paths import NXC_PATH
 
@@ -16,6 +17,7 @@ class NXCModule:
     name = "pre2k"
     description = "Identify pre-created computer accounts, save the results to a file, and obtain TGTs for each"
     supported_protocols = ["ldap"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         pass

--- a/nxc/modules/presence.py
+++ b/nxc/modules/presence.py
@@ -5,6 +5,8 @@ from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVE
 from contextlib import suppress
 import traceback
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -15,6 +17,7 @@ class NXCModule:
     name = "presence"
     description = "Traces Domain and Enterprise Admin presence in the target over SMB"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """There are no module options."""

--- a/nxc/modules/printerbug.py
+++ b/nxc/modules/printerbug.py
@@ -1,7 +1,11 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     name = "printerbug"
     description = "[REMOVED] Module to check if the Target is vulnerable to PrinterBug. Set LISTENER IP for coercion."
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/printnightmare.py
+++ b/nxc/modules/printnightmare.py
@@ -7,6 +7,8 @@ from impacket.dcerpc.v5.ndr import NDRCALL, NDRPOINTER, NDRSTRUCT, NDRUNION, NUL
 from impacket.dcerpc.v5.dtypes import DWORD, LPWSTR, ULONG, WSTR
 from impacket.dcerpc.v5.rprn import checkNullString, STRING_HANDLE, PBYTE_ARRAY
 
+from nxc.helpers.misc import CATEGORY
+
 KNOWN_PROTOCOLS = {
     135: {"bindstr": r"ncacn_ip_tcp:%s[135]"},
     445: {"bindstr": r"ncacn_np:%s[\pipe\epmapper]"},
@@ -22,6 +24,7 @@ class NXCModule:
     name = "printnightmare"
     description = "Check if host vulnerable to printnightmare"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/procdump.py
+++ b/nxc/modules/procdump.py
@@ -6,6 +6,7 @@ import base64
 import re
 import pypykatz
 from nxc.helpers.bloodhound import add_user_bh
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import TMP_PATH
 from os.path import abspath, join
 from datetime import datetime
@@ -15,6 +16,7 @@ class NXCModule:
     name = "procdump"
     description = "Get lsass dump using procdump64 and parse the result with pypykatz"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/pso.py
+++ b/nxc/modules/pso.py
@@ -1,3 +1,5 @@
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -8,6 +10,7 @@ class NXCModule:
     name = "pso"
     description = "Module to get the Fine Grained Password Policy/PSOs"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/putty.py
+++ b/nxc/modules/putty.py
@@ -7,6 +7,7 @@ from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 from os import makedirs
 from nxc.helpers.logger import highlight
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 import re
 
@@ -17,6 +18,7 @@ class NXCModule:
     name = "putty"
     description = "Query the registry for users who saved ssh private keys in PuTTY. Download the private keys if found."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/rdcman.py
+++ b/nxc/modules/rdcman.py
@@ -2,6 +2,7 @@ from dploot.triage.rdg import RDGTriage, RDGServerProfile
 from dploot.lib.target import Target
 
 from nxc.helpers.logger import highlight
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.dpapi import collect_masterkeys_from_target, get_domain_backup_key, upgrade_to_dploot_connection
 
 
@@ -9,6 +10,7 @@ class NXCModule:
     name = "rdcman"
     description = "Remotely dump Remote Desktop Connection Manager (sysinternals) credentials"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """ """

--- a/nxc/modules/rdp.py
+++ b/nxc/modules/rdp.py
@@ -1,6 +1,7 @@
 from sys import exit
 
 from nxc.connection import dcom_FirewallChecker
+from nxc.helpers.misc import CATEGORY
 
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
@@ -15,6 +16,7 @@ class NXCModule:
     name = "rdp"
     description = "Enables/Disables RDP"
     supported_protocols = ["smb", "wmi"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/recent_files.py
+++ b/nxc/modules/recent_files.py
@@ -1,5 +1,6 @@
 import pylnk3
 from io import BytesIO
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
@@ -9,10 +10,11 @@ class NXCModule:
     name = "recent_files"
     description = "Extracts recently modified files"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
     false_positive = [".", "..", "desktop.ini", "Public", "Default", "Default User", "All Users", ".NET v4.5", ".NET v4.5 Classic"]
 
     def options(self, context, module_options):
-        """No options"""
+        """No options available"""
 
     def on_admin_login(self, context, connection):
         lnks = []

--- a/nxc/modules/recyclebin.py
+++ b/nxc/modules/recyclebin.py
@@ -1,4 +1,5 @@
 from os import makedirs
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 from os.path import join, abspath
 from impacket.dcerpc.v5 import rrp
@@ -13,6 +14,7 @@ class NXCModule:
     name = "recyclebin"
     description = "Lists and exports users' recycle bins"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """No options available"""

--- a/nxc/modules/reg-query.py
+++ b/nxc/modules/reg-query.py
@@ -2,11 +2,14 @@ from impacket.dcerpc.v5.rpcrt import DCERPCException
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     name = "reg-query"
     description = "Performs a registry query on the machine"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/reg-winlogon.py
+++ b/nxc/modules/reg-winlogon.py
@@ -1,5 +1,6 @@
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
@@ -12,6 +13,7 @@ class NXCModule:
     name = "reg-winlogon"
     description = "Collect autologon credential stored in the registry"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/remote-uac.py
+++ b/nxc/modules/remote-uac.py
@@ -1,5 +1,6 @@
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
+from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
@@ -7,6 +8,7 @@ class NXCModule:
     name = "remote-uac"
     description = "Enable or disable remote UAC"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/remove-mic.py
+++ b/nxc/modules/remove-mic.py
@@ -20,11 +20,14 @@ from impacket import ntlm
 from impacket import nt_errors
 from impacket.smbconnection import SessionError
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     name = "remove-mic"
     description = "Check if host vulnerable to CVE-2019-1040"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/runasppl.py
+++ b/nxc/modules/runasppl.py
@@ -2,12 +2,15 @@ from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 from impacket.dcerpc.v5.rrp import DCERPCSessionError
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     # Reworked by @Defte_ 13/10/2024 to remove unecessary execute operation
     name = "runasppl"
     description = "Check if the registry value RunAsPPL is set or not"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/sccm.py
+++ b/nxc/modules/sccm.py
@@ -1,6 +1,7 @@
 from impacket.ldap import ldap, ldaptypes, ldapasn1 as ldapasn1_impacket
 from impacket.ldap.ldap import LDAPSearchError
 from ldap3.protocol.microsoft import security_descriptor_control
+from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
 SAM_USER_OBJECT = 0x30000000
@@ -22,6 +23,7 @@ class NXCModule:
     name = "sccm"
     description = "Find a SCCM infrastructure in the Active Directory"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self):
         self.sccm_site_servers = []     # List of dns host names of the SCCM site servers

--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -1,5 +1,6 @@
 import os
 from traceback import format_exc
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.atexec import TSCH_EXEC
 
 
@@ -10,6 +11,10 @@ class NXCModule:
     Modified by @Defte_ so that output on multiples lines are printed correctly (28/04/2025)
     Modified by @Defte_ so that we can upload a custom binary to execute using the BINARY option (28/04/2025)
     """
+    name = "schtask_as"
+    description = "Remotely execute a scheduled task as a logged on user"
+    supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         r"""
@@ -48,10 +53,6 @@ class NXCModule:
         if "LOCATION" in module_options:
             # Ensure trailing backslashes
             self.output_file_location = module_options["LOCATION"].rstrip("\\") + "\\"
-
-    name = "schtask_as"
-    description = "Remotely execute a scheduled task as a logged on user"
-    supported_protocols = ["smb"]
 
     def on_admin_login(self, context, connection):
         self.logger = context.log

--- a/nxc/modules/scuffy.py
+++ b/nxc/modules/scuffy.py
@@ -1,5 +1,6 @@
 import ntpath
 from sys import exit
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import TMP_PATH
 
 
@@ -13,6 +14,7 @@ class NXCModule:
     name = "scuffy"
     description = "Creates and dumps an arbitrary .scf file with the icon property containing a UNC path to the declared SMB server against all writeable shares"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/security-questions.py
+++ b/nxc/modules/security-questions.py
@@ -4,6 +4,8 @@ from impacket.dcerpc.v5.rpcrt import DCERPCException
 from json import loads
 from traceback import format_exc as traceback_format_exc
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -17,6 +19,7 @@ class NXCModule:
     name = "security-questions"
     description = "Gets security questions and answers for users on computer"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module):
         pass

--- a/nxc/modules/shadowcoerce.py
+++ b/nxc/modules/shadowcoerce.py
@@ -1,7 +1,11 @@
+from nxc.helpers.misc import CATEGORY
+
+
 class NXCModule:
     name = "shadowcoerce"
     description = "[REMOVED] Module to check if the target is vulnerable to ShadowCoerce, credit to @Shutdown and @topotam"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/shadowrdp.py
+++ b/nxc/modules/shadowrdp.py
@@ -1,6 +1,8 @@
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 
+from nxc.helpers.misc import CATEGORY
+
 
 # Module by @Defte_
 # Enables or disables shadow RDP
@@ -8,6 +10,7 @@ class NXCModule:
     name = "shadowrdp"
     description = "Enables or disables shadow RDP"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/slinky.py
+++ b/nxc/modules/slinky.py
@@ -1,6 +1,7 @@
 import pylnk3
 import ntpath
 from sys import exit
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import TMP_PATH
 
 
@@ -14,6 +15,7 @@ class NXCModule:
     name = "slinky"
     description = "Creates windows shortcuts with the icon attribute containing a URI to the specified  server (default SMB) in all shares with write permissions"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self):
         self.server = None

--- a/nxc/modules/smbghost.py
+++ b/nxc/modules/smbghost.py
@@ -4,6 +4,8 @@
 import socket
 import struct
 
+from nxc.helpers.misc import CATEGORY
+
 # Constants
 MAX_ATTEMPTS = 2000  # False negative chance: 0.04%
 
@@ -15,6 +17,7 @@ class NXCModule:
     name = "smbghost"
     description = "Module to check for the SMB dialect 3.1.1 and compression capability of the host, which is an indicator for the SMBGhost vulnerability (CVE-2020-0796)."
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/snipped.py
+++ b/nxc/modules/snipped.py
@@ -1,6 +1,7 @@
 import ntpath
 import os
 from os.path import join, getsize, exists
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 
 
@@ -9,6 +10,7 @@ class NXCModule:
     name = "snipped"
     description = "Downloads screenshots taken by the (new) Snipping Tool."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/spider_plus.py
+++ b/nxc/modules/spider_plus.py
@@ -3,6 +3,7 @@ import errno
 from os.path import abspath, join, split, exists, splitext, getsize, sep
 from os import makedirs, remove, stat
 import time
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 from nxc.protocols.smb.remotefile import RemoteFile
 from impacket.smb3structs import FILE_READ_DATA
@@ -472,6 +473,7 @@ class NXCModule:
     name = "spider_plus"
     description = "List files recursively and save a JSON share-file metadata to the 'OUTPUT_FOLDER'. See module options for finer configuration."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/spooler.py
+++ b/nxc/modules/spooler.py
@@ -9,6 +9,8 @@ from impacket.dcerpc.v5.rpch import (
 )
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 
+from nxc.helpers.misc import CATEGORY
+
 KNOWN_PROTOCOLS = {
     135: {"bindstr": r"ncacn_ip_tcp:%s[135]"},
     445: {"bindstr": r"ncacn_np:%s[\pipe\epmapper]"},
@@ -24,6 +26,7 @@ class NXCModule:
     name = "spooler"
     description = "Detect if print spooler is enabled or not"
     supported_protocols = ["smb", "wmi"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/subnets.py
+++ b/nxc/modules/subnets.py
@@ -2,6 +2,8 @@ from impacket.ldap import ldapasn1 as ldapasn1_impacket
 from impacket.ldap.ldap import LDAPSearchError
 import sys
 
+from nxc.helpers.misc import CATEGORY
+
 
 def search_res_entry_to_dict(results):
     data = {}
@@ -19,6 +21,10 @@ class NXCModule:
     Authors:
       Podalirius: @podalirius_
     """
+    name = "subnets"
+    description = "Retrieves the different Sites and Subnets of an Active Directory"
+    supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """SHOWSERVERS    Toggle printing of servers (default: true)"""
@@ -32,10 +38,6 @@ class NXCModule:
             else:
                 context.log.fail("Could not parse showservers option for 'SHOWSERVERS'. Please use 'true' or 'false'.")
                 exit(1)
-
-    name = "subnets"
-    description = "Retrieves the different Sites and Subnets of an Active Directory"
-    supported_protocols = ["ldap"]
 
     def on_login(self, context, connection):
         dn = connection.args.base_dn if connection.args.base_dn else connection.ldap_connection._baseDN

--- a/nxc/modules/teams_localdb.py
+++ b/nxc/modules/teams_localdb.py
@@ -1,4 +1,5 @@
 import sqlite3
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import TMP_PATH
 from os.path import abspath, join
 
@@ -7,9 +8,10 @@ class NXCModule:
     name = "teams_localdb"
     description = "Retrieves the cleartext ssoauthcookie from the local Microsoft Teams database, if teams is open we kill all Teams process"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
-        """ """
+        """No options available"""
 
     def on_admin_login(self, context, connection):
         context.log.display("Killing all Teams process to open the cookie file")

--- a/nxc/modules/test_connection.py
+++ b/nxc/modules/test_connection.py
@@ -1,5 +1,7 @@
 from sys import exit
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -10,6 +12,7 @@ class NXCModule:
     name = "test_connection"
     description = "Pings a host"
     supported_protocols = ["smb", "mssql"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """HOST      Host to ping"""

--- a/nxc/modules/timeroast.py
+++ b/nxc/modules/timeroast.py
@@ -4,6 +4,8 @@ from time import time
 from socket import socket, AF_INET, SOCK_DGRAM
 from struct import pack, unpack
 
+from nxc.helpers.misc import CATEGORY
+
 
 def hashcat_format(rid, hashval, salt):
     """Encodes hash in Hashcat-compatible format (with username prefix)."""
@@ -23,6 +25,7 @@ class NXCModule:
     name = "timeroast"
     description = "Timeroasting exploits Windows NTP authentication to request password hashes of any computer or trust account"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/uac.py
+++ b/nxc/modules/uac.py
@@ -2,11 +2,14 @@
 from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     name = "uac"
     description = "Checks UAC status"
     supported_protocols = ["smb"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/user-desc.py
+++ b/nxc/modules/user-desc.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from impacket.ldap import ldap, ldapasn1
 from impacket.ldap.ldap import LDAPSearchError
 
+from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 
 
@@ -16,6 +17,7 @@ class NXCModule:
     name = "user-desc"
     description = "Get user descriptions stored in Active Directory"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, multiple_options=None):
         self.keywords = None

--- a/nxc/modules/veeam.py
+++ b/nxc/modules/veeam.py
@@ -6,6 +6,7 @@ from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 import traceback
 from base64 import b64encode
+from nxc.helpers.misc import CATEGORY
 from nxc.helpers.powershell import get_ps_script
 
 
@@ -15,6 +16,7 @@ class NXCModule:
     name = "veeam"
     description = "Extracts credentials from local Veeam SQL Database"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self):
         with open(get_ps_script("veeam_dump_module/veeam_dump_mssql.ps1")) as psFile:

--- a/nxc/modules/vnc.py
+++ b/nxc/modules/vnc.py
@@ -12,6 +12,7 @@ from binascii import unhexlify
 import codecs
 import re
 
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.dpapi import upgrade_to_dploot_connection
 
 
@@ -24,6 +25,7 @@ class NXCModule:
     name = "vnc"
     description = "Loot Passwords from VNC server and client configurations"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/modules/wam.py
+++ b/nxc/modules/wam.py
@@ -4,6 +4,7 @@ from dploot.triage.wam import WamTriage
 from dploot.lib.target import Target
 
 from nxc.helpers.logger import highlight
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.dpapi import collect_masterkeys_from_target, get_domain_backup_key, upgrade_to_dploot_connection
 
 
@@ -11,9 +12,10 @@ class NXCModule:
     name = "wam"
     description = "Dump access token from Token Broker Cache. More info here https://blog.xpnsec.com/wam-bam/. Module by zblurx"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
-        """ """
+        """No options available"""
 
     def on_admin_login(self, context, connection):
         username = connection.username

--- a/nxc/modules/wcc.py
+++ b/nxc/modules/wcc.py
@@ -6,6 +6,7 @@ import time
 from impacket.system_errors import ERROR_NO_MORE_ITEMS, ERROR_FILE_NOT_FOUND, ERROR_OBJECT_NOT_FOUND
 from termcolor import colored
 
+from nxc.helpers.misc import CATEGORY
 from nxc.logger import nxc_logger
 from impacket.dcerpc.v5 import rrp, samr, scmr
 from impacket.dcerpc.v5.rrp import DCERPCSessionError
@@ -87,6 +88,7 @@ class NXCModule:
     name = "wcc"
     description = "Check various security configuration items on Windows machines"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def __init__(self):
         self.context = None

--- a/nxc/modules/wdigest.py
+++ b/nxc/modules/wdigest.py
@@ -4,11 +4,14 @@ from impacket.examples.secretsdump import RemoteOperations
 from sys import exit
 import contextlib
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     name = "wdigest"
     description = "Creates/Deletes the 'UseLogonCredential' registry key enabling WDigest cred dumping on Windows >= 8.1"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         """ACTION  Create/Delete the registry key (choices: enable, disable, check)"""

--- a/nxc/modules/web_delivery.py
+++ b/nxc/modules/web_delivery.py
@@ -1,5 +1,7 @@
 from sys import exit
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """
@@ -12,6 +14,7 @@ class NXCModule:
     name = "web_delivery"
     description = "Kicks off a Metasploit Payload using the exploit/multi/script/web_delivery module"
     supported_protocols = ["smb", "mssql"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """

--- a/nxc/modules/webdav.py
+++ b/nxc/modules/webdav.py
@@ -1,3 +1,4 @@
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.remotefile import RemoteFile
 from impacket import nt_errors
 from impacket.smb3structs import FILE_READ_DATA
@@ -15,6 +16,7 @@ class NXCModule:
     name = "webdav"
     description = "Checks whether the WebClient service is running on the target"
     supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """MSG     Info message when the WebClient service is running. '{}' is replaced by the target."""

--- a/nxc/modules/whoami.py
+++ b/nxc/modules/whoami.py
@@ -1,4 +1,5 @@
 import datetime
+from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
 
@@ -11,6 +12,7 @@ class NXCModule:
     name = "whoami"
     description = "Get details of provided user"
     supported_protocols = ["ldap"]
+    category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
         """USER  Enumerate information about a different SamAccountName"""

--- a/nxc/modules/wifi.py
+++ b/nxc/modules/wifi.py
@@ -2,6 +2,7 @@ from dploot.lib.target import Target
 from dploot.triage.wifi import WifiTriage
 
 from nxc.helpers.logger import highlight
+from nxc.helpers.misc import CATEGORY
 from nxc.protocols.smb.dpapi import collect_masterkeys_from_target, upgrade_to_dploot_connection
 
 
@@ -9,9 +10,10 @@ class NXCModule:
     name = "wifi"
     description = "Get key of all wireless interfaces"
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
-        """ """
+        """No options available"""
 
     def on_admin_login(self, context, connection):
         username = connection.username

--- a/nxc/modules/winscp.py
+++ b/nxc/modules/winscp.py
@@ -14,6 +14,8 @@ from io import BytesIO
 import re
 import configparser
 
+from nxc.helpers.misc import CATEGORY
+
 
 class NXCModule:
     """Module by @NeffIsBack"""
@@ -21,6 +23,7 @@ class NXCModule:
     name = "winscp"
     description = "Looks for WinSCP.ini files in the registry and default locations and tries to extract credentials."
     supported_protocols = ["smb"]
+    category = CATEGORY.CREDENTIAL_DUMPING
 
     def options(self, context, module_options):
         r"""

--- a/nxc/modules/zerologon.py
+++ b/nxc/modules/zerologon.py
@@ -4,6 +4,7 @@
 from impacket.dcerpc.v5 import nrpc, epm, transport
 from impacket.dcerpc.v5.rpcrt import DCERPCException
 import sys
+from nxc.helpers.misc import CATEGORY
 from nxc.logger import nxc_logger
 
 # Give up brute-forcing after this many attempts. If vulnerable, 256 attempts are expected to be necessary on average.
@@ -14,6 +15,7 @@ class NXCModule:
     name = "zerologon"
     description = "Module to check if the DC is vulnerable to Zerologon aka CVE-2020-1472"
     supported_protocols = ["smb", "wmi"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -159,17 +159,20 @@ def main():
     # with the new nxc/config.py this can be eventually removed, as it can be imported anywhere
     protocol_object.config = nxc_config
 
-    if args.module or args.list_modules:
+    if args.module or args.list_modules is not None:
         loader = ModuleLoader(args, db, nxc_logger)
         modules = loader.list_modules()
 
-    if args.list_modules:
+    if args.list_modules is not None:
         low_privilege_modules = {m: props for m, props in modules.items() if args.protocol in props["supported_protocols"] and not props["requires_admin"]}
         high_privilege_modules = {m: props for m, props in modules.items() if args.protocol in props["supported_protocols"] and props["requires_admin"]}
 
         # List low privilege modules
         nxc_logger.highlight("LOW PRIVILEGE MODULES")
         for category, color in {CATEGORY.ENUMERATION: "green", CATEGORY.CREDENTIAL_DUMPING: "cyan", CATEGORY.PRIVILEGE_ESCALATION: "magenta"}.items():
+            # Add category filter for module listing
+            if args.list_modules and args.list_modules.lower() != category.name.lower():
+                continue
             if len([module for module in low_privilege_modules.values() if module["category"] == category]) > 0:
                 nxc_logger.highlight(colored(f"{category.name}", color, attrs=["bold"]))
             for name, props in sorted(low_privilege_modules.items()):
@@ -179,6 +182,9 @@ def main():
         # List high privilege modules
         nxc_logger.highlight("\nHIGH PRIVILEGE MODULES (requires admin privs)")
         for category, color in {CATEGORY.ENUMERATION: "green", CATEGORY.CREDENTIAL_DUMPING: "cyan", CATEGORY.PRIVILEGE_ESCALATION: "magenta"}.items():
+            # Add category filter for module listing
+            if args.list_modules and args.list_modules.lower() != category.name.lower():
+                continue
             if len([module for module in high_privilege_modules.values() if module["category"] == category]) > 0:
                 nxc_logger.highlight(colored(f"{category.name}", color, attrs=["bold"]))
             for name, props in sorted(high_privilege_modules.items()):

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -1,7 +1,9 @@
 # PYTHON_ARGCOMPLETE_OK
 import sys
+
+from termcolor import colored
 from nxc.helpers.logger import highlight
-from nxc.helpers.misc import identify_target_file
+from nxc.helpers.misc import identify_target_file, CATEGORY
 from nxc.parsers.ip import parse_targets
 from nxc.parsers.nmap import parse_nmap_xml
 from nxc.parsers.nessus import parse_nessus_file
@@ -162,14 +164,26 @@ def main():
         modules = loader.list_modules()
 
     if args.list_modules:
+        low_privilege_modules = {m: props for m, props in modules.items() if args.protocol in props["supported_protocols"] and not props["requires_admin"]}
+        high_privilege_modules = {m: props for m, props in modules.items() if args.protocol in props["supported_protocols"] and props["requires_admin"]}
+
+        # List low privilege modules
         nxc_logger.highlight("LOW PRIVILEGE MODULES")
-        for name, props in sorted(modules.items()):
-            if args.protocol in props["supported_protocols"] and not props["requires_admin"]:
-                nxc_logger.display(f"{name:<25} {props['description']}")
+        for category, color in {CATEGORY.ENUMERATION: "green", CATEGORY.CREDENTIAL_DUMPING: "cyan", CATEGORY.PRIVILEGE_ESCALATION: "magenta"}.items():
+            if len([module for module in low_privilege_modules.values() if module["category"] == category]) > 0:
+                nxc_logger.highlight(colored(f"{category.name}", color, attrs=["bold"]))
+            for name, props in sorted(low_privilege_modules.items()):
+                if props["category"] == category:
+                    nxc_logger.display(f"{name:<25} {props['description']}")
+
+        # List high privilege modules
         nxc_logger.highlight("\nHIGH PRIVILEGE MODULES (requires admin privs)")
-        for name, props in sorted(modules.items()):
-            if args.protocol in props["supported_protocols"] and props["requires_admin"]:
-                nxc_logger.display(f"{name:<25} {props['description']}")
+        for category, color in {CATEGORY.ENUMERATION: "green", CATEGORY.CREDENTIAL_DUMPING: "cyan", CATEGORY.PRIVILEGE_ESCALATION: "magenta"}.items():
+            if len([module for module in high_privilege_modules.values() if module["category"] == category]) > 0:
+                nxc_logger.highlight(colored(f"{category.name}", color, attrs=["bold"]))
+            for name, props in sorted(high_privilege_modules.items()):
+                if props["category"] == category:
+                    nxc_logger.display(f"{name:<25} {props['description']}")
         exit(0)
     elif args.module and args.show_module_options:
         for module in args.module:


### PR DESCRIPTION
## Description

As discuessed in https://github.com/Pennyw0rth/NetExec/discussions/692 we do have many many modules by now, especially for the SMB proto. This PR solves this for the intermediate future, by introducing categories. 

For now i have added `ENUMERATION`, `CREDENTIAL DUMPING` and `PRIVILEGE ESCALATION`. This does not aim at being perfect, but more a "best fit" approach for modules. Some modules might not seem fitting perfectly, but i think having a bit of a structure is better than nothing. 

If someone has feedback on something please let me know. I will also post screenshots below so everyone can check if the modules to fit its category i have chosen for now.

You can also filter for only one category by specifying the category after `-L`:
<img width="1459" height="462" alt="image" src="https://github.com/user-attachments/assets/538bc4d4-03f0-445a-8c99-8d29e16b44fa" />


## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
List the modules for each proto

## Screenshots (if appropriate):
SMB:
<img width="1570" height="1176" alt="image" src="https://github.com/user-attachments/assets/2527539a-2652-40aa-927d-69c79c02a765" />
<img width="1582" height="389" alt="image" src="https://github.com/user-attachments/assets/f299b404-8263-4f7d-80f9-c965bd8466d8" />

Rest:
<img width="1580" height="1181" alt="image" src="https://github.com/user-attachments/assets/594288e6-ba18-4f68-b20d-2e2b91d044e3" />
<img width="1562" height="721" alt="image" src="https://github.com/user-attachments/assets/a99d1ebd-300d-4a09-94a1-1b197d1c4cec" />
