### PR TITLE
Fix stacktrace with anon auth and using gmsa

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1278,15 +1278,13 @@ class ldap(connection):
     def gmsa(self):
         self.logger.display("Getting GMSA Passwords")
         search_filter = "(objectClass=msDS-GroupManagedServiceAccount)"
-        gmsa_accounts = self.ldap_connection.search(
-            searchBase=self.baseDN,
+        gmsa_accounts = self.search(
             searchFilter=search_filter,
             attributes=[
                 "sAMAccountName",
                 "msDS-ManagedPassword",
                 "msDS-GroupMSAMembership",
             ],
-            sizeLimit=0,
         )
         gmsa_accounts_parsed = parse_result_attributes(gmsa_accounts)
         if gmsa_accounts_parsed:


### PR DESCRIPTION
## Description

Switching to internal search function as this already handles all errors which might occur such as LDAPSearchErrors. Fixes #890 which threw stack traces when using anon auth and then running the gmsa queries.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
`nxc ldap <ip> -u '' -p '' --gmsa`

## Screenshots (if appropriate):
Before:
<img width="1581" height="1114" alt="image" src="https://github.com/user-attachments/assets/6be082b0-faf0-4035-811f-84c70cc0becf" />
After:
<img width="1582" height="167" alt="image" src="https://github.com/user-attachments/assets/d3fce288-6482-4774-91a3-b6bc8a1ca6ab" />
