### PR TITLE
Refactor to use internal ldap search function to prevent stack traces

### DIFF
--- a/nxc/modules/badsuccessor.py
+++ b/nxc/modules/badsuccessor.py
@@ -92,10 +92,9 @@ class NXCModule:
             return True
         return any(sid.startswith(domain_sid) and sid.endswith(suffix) for suffix in EXCLUDED_SIDS_SUFFIXES)
 
-    def get_domain_sid(self, ldap_session, base_dn):
+    def get_domain_sid(self):
         """Retrieve the domain SID from the domain object in LDAP"""
-        r = ldap_session.search(
-            searchBase=base_dn,
+        r = self.connection.search(
             searchFilter="(objectClass=domain)",
             attributes=["objectSid"]
         )
@@ -103,8 +102,8 @@ class NXCModule:
         if parsed and "objectSid" in parsed[0]:
             return parsed[0]["objectSid"]
 
-    def find_bad_successor_ous(self, ldap_session, entries, base_dn):
-        domain_sid = self.get_domain_sid(ldap_session, base_dn)
+    def find_bad_successor_ous(self, entries):
+        domain_sid = self.get_domain_sid()
         results = {}
         parsed = parse_result_attributes(entries)
         for entry in parsed:
@@ -144,15 +143,13 @@ class NXCModule:
                     results.setdefault(owner_sid, []).append(dn)
         return results
 
-    def resolve_sid_to_name(self, ldap_session, sid, base_dn):
+    def resolve_sid_to_name(self, sid):
         """
         Resolves a SID to a samAccountName using LDAP
 
         Args:
         ----
-            ldap_session: The LDAP connection
             sid: The SID to resolve
-            base_dn: The base DN for the LDAP search
 
         Returns:
         -------
@@ -160,8 +157,7 @@ class NXCModule:
         """
         try:
             search_filter = f"(objectSid={sid})"
-            response = ldap_session.search(
-                searchBase=base_dn,
+            response = self.connection.search(
                 searchFilter=search_filter,
                 attributes=["sAMAccountName"]
             )
@@ -174,9 +170,10 @@ class NXCModule:
             return sid
 
     def on_login(self, context, connection):
+        self.connection = connection
+
         # Check for a domain controller with Windows Server 2025
-        resp = connection.ldap_connection.search(
-            searchBase=connection.ldap_connection._baseDN,
+        resp = self.connection.search(
             searchFilter="(&(objectCategory=computer)(primaryGroupId=516))",
             attributes=["operatingSystem", "dNSHostName"]
         )
@@ -192,15 +189,15 @@ class NXCModule:
 
         # Enumerate dMSA objects
         controls = security_descriptor_control(sdflags=0x07)  # OWNER_SECURITY_INFORMATION
-        resp = connection.ldap_connection.search(
-            searchBase=connection.ldap_connection._baseDN,
+        resp = self.connection.search(
             searchFilter="(objectClass=organizationalUnit)",
             attributes=["distinguishedName", "nTSecurityDescriptor"],
-            searchControls=controls)  # Fixed parameter name
+            searchControls=controls
+        )
 
         context.log.debug(f"Found {len(resp)} entries")
 
-        results = self.find_bad_successor_ous(connection.ldap_connection, resp, connection.ldap_connection._baseDN)
+        results = self.find_bad_successor_ous(resp)
 
         if results:
             context.log.success(f"Found {len(results)} results")
@@ -208,11 +205,7 @@ class NXCModule:
             context.log.highlight("No account found")
 
         for sid, ous in results.items():
-            samaccountname = self.resolve_sid_to_name(
-                connection.ldap_connection,
-                sid,
-                connection.ldap_connection._baseDN
-            )
+            samaccountname = self.resolve_sid_to_name(sid)
 
             for ou in ous:
                 if sid == samaccountname:


### PR DESCRIPTION
## Description

When using anon auth nxc will print stack traces because of unhandled LDAPSearchErrors as reported in #891. This PR changes the native impacket search requests to the search request of the nxc ldap object as this handles search errors properly, not displaying stack traces.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
`nxc smb <ip> -u '' -p '' -M badsuccessor` against a host that doesn't allow anonymous ldap queries

## Screenshots (if appropriate):
Before:
<img width="1573" height="1079" alt="image" src="https://github.com/user-attachments/assets/b2e94b0b-8fd6-42cb-94a6-9732f5cb9fbc" />
After:
<img width="1981" height="157" alt="image" src="https://github.com/user-attachments/assets/884ef8e1-109e-454f-8315-9afe28fdcfed" />
