### PR TITLE
fix(dc_list): disable automatic configuration of DNS so we can point it to the target

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -819,18 +819,23 @@ class ldap(connection):
                 self.logger.highlight(item["name"] + "$")
 
     def dc_list(self):
-        # Building the search filter
-        resolv = resolver.Resolver()
+        # bypass host resolver configuration via configure=False (default pulls from /etc/resolv.conf or registry on Windows)
         if self.args.dns_server:
+            resolv = resolver.Resolver(configure=False)
+            self.logger.debug(f"DNS Server option set, using DNS server: {self.args.dns_server}")
             resolv.nameservers = [self.args.dns_server]
         else:
+            resolv = resolver.Resolver(configure=False)
+            self.logger.debug(f"No DNS Server option set, using host: {self.host}")
             resolv.nameservers = [self.host]
+
         resolv.timeout = self.args.dns_timeout
 
-        # Function to resolve and display hostnames
         def resolve_and_display_hostname(name, domain_name=None):
             prefix = f"[{domain_name}] " if domain_name else ""
             try:
+                self.logger.debug(f"DNS server set to: {resolv.nameservers}")
+
                 # Resolve using DNS server for A, AAAA, CNAME, PTR, and NS records
                 for record_type in ["A", "AAAA", "CNAME", "PTR", "NS"]:
                     try:

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -828,8 +828,6 @@ class ldap(connection):
         def resolve_and_display_hostname(name, domain_name=None):
             prefix = f"[{domain_name}] " if domain_name else ""
             try:
-                self.logger.debug(f"DNS server set to: {resolv.nameservers}")
-
                 # Resolve using DNS server for A, AAAA, CNAME, PTR, and NS records
                 for record_type in ["A", "AAAA", "CNAME", "PTR", "NS"]:
                     try:

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -820,15 +820,9 @@ class ldap(connection):
 
     def dc_list(self):
         # bypass host resolver configuration via configure=False (default pulls from /etc/resolv.conf or registry on Windows)
-        if self.args.dns_server:
-            resolv = resolver.Resolver(configure=False)
-            self.logger.debug(f"DNS Server option set, using DNS server: {self.args.dns_server}")
-            resolv.nameservers = [self.args.dns_server]
-        else:
-            resolv = resolver.Resolver(configure=False)
-            self.logger.debug(f"No DNS Server option set, using host: {self.host}")
-            resolv.nameservers = [self.host]
-
+        resolv = resolver.Resolver(configure=False)
+        resolv.nameservers = [self.args.dns_server] if self.args.dns_server else [self.host]
+        self.logger.debug(f"DNS Server option: {self.args.dns_server}, using DNS server: {resolv.nameservers}")
         resolv.timeout = self.args.dns_timeout
 
         def resolve_and_display_hostname(name, domain_name=None):


### PR DESCRIPTION
## Description

Removes the auto configuration of the Resolver via configure=False so we can properly set either the target DNS via `--dns-server` or point directly to the host by default.
By not using the auto configuration setting, we no longer check the host's system DNS settings (/etc/resolv.conf or windows registry) and fall back to the target host, which was the original code intended to do.

Resolves #873

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Deprecation of feature or functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
None needed, but tested with GOAD

## Screenshots (if appropriate):
N/A

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
