### PR TITLE
Fix 879

### DIFF
--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -22,8 +22,6 @@ class NXCModule:
 
     def on_login(self, context, connection):
         try:
-            ldap_connection = connection.ldap_connection
-
             # Define the search filter for pre-created computer accounts
             search_filter = "(&(objectClass=computer)(userAccountControl=4128))"
             attributes = ["sAMAccountName", "userAccountControl", "dNSHostName"]
@@ -82,8 +80,6 @@ class NXCModule:
 
             except Exception as e:
                 context.log.fail(f"Error occurred during search: {e}")
-
-            ldap_connection.close()
             return True
 
         except Exception as e:

--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -21,70 +21,63 @@ class NXCModule:
         """No options available"""
 
     def on_login(self, context, connection):
+        # Define the search filter for pre-created computer accounts
+        search_filter = "(&(objectClass=computer)(userAccountControl=4128))"
+        attributes = ["sAMAccountName", "userAccountControl", "dNSHostName"]
+
+        context.log.info(f"Using search filter: {search_filter}")
+        context.log.info(f"Attributes to retrieve: {attributes}")
+
+        computers = []
+
         try:
-            # Define the search filter for pre-created computer accounts
-            search_filter = "(&(objectClass=computer)(userAccountControl=4128))"
-            attributes = ["sAMAccountName", "userAccountControl", "dNSHostName"]
+            # Use paged search to retrieve all computer accounts with specific flags
+            search_results = connection.search(search_filter, attributes)
+            results = parse_result_attributes(search_results)
+            context.log.debug(f"Search results: {results}")
 
-            context.log.info(f"Using search filter: {search_filter}")
-            context.log.info(f"Attributes to retrieve: {attributes}")
+            for computer in results:
+                context.log.debug(f"Processing computer: {computer['sAMAccountName']}, UAC: {computer['userAccountControl']}")
+                # Check if the account is a pre-created computer account
+                if int(computer["userAccountControl"]) == 4128:  # 4096 | 32
+                    computers.append(computer["sAMAccountName"])
+                    context.log.debug(f"Added computer: {computer['sAMAccountName']}")
 
-            computers = []
+            # Save computers to file
+            domain_dir = os.path.join(f"{NXC_PATH}/modules/pre2k", connection.domain)
+            output_file = os.path.join(domain_dir, "precreated_computers.txt")
 
-            try:
-                # Use paged search to retrieve all computer accounts with specific flags
-                search_results = connection.search(search_filter, attributes)
-                results = parse_result_attributes(search_results)
-                context.log.debug(f"Search results: {results}")
+            # Create directories if they do not exist
+            os.makedirs(domain_dir, exist_ok=True)
 
-                for computer in results:
-                    context.log.debug(f"Processing computer: {computer['sAMAccountName']}, UAC: {computer['userAccountControl']}")
-                    # Check if the account is a pre-created computer account
-                    if int(computer["userAccountControl"]) == 4128:  # 4096 | 32
-                        computers.append(computer["sAMAccountName"])
-                        context.log.debug(f"Added computer: {computer['sAMAccountName']}")
-
-                # Save computers to file
-                domain_dir = os.path.join(f"{NXC_PATH}/modules/pre2k", connection.domain)
-                output_file = os.path.join(domain_dir, "precreated_computers.txt")
-
-                # Create directories if they do not exist
-                os.makedirs(domain_dir, exist_ok=True)
-
-                with open(output_file, "w") as file:
-                    for computer in computers:
-                        file.write(f"{computer}\n")
-
-                # Print discovered pre-created computer accounts
-                if computers:
-                    for computer in computers:
-                        context.log.highlight(f"Pre-created computer account: {computer}")
-                    context.log.success(f"Found {len(computers)} pre-created computer accounts. Saved to {output_file}")
-                else:
-                    context.log.info("No pre-created computer accounts found.")
-
-                # Obtain TGTs and save to ccache
-                ccache_base_dir = f"{NXC_PATH}/modules/pre2k/ccache"
-                os.makedirs(ccache_base_dir, exist_ok=True)
-
-                successful_tgts = 0
-
+            with open(output_file, "w") as file:
                 for computer in computers:
-                    machine_name = computer[:-1].lower()  # Remove trailing '$' and convert to lowercase
-                    if self.get_tgt(context, machine_name, connection.domain, connection.kdcHost, ccache_base_dir):
-                        successful_tgts += 1
+                    file.write(f"{computer}\n")
 
-                # Summary of TGT results
-                if successful_tgts > 0:
-                    context.log.success(f"Successfully obtained TGT for {successful_tgts} pre-created computer accounts. Saved to {ccache_base_dir}")
+            # Print discovered pre-created computer accounts
+            if computers:
+                for computer in computers:
+                    context.log.highlight(f"Pre-created computer account: {computer}")
+                context.log.success(f"Found {len(computers)} pre-created computer accounts. Saved to {output_file}")
+            else:
+                context.log.info("No pre-created computer accounts found.")
 
-            except Exception as e:
-                context.log.fail(f"Error occurred during search: {e}")
-            return True
+            # Obtain TGTs and save to ccache
+            ccache_base_dir = f"{NXC_PATH}/modules/pre2k/ccache"
+            os.makedirs(ccache_base_dir, exist_ok=True)
 
+            successful_tgts = 0
+
+            for computer in computers:
+                machine_name = computer[:-1].lower()  # Remove trailing '$' and convert to lowercase
+                if self.get_tgt(context, machine_name, connection.domain, connection.kdcHost, ccache_base_dir):
+                    successful_tgts += 1
+
+            # Summary of TGT results
+            if successful_tgts > 0:
+                context.log.success(f"Successfully obtained TGT for {successful_tgts} pre-created computer accounts. Saved to {ccache_base_dir}")
         except Exception as e:
-            context.log.fail(f"Error occurred during LDAP connection: {e}")
-            return False
+            context.log.fail(f"Error occurred during search: {e}")
 
     def get_tgt(self, context, username, domain, kdcHost, ccache_base_dir):
         try:

--- a/nxc/modules/pre2k.py
+++ b/nxc/modules/pre2k.py
@@ -18,7 +18,7 @@ class NXCModule:
     supported_protocols = ["ldap"]
 
     def options(self, context, module_options):
-        pass
+        """No options available"""
 
     def on_login(self, context, connection):
         try:


### PR DESCRIPTION
## Description

Fixes #879 which is caused by a `connection.close()` at the end of the module. In general, modules should not close connections

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Run another module after pre2k: `nxc ldap <ip> -u -p -M pre2k -M adcs`

## Screenshots (if appropriate):
Before:
<img width="1578" height="1126" alt="image" src="https://github.com/user-attachments/assets/4096385c-d227-4e7a-b896-2779c4dc7921" />
After:
<img width="1581" height="281" alt="image" src="https://github.com/user-attachments/assets/3b4340ba-d9fe-45ea-99e1-5c48859ef5c7" />
