### PR TITLE
display group description for --groups

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -790,7 +790,7 @@ class ldap(connection):
             attributes = ["member"]
         else:
             search_filter = "(objectCategory=group)"
-            attributes = ["cn", "member"]
+            attributes = ["cn", "member", "description"]
         resp = self.search(search_filter, attributes, 0)
         resp_parsed = parse_result_attributes(resp)
         self.logger.debug(f"Total of records returned {len(resp_parsed)}")
@@ -807,12 +807,13 @@ class ldap(connection):
                 for user in resp_parsed[0]["member"]:
                     self.logger.highlight(user.split(",")[0].split("=")[1])
         else:
+            self.logger.highlight(f"{'-Group-':<40} {'-Members-':<9} {'-Description-':<60}")
             for item in resp_parsed:
                 try:
                     # Fix if group has only one member
                     if not isinstance(item.get("member", []), list):
                         item["member"] = [item["member"]]
-                    self.logger.highlight(f"{item['cn']:<40} membercount: {len(item.get('member', []))}")
+                    self.logger.highlight(f"{item['cn']:<40} {len(item.get('member', [])):<9} {item.get('description', '')}")
                 except Exception as e:
                     self.logger.debug("Exception:", exc_info=True)
                     self.logger.debug(f"Skipping item, cannot process due to error {e}")


### PR DESCRIPTION
## Description

As pointed out in #883, only groups and membership # is output, but for users we display their description. This PR adds that functionality to groups as well and resolves #883.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
N/A

## Screenshots (if appropriate):
Before:
<img width="1166" height="206" alt="image" src="https://github.com/user-attachments/assets/844cf2b0-6557-4a99-a4b6-a72bb286e880" />

After:
<img width="1167" height="220" alt="image" src="https://github.com/user-attachments/assets/126da7b4-e4f7-44f6-b638-bfb581964a1f" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
