### PR TITLE
Resolve hostname to IP in dc_list when no --dns-server is given

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -3,6 +3,7 @@
 import hashlib
 import hmac
 import os
+import socket
 from errno import EHOSTUNREACH, ETIMEDOUT, ENETUNREACH
 from binascii import hexlify
 from datetime import datetime
@@ -830,7 +831,8 @@ class ldap(connection):
     def dc_list(self):
         # bypass host resolver configuration via configure=False (default pulls from /etc/resolv.conf or registry on Windows)
         resolv = resolver.Resolver(configure=False)
-        resolv.nameservers = [self.args.dns_server] if self.args.dns_server else [self.host]
+        ns = self.args.dns_server or self.host
+        resolv.nameservers = [socket.gethostbyname(ns)]
         self.logger.debug(f"DNS Server option: {self.args.dns_server}, using DNS server: {resolv.nameservers}")
         resolv.timeout = self.args.dns_timeout
 


### PR DESCRIPTION
## Description
This PR fixes issue [#870](https://github.com/Pennyw0rth/NetExec/issues/870) where `nxc ldap --dc-list` fails when using a hostname target together with the Kerberos (-k) flag.

### Problem

When Kerberos is enabled, NetExec preserves the FQDN in `self.host` to build the SPN correctly.
However, `dc_list()` uses `self.host` as the DNS nameserver when `--dns-server` is not provided.
If `self.host` is a FQDN, dnspython raises:

`ValueError: nameserver <hostname> is not a ... IP address, nor a valid https URL`

This prevented `--dc-list` from working with Kerberos unless the user explicitly provided `--dns-server` or targeted the DC by IP.

###Fix

- We now resolve `self.host` to an IP once (using socket.gethostbyname()) when no `--dns-server` is provided.

- This guarantees resolv.nameservers always receives an IP, avoiding the ValueError.

- `/etc/hosts` entries are honored, so local hostname resolution still works.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):

Before : 

<img width="1911" height="909" alt="1" src="https://github.com/user-attachments/assets/a458e3b8-f16d-4d92-9e36-873994b3409e" />

After : 

<img width="1681" height="131" alt="2" src="https://github.com/user-attachments/assets/fa5a67ab-3613-46cf-b50f-18b233bc6863" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)

