### PR TITLE
Show success messages when krb conf is saved.

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -333,6 +333,8 @@ class smb(connection):
 """
                     host_file.write(data)
                     self.logger.debug(data)
+                    self.logger.success(f"krb5 conf saved to: {self.args.generate_krb5_file}")
+                    self.logger.success(f"Run the following command to use the conf file: export KRB5_CONFIG={self.args.generate_krb5_file}")
 
         return self.host, self.hostname, self.targetDomain
 


### PR DESCRIPTION

## Description

This pull request introduces a minor improvement to the SMB protocol logging in `nxc/protocols/smb.py`. It adds user-friendly success messages to inform the user when a `krb5` configuration file has been saved and provides guidance on how to use it.

* Logging improvements:
  * Added success messages to notify the user when the `krb5` configuration file is saved and included instructions for setting the `KRB5_CONFIG` environment variable.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
N/A

## Screenshots (if appropriate):

Displays a message similar to one shown with `--generate-tgt`.

<img width="1645" height="144" alt="image" src="https://github.com/user-attachments/assets/f880f388-21af-44e5-8d9f-06fc92855d0d" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
