### PR TITLE
Minor bug fixes

### DIFF
--- a/nxc/modules/scuffy.py
+++ b/nxc/modules/scuffy.py
@@ -59,12 +59,7 @@ class NXCModule:
     def on_login(self, context, connection):
         shares = connection.shares()
         for share in shares:
-            if "WRITE" in share["access"] and share["name"] not in [
-                "C$",
-                "ADMIN$",
-                "NETLOGON",
-                "SYSVOL",
-            ]:
+            if "WRITE" in share["access"] and share["name"] not in ["C$", "ADMIN$", "NETLOGON", "SYSVOL"]:
                 context.log.success(f"Found writable share: {share['name']}")
                 if not self.cleanup:
                     with open(self.scf_path, "rb") as scf:

--- a/nxc/modules/scuffy.py
+++ b/nxc/modules/scuffy.py
@@ -63,6 +63,7 @@ class NXCModule:
                 "C$",
                 "ADMIN$",
                 "NETLOGON",
+                "SYSVOL",
             ]:
                 context.log.success(f"Found writable share: {share['name']}")
                 if not self.cleanup:

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -112,18 +112,21 @@ def main():
 
     if hasattr(args, "target") and args.target:
         for target in args.target:
-            if exists(target) and os.path.isfile(target):
-                target_file_type = identify_target_file(target)
-                if target_file_type == "nmap":
-                    targets.extend(parse_nmap_xml(target, args.protocol))
-                elif target_file_type == "nessus":
-                    targets.extend(parse_nessus_file(target, args.protocol))
+            try:
+                if exists(target) and os.path.isfile(target):
+                    target_file_type = identify_target_file(target)
+                    if target_file_type == "nmap":
+                        targets.extend(parse_nmap_xml(target, args.protocol))
+                    elif target_file_type == "nessus":
+                        targets.extend(parse_nessus_file(target, args.protocol))
+                    else:
+                        with open(target) as target_file:
+                            for target_entry in target_file:
+                                targets.extend(parse_targets(target_entry.strip()))
                 else:
-                    with open(target) as target_file:
-                        for target_entry in target_file:
-                            targets.extend(parse_targets(target_entry.strip()))
-            else:
-                targets.extend(parse_targets(target))
+                    targets.extend(parse_targets(target))
+            except Exception as e:
+                nxc_logger.fail(f"Failed to parse target '{target}': {e}")
 
     # The following is a quick hack for the powershell obfuscation functionality, I know this is yucky
     if hasattr(args, "clear_obfscripts") and args.clear_obfscripts:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1169,7 +1169,7 @@ class smb(connection):
                 # Calculate max lengths for formatting
                 maxSidLen = max(len(key) + 1 for key in sessions)
                 maxSidLen = max(maxSidLen, len("SID") + 1)
-                maxUsernameLen = max(len(vals["Username"] + vals["Domain"]) + 1 for vals in sessions.values()) + 1
+                maxUsernameLen = max(len(str(vals["Username"]) + str(vals["Domain"])) + 1 for vals in sessions.values()) + 1
                 maxUsernameLen = max(maxUsernameLen, len("USERNAME") + 1)
 
                 # Create the template for formatting


### PR DESCRIPTION
## Description

On my current assessment i encountered a few issues which are fixed here:
- Handle Exceptions per target (file), which crashed on me as one of the input xml files was broken
- Cast returned values of the `reg_sessions` command to `str`, as it returned an empty byte string which raised an exception because `str` could not be concatenated to `bytes`
- Add the `SYSVOL` share to the exclusion list of scuffy similar to slinky, as this share will not be visited by normal users

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
The first bug can be tested by supplying a broken nmap xml file as target file. The reg_session one i have no idea why that happened.

## Screenshots (if appropriate):
Confidential due to prod environment