### PR TITLE
Enforce that category is one of the enums

### DIFF
--- a/nxc/loaders/moduleloader.py
+++ b/nxc/loaders/moduleloader.py
@@ -8,6 +8,7 @@ from os.path import dirname
 from os.path import join as path_join
 
 from nxc.context import Context
+from nxc.helpers.misc import CATEGORY
 from nxc.logger import NXCAdapter
 from nxc.paths import NXC_PATH
 
@@ -30,8 +31,8 @@ class ModuleLoader:
         elif not hasattr(module, "description"):
             self.logger.fail(f"{module_path} missing the description variable")
             module_error = True
-        elif not hasattr(module, "category"):
-            self.logger.fail(f"{module_path} missing the category variable")
+        elif not hasattr(module, "category") or module.category not in [CATEGORY.ENUMERATION, CATEGORY.CREDENTIAL_DUMPING, CATEGORY.PRIVILEGE_ESCALATION]:
+            self.logger.fail(f"{module_path} missing the category variable or invalid category")
             module_error = True
         elif not hasattr(module, "supported_protocols"):
             self.logger.fail(f"{module_path} missing the supported_protocols variable")


### PR DESCRIPTION
## Description

This PR enforces, that a module is one of the pre-defined enums.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Try setting an invalid category

## Screenshots (if appropriate):
Before&After with a category "Test":
<img width="1550" height="1123" alt="image" src="https://github.com/user-attachments/assets/51994693-ed50-4769-9ed7-2f92d2641484" />

