### PR TITLE
Add --credfile option for using "user:pass" files for authentication

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -86,6 +86,7 @@ def gen_cli_args():
     credential_group = std_parser.add_argument_group("Authentication", "Options for authenticating")
     credential_group.add_argument("-u", "--username", metavar="USERNAME", dest="username", nargs="+", default=[], help="username(s) or file(s) containing usernames")
     credential_group.add_argument("-p", "--password", metavar="PASSWORD", dest="password", nargs="+", default=[], help="password(s) or file(s) containing passwords")
+    credential_group.add_argument("--credfile", metavar="CREDFILE", dest="credfile", help="file containing credentials in format 'user:pass' (one per line)")
     credential_group.add_argument("-id", metavar="CRED_ID", nargs="+", default=[], type=str, dest="cred_id", help="database credential ID(s) to use for authentication")
     credential_group.add_argument("--ignore-pw-decoding", action="store_true", help="Ignore non UTF-8 characters when decoding the password file")
     credential_group.add_argument("--no-bruteforce", action="store_true", help="No spray when using file for username and password (user1 => password1, user2 => password2)")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -383,30 +383,30 @@ class connection:
         cred_type = []
 
         # Parse credfile if specified - break it into username and password lists
-        if hasattr(self.args, 'credfile') and self.args.credfile:
+        if hasattr(self.args, "credfile") and self.args.credfile:
             try:
                 cred_usernames = []
                 cred_passwords = []
-                
+
                 with open(self.args.credfile, errors=("ignore" if self.args.ignore_pw_decoding else "strict")) as credfile:
                     for line in credfile:
                         line = line.strip()
-                        if not line or ':' not in line:
+                        if not line or ":" not in line:
                             continue
-                        
-                        user_part, pass_part = line.split(':', 1)
+
+                        user_part, pass_part = line.split(":", 1)
                         cred_usernames.append(user_part.strip())
                         cred_passwords.append(pass_part.strip())
-                
+
                 # Add credfile usernames and passwords to the args lists
-                if not hasattr(self.args, 'username'):
+                if not hasattr(self.args, "username"):
                     self.args.username = []
-                if not hasattr(self.args, 'password'):
+                if not hasattr(self.args, "password"):
                     self.args.password = []
-                
+
                 self.args.username.extend(cred_usernames)
                 self.args.password.extend(cred_passwords)
-                
+
             except UnicodeDecodeError as e:
                 self.logger.error(f"{type(e).__name__}: Could not decode credfile. Make sure the file only contains UTF-8 characters.")
                 self.logger.error("You can ignore non UTF-8 characters with the option '--ignore-pw-decoding'")
@@ -569,7 +569,7 @@ class connection:
             cred_type.extend(db_cred_type)
             data.extend(db_data)
 
-        if self.args.username or (hasattr(self.args, 'credfile') and self.args.credfile):
+        if self.args.username or (hasattr(self.args, "credfile") and self.args.credfile):
             parsed_domain, parsed_username, parsed_owned, parsed_secret, parsed_cred_type, parsed_data = self.parse_credentials()
             domain.extend(parsed_domain)
             username.extend(parsed_username)

--- a/tests/data/test_credfile.txt
+++ b/tests/data/test_credfile.txt
@@ -1,0 +1,5 @@
+Administrator:Passw0rd!
+Anonymous:None
+ftp:ftp
+guest:guest
+robert.baratheon:iamthekingoftheworld

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -174,6 +174,10 @@ netexec smb TARGET_HOST -u '' -p '' -M petitpotam
 netexec smb TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce
 netexec smb TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce --continue-on-success
 netexec smb TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE
+##### SMB Credfile
+netexec smb TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce
+netexec smb TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce --continue-on-success
+netexec smb TARGET_HOST --credfile TEST_CREDFILE
 ##### SMB Hash File
 netexec smb TARGET_HOST -u LOGIN_USERNAME -H tests/data/test_hashes.txt
 netexec smb TARGET_HOST -u TEST_USER_FILE -H tests/data/test_hashes.txt
@@ -278,6 +282,10 @@ netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD
 netexec ssh TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce
 netexec ssh TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce --continue-on-success
+##### SSH Credfile
+netexec ssh TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce
+netexec ssh TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce --continue-on-success
+netexec ssh TARGET_HOST --credfile TEST_CREDFILE
 netexec ssh TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --key-file tests/data/test_key.priv
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p '' --key-file tests/data/test_key.priv
@@ -295,6 +303,10 @@ netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --put tests/data/tes
 netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --get test_file.txt
 netexec ftp TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce
 netexec ftp TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce --continue-on-success
+##### FTP Credfile
+netexec ftp TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce
+netexec ftp TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce --continue-on-success
+netexec ftp TARGET_HOST --credfile TEST_CREDFILE
 netexec ftp TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE
 ##### NFS
 netexec nfs TARGET_HOST -u "" -p "" --shares

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -185,6 +185,10 @@ netexec smb TARGET_HOST -u TEST_USER_FILE -H tests/data/test_hashes.txt
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --wmi-namespace root/cimv2
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x whoami
+##### WMI Credfile
+netexec wmi TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce
+netexec wmi TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce --continue-on-success
+netexec wmi TARGET_HOST --credfile TEST_CREDFILE
 ##### WMI Modules
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ioxidresolver
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M spooler
@@ -209,6 +213,10 @@ netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --admin-co
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --gmsa
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --pso
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --pass-pol
+##### LDAP Credfile
+netexec ldap TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce
+netexec ldap TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce --continue-on-success
+netexec ldap TARGET_HOST --credfile TEST_CREDFILE
 ##### LDAP Modules
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -L
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M adcs
@@ -234,6 +242,10 @@ netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --lsa --d
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --lsa --dump-method powershell
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --laps
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --check-proto http
+##### WINRM Credfile
+netexec winrm TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce
+netexec winrm TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce --continue-on-success
+netexec winrm TARGET_HOST --credfile TEST_CREDFILE
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --check-proto https
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --check-proto http https
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --port 5985
@@ -247,6 +259,10 @@ netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ntds-d
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # Need a space at the end for kerb regex
 netexec {DNS} mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # Need a space at the end for kerb regex
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --rid-brute
+##### MSSQL Credfile
+netexec mssql TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce
+netexec mssql TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce --continue-on-success
+netexec mssql TARGET_HOST --credfile TEST_CREDFILE
 ##### MSSQL PowerShell
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --force-ps32
@@ -278,6 +294,10 @@ netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --nla-scree
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --screenshot
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig
+##### RDP Credfile
+netexec rdp TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce
+netexec rdp TARGET_HOST --credfile TEST_CREDFILE --no-bruteforce --continue-on-success
+netexec rdp TARGET_HOST --credfile TEST_CREDFILE
 ##### SSH - Default test passwords and random key; switch these out if you want correct authentication
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD
 netexec ssh TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce

--- a/tests/e2e_tests.py
+++ b/tests/e2e_tests.py
@@ -100,6 +100,12 @@ def get_cli_args():
         help="Path to the file containing test passwords",
     )
     parser.add_argument(
+        "--test-credfile",
+        required=False,
+        default=normpath(join(script_dir, "data", "test_credfile.txt")),
+        help="Path to the file containing test credentials in user:pass format",
+    )
+    parser.add_argument(
         "--amsi-bypass-file",
         required=False,
         default=normpath(join(script_dir, "data", "test_amsi_bypass.txt")),
@@ -181,6 +187,7 @@ def replace_command(args, line):
         .replace("KERBEROS ", kerberos)\
         .replace("TEST_USER_FILE", args.test_user_file)\
         .replace("TEST_PASSWORD_FILE", args.test_password_file)\
+        .replace("TEST_CREDFILE", args.test_credfile)\
         .replace("AMSI_BYPASS_FILE", args.amsi_bypass_file)\
         .replace("TEST_NORMAL_FILE", args.test_normal_file)\
         .replace("{DNS}", dns_server)\


### PR DESCRIPTION
## Description

This PR adds a new `--credfile` option that allows users to specify credentials in a file with `user:pass` format, similar to how `-u` and `-p` work with username and password files. The implementation follows the same parsing and bruteforce logic patterns as the existing credential handling.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Ran using `uv` from the following operational system

```
Arch Linux x86_64 Linux 6.16.5-arch1-1
```

To test simply cloned and ran with `uv install`

```
git clone https://github.com/mHijuxS/NetExec
cd NetExec
uv tool install .
nxc ssh localhost --credfile testcreds
```

## Screenshots (if appropriate):
<img width="1032" height="384" alt="image" src="https://github.com/user-attachments/assets/4c13cf66-8d7d-4389-bbc8-471fd796f550" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
