### PR TITLE
Fix MAQ module crash

### DIFF
--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -33,10 +33,4 @@ class NXCModule:
             context.log.fail("No LDAP entries returned.")
             return
 
-        maq = entries[0].get("ms-DS-MachineAccountQuota")
-        if isinstance(maq, list):
-            maq = maq[0] if maq else None
-        if isinstance(maq, (bytes, bytearray)):
-            maq = maq.decode("utf-8", errors="ignore")
-
-        context.log.highlight(f"MachineAccountQuota: {maq if maq else '<not set>'}")
+        context.log.highlight(f"MachineAccountQuota: {entries[0]['ms-DS-MachineAccountQuota']}")

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -22,7 +22,7 @@ class NXCModule:
     description = "Retrieves the MachineAccountQuota domain-level attribute"
     supported_protocols = ["ldap"]
     category = CATEGORY.ENUMERATION
-    
+
     def on_login(self, context, connection):
          context.log.display("Getting the MachineAccountQuota")
          try:

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -5,6 +5,7 @@ from nxc.helpers.misc import CATEGORY
 class NXCModule:
     """
     Module by Shutdown and Podalirius
+    Modified by @azoxlpf to handle null session errors and avoid IndexError when no LDAP results are returned.
 
     Initial module:
       https://github.com/ShutdownRepo/CrackMapExec-MachineAccountQuota
@@ -21,12 +22,21 @@ class NXCModule:
     description = "Retrieves the MachineAccountQuota domain-level attribute"
     supported_protocols = ["ldap"]
     category = CATEGORY.ENUMERATION
-
+    
     def on_login(self, context, connection):
-        context.log.display("Getting the MachineAccountQuota")
-        result = connection.search("(objectClass=*)", ["ms-DS-MachineAccountQuota"])
-        try:
-            maq = result[0]["attributes"][0]["vals"][0]
-            context.log.highlight(f"MachineAccountQuota: {maq}")
-        except PyAsn1Error:
-            context.log.highlight("MachineAccountQuota: <not set>")
+         context.log.display("Getting the MachineAccountQuota")
+         try:
+             result = connection.search("(objectClass=*)", ["ms-DS-MachineAccountQuota"])
+         except Exception as e:
+             context.log.fail(f"LDAP search failed: {e}")
+             return
+
+         if not result:
+             context.log.fail("No LDAP entries returned.")
+             return
+
+         try:
+             maq = result[0]["attributes"][0]["vals"][0]
+             context.log.highlight(f"MachineAccountQuota: {maq}")
+         except (IndexError, KeyError, PyAsn1Error):
+             context.log.highlight("MachineAccountQuota: <not set>")


### PR DESCRIPTION
## Description

This PR fixes issue #[872](https://github.com/Pennyw0rth/NetExec/issues/872) where the maq module crashed with
`IndexError: list index out of range when running against a DC that does not allow anonymous LDAP bind.`

Changes:

- Wrapped connection.search() in try/except to catch LDAP operationsError.

- Added check for empty result before indexing result[0].

- Caught IndexError and KeyError when parsing attributes to prevent crash.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)


## Screenshots:

<img width="1921" height="238" alt="1" src="https://github.com/user-attachments/assets/a6c597ed-6fdb-4def-a493-3c040892d190" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
