### PR TITLE
refactor keepass_discover module

### DIFF
--- a/nxc/modules/keepass_discover.py
+++ b/nxc/modules/keepass_discover.py
@@ -1,5 +1,7 @@
-from csv import reader
+import re
 from nxc.helpers.misc import CATEGORY
+from impacket.dcerpc.v5 import tsts as TSTS
+from contextlib import suppress
 
 
 class NXCModule:
@@ -8,6 +10,8 @@ class NXCModule:
 
     Module by @d3lb3
     Inspired by @harmj0y https://raw.githubusercontent.com/GhostPack/KeeThief/master/PowerShell/KeePassConfig.ps1
+
+    Refactored by @lodos2005
     """
 
     name = "keepass_discover"
@@ -16,56 +20,133 @@ class NXCModule:
     category = CATEGORY.ENUMERATION
 
     def __init__(self):
-        self.search_type = "ALL"
-        self.search_path = "'C:\\Users\\','$env:PROGRAMFILES','env:ProgramFiles(x86)'"
+        self.search_type = "DEFAULT"
+        self.search_path = "Users,Program Files,Program Files (x86)"
 
     def options(self, context, module_options):
         r"""
         SEARCH_TYPE     Specify what to search, between:
                           PROCESS     Look for running KeePass.exe process only
-                          FILES       Look for KeePass-related files (KeePass.config.xml, .kdbx, KeePass.exe) only, may take some time
-                          ALL         Look for running KeePass.exe process and KeePass-related files (default)
+                          FILES       Look for KeePass-related files in default locations
+                          DEEP_FILES  Look for KeePass-related files by spidering SEARCH_PATH (slow)
+                          DEFAULT     Look for running process and files in default locations (default)
+                          ALL         Look for running process and deep search for files
 
-        SEARCH_PATH     Comma-separated remote locations where to search for KeePass-related files (you must add single quotes around the paths if they include spaces)
-                        Default: 'C:\\Users\\','$env:PROGRAMFILES','env:ProgramFiles(x86)'
+        SEARCH_PATH     Comma-separated remote locations on C$ where to search for KeePass-related files (used by DEEP_FILES and ALL_DEEP).
+                        Default: Users,Program Files,Program Files (x86)
         """
         if "SEARCH_PATH" in module_options:
             self.search_path = module_options["SEARCH_PATH"]
 
         if "SEARCH_TYPE" in module_options:
-            self.search_type = module_options["SEARCH_TYPE"]
+            self.search_type = module_options["SEARCH_TYPE"].upper()
 
     def on_admin_login(self, context, connection):
-        if self.search_type == "ALL" or self.search_type == "PROCESS":
-            # search for keepass process
-            search_keepass_process_command_str = 'powershell.exe "Get-Process kee* -IncludeUserName | Select-Object -Property Id,UserName,ProcessName | ConvertTo-CSV -NoTypeInformation"'
-            search_keepass_process_output_csv = connection.execute(search_keepass_process_command_str, True)  # we return the powershell command as a CSV for easier column parsing
-            csv_reader = reader(search_keepass_process_output_csv.split("\n"), delimiter=",")
-            next(csv_reader)  # to skip the csv header line
-            row_number = 0  # as csv_reader is an iterator we can't get its length without exhausting it
-            for row in csv_reader:
-                row_number += 1
-                keepass_process_id = row[0]
-                keepass_process_username = row[1]
-                keepass_process_name = row[2]
-                context.log.highlight(f'Found process "{keepass_process_name}" with PID {keepass_process_id} (user {keepass_process_username})')
-            if row_number == 0:
-                context.log.display("No KeePass-related process was found")
+        if self.search_type in ("PROCESS", "DEFAULT", "ALL"):
+            self.check_processes(context, connection)
 
-        # search for keepass-related files
-        if self.search_type == "ALL" or self.search_type == "FILES":
-            search_keepass_files_payload = f"Get-ChildItem -Path {self.search_path} -Recurse -Force -Include ('KeePass.config.xml','KeePass.exe','*.kdbx') -ErrorAction SilentlyContinue | Select FullName -ExpandProperty FullName"
-            search_keepass_files_cmd = f'powershell.exe "{search_keepass_files_payload}"'
-            search_keepass_files_output = connection.execute(search_keepass_files_cmd, True).split("\r\n")
-            found = False
-            found_xml = False
-            for file in search_keepass_files_output:
-                if "KeePass" in file or "kdbx" in file:
-                    if "xml" in file:
-                        found_xml = True
-                    found = True
-                    context.log.highlight(f"Found {file}")
-            if not found:
-                context.log.display("No KeePass-related file were found")
-            elif not found_xml:
+        if self.search_type in ("FILES", "DEEP_FILES", "DEFAULT", "ALL"):
+            self.fast_file_search(context, connection)
+
+        if self.search_type in ("DEEP_FILES", "ALL"):
+            self.deep_file_search(context, connection)
+
+    def check_processes(self, context, connection):
+        context.log.display("Searching for KeePass processes via Tasklist")
+        try:
+            with TSTS.LegacyAPI(connection.conn, connection.remoteName, kerberos=connection.kerberos) as legacy:
+                handle = legacy.hRpcWinStationOpenServer()
+                processes = legacy.hRpcWinStationGetAllProcesses(handle)
+
+            if not processes:
+                context.log.display("Could not enumerate processes, tasklist empty or error.")
+            else:
+                found_procs = [p for p in processes if p["ImageName"] and re.match(r"kee.*", p["ImageName"], re.IGNORECASE)]
+                if found_procs:
+                    for p in found_procs:
+                        context.log.highlight(f'Found process "{p["ImageName"]}" with PID {p["UniqueProcessId"]} (user SID {p["pSid"]})')
+                else:
+                    context.log.display("No KeePass-related process was found")
+        except Exception as e:
+            context.log.fail(f"Error enumerating processes: {e}")
+
+    def fast_file_search(self, context, connection):
+        context.log.display("Searching for KeePass files in default locations (fast search)")
+
+        known_paths = [
+            r"Program Files\KeePass Password Safe 2\KeePass.config.xml",
+            r"Program Files\KeePass Password Safe 2\KeePass.config.enforced.xml",
+            r"Program Files (x86)\KeePass Password Safe 2\KeePass.config.xml",
+            r"Program Files (x86)\KeePass Password Safe 2\KeePass.config.enforced.xml",
+        ]
+
+        user_folders = []
+        try:
+            users = connection.conn.listPath("C$", r"\Users\*")
+            user_folders = [user.get_longname() for user in users if user.get_longname() not in (".", "..")]
+        except Exception as e:
+            context.log.debug(f"Could not list users from C$\\Users: {e}")
+
+        for user in user_folders:
+            known_paths.extend([
+                rf"Users\{user}\AppData\Local\VirtualStore\Program Files\KeePass Password Safe 2\KeePass.config.xml",
+                rf"Users\{user}\AppData\Roaming\KeePass\KeePass.config.xml",
+                rf"Users\{user}\AppData\Local\KeePass\KeePass.config.xml",
+                rf"Users\{user}\AppData\Roaming\KeePassDatabase\KeePass.config.xml",
+                rf"Users\{user}\AppData\Roaming\KeePassDatabase\KeePass.config.enforced.xml",
+                rf"Users\{user}\.config\KeePass\KeePass.config.xml"
+            ])
+
+        found_files = []
+        for path in known_paths:
+            with suppress(Exception):
+                connection.conn.listPath("C$", path.replace("/", "\\"))
+                full_path = f"C:\\{path}"
+                found_files.append(full_path)
+
+        for user in user_folders:
+            for folder in ["Documents", "Desktop"]:
+                try:
+                    files = connection.spider("C$", folder=rf"Users\{user}\{folder}", pattern=["*.kdbx"], silent=True)
+                    found_files.extend([f"C:\\{f}" for f in files])
+                except Exception as e:
+                    context.log.debug(f"Error spidering for .kdbx in C$\\Users\\{user}\\{folder}: {e}")
+        if found_files:
+            for f in found_files:
+                context.log.highlight(f"Found {f}")
+            found_xml = any(".config" in f for f in found_files)
+            if not found_xml:
                 context.log.fail("No config settings file found !!!")
+        else:
+            context.log.display("No KeePass-related files were found in default locations")
+
+    def deep_file_search(self, context, connection):
+        context.log.display(f"Searching for KeePass files on C$ in '{self.search_path}' (deep search)")
+
+        paths = self.search_path.split(",")
+        all_found_files = []
+
+        for path in paths:
+            folder_path = path.strip().replace("\\", "/")
+            if folder_path.startswith("C:/"):
+                folder_path = folder_path[3:]
+            elif folder_path.startswith("/"):
+                folder_path = folder_path[1:]
+
+            try:
+                found = connection.spider("C$", folder=folder_path, pattern=["KeePass.config.xml", "KeePass.exe", "*.kdbx"], silent=True)
+                all_found_files.extend([f"C:\\{f}" for f in found])
+            except Exception as e:
+                context.log.debug(f"Error spidering {path} on C$: {e}")
+
+        if all_found_files:
+            found_xml = False
+            for file_path in all_found_files:
+                if "KeePass.config.xml" in file_path or "KeePass.config.enforced.xml" in file_path:
+                    found_xml = True
+                context.log.highlight(f"Found {file_path}")
+
+            if not found_xml:
+                context.log.fail("No config settings file found !!!")
+        else:
+            context.log.display("No KeePass-related files were found")


### PR DESCRIPTION
## Description

This PR completely refactors the keepass_discover module, removing its dependency on PowerShell and introducing a more efficient, tiered search strategy.

- **Key Changes:** Native Process Enumeration: Process discovery now uses impacket's TSTS.LegacyAPI instead of Get-Process.
- **Tiered File Search:** A new fast search (FILES) checks only common KeePass installation and configuration directories. The existing deep search (DEEP_FILES) now uses the native connection.spider() method for a comprehensive scan.
- **Improved Module Options:** DEFAULT: The new default option, combines process discovery with a fast file search. ALL: Combines process discovery with a deep file search for the most thorough scan.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):
<img width="1114" height="115" alt="Screenshot 2025-09-11 at 02 13 54" src="https://github.com/user-attachments/assets/48c30983-bbbf-47d7-8166-627b2d51ade3" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
