### PR TITLE
Show hosts file successfully saved message.

### DIFF
--- a/nxc/hosts
+++ b/nxc/hosts
@@ -1,1 +1,0 @@
-10.10.11.181     DC.absolute.htb absolute.htb DC

--- a/nxc/hosts
+++ b/nxc/hosts
@@ -1,0 +1,1 @@
+10.10.11.181     DC.absolute.htb absolute.htb DC

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -312,6 +312,7 @@ class smb(connection):
                     dc_part = f" {self.targetDomain}" if self.isdc else ""
                     host_file.write(f"{self.host}     {self.hostname}.{self.targetDomain}{dc_part} {self.hostname}\n")
                     self.logger.debug(f"Line added to {self.args.generate_hosts_file} {self.host}    {self.hostname}.{self.targetDomain}{dc_part} {self.hostname}")
+                    self.logger.success(f"Hosts file saved to: {self.args.generate_hosts_file}")
             elif self.args.generate_krb5_file and self.isdc:
                 with open(self.args.generate_krb5_file, "w+") as host_file:
                     data = f"""


### PR DESCRIPTION
This PR improves the user experience of the --generate-hosts-file module by adding a successfully generated hosts file message once the file is created.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
NA

## Screenshots (if appropriate):
<img width="1403" height="74" alt="nxc" src="https://github.com/user-attachments/assets/e5ab28d3-2e05-41f1-bd4f-4fc964d91152" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
