### PR TITLE
fix(printnightmare): do not exit thread on failure to bind so other modules can run

### DIFF
--- a/nxc/modules/printnightmare.py
+++ b/nxc/modules/printnightmare.py
@@ -1,4 +1,3 @@
-import sys
 from impacket import system_errors
 from impacket.dcerpc.v5.rpcrt import DCERPCException, RPC_C_AUTHN_GSS_NEGOTIATE, rpc_status_codes
 from impacket.structure import Structure
@@ -67,7 +66,7 @@ class NXCModule:
             dce.bind(rprn.MSRPC_UUID_RPRN)
         except Exception as e:
             context.log.fail(f"Failed to bind: {e}")
-            sys.exit(1)
+            return False
 
         flags = APD_COPY_ALL_FILES | APD_COPY_FROM_DIRECTORY | APD_INSTALL_WARNED_DRIVER
 


### PR DESCRIPTION
## Description

On a failure to bind we run `sys.exit(1)` instead of returning false, which kills the thread, not allowing any future modules to run. Resolves #882 

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
N/A

## Screenshots (if appropriate):
Before:
<img width="1678" height="122" alt="image" src="https://github.com/user-attachments/assets/a5a5588a-666f-4d9f-852a-12cbde83d701" />

After:
<img width="1670" height="189" alt="image" src="https://github.com/user-attachments/assets/5819446e-256e-4e80-99d2-63971ccfc2c2" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
