### PR TITLE
Update gpp_password.py

### DIFF
--- a/nxc/modules/gpp_password.py
+++ b/nxc/modules/gpp_password.py
@@ -21,12 +21,13 @@ class NXCModule:
     def on_login(self, context, connection):
         shares = connection.shares()
         for share in shares:
-            if share["name"] == "SYSVOL" and "READ" in share["access"]:
+            if share["name"].lower() == "sysvol" and "READ" in share["access"]:
+                sysvol = share["name"]
                 context.log.success("Found SYSVOL share")
                 context.log.display("Searching for potential XML files containing passwords")
 
                 paths = connection.spider(
-                    "SYSVOL",
+                    sysvol,
                     pattern=[
                         "Groups.xml",
                         "Services.xml",
@@ -41,7 +42,7 @@ class NXCModule:
                     context.log.display(f"Found {path}")
 
                     buf = BytesIO()
-                    connection.conn.getFile("SYSVOL", path, buf.write)
+                    connection.conn.getFile(sysvol, path, buf.write)
                     xml = ET.fromstring(buf.getvalue())
                     sections = []
 


### PR DESCRIPTION
## Description

The gpp_password accepts only share's name "SYSVOL". When openldap is used, the original SYSVOL share can named in lowercase manner - for example "sysvol".

The fix introduces treating "SYSVOL" share name as case-insensitive.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Please provide guidance on what setup is needed to test the introduced changes, such as your locally running machine Python version & OS, as well as the target(s) you tested against, including software versions.
In particular:
- Bug Fix: Please provide a short description on how to trigger the bug, to make the bug reproducable for the reviewer.
- Added Feature/Enhancement: Please specify what setup is needed in order to test the changes. E.g. is additional software needed? GPO changes required? Specific registry settings that need to be changed?

## Screenshots (if appropriate):
Screenshots are always nice to have and can give a visual representation of the change.
If appropriate include before and after screenshot(s) to show which results are to be expected.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
