### PR TITLE
Ephemeral module

### DIFF
--- a/nxc/modules/ephemeral.py
+++ b/nxc/modules/ephemeral.py
@@ -1,0 +1,107 @@
+# ~/.nxc/modules/ephemeral.py
+import threading
+import time
+import os
+
+class NXCModule:
+    name = "ephemeral"
+    description = "Run bash scripts entirely in memory on a Linux target"
+    supported_protocols = ["ssh"]
+    opsec_safe = True
+    multiple_hosts = False
+    category = CATEGORY.ENUMERATION
+
+    def __init__(self):
+        self.conn = None
+        self.transport = None
+        self.script_path = None
+        self.raw_command = None
+        self.thread = None
+
+    def options(self, context, module_options):
+        self.script_path = module_options.get("SCRIPT")
+        self.raw_command = module_options.get("COMMAND")
+
+        context.log.display("[ephemeral] Ready to run script in memory.")
+
+        if self.script_path and not os.path.isfile(self.script_path):
+            context.log.error(f"[ephemeral] Script file not found: {self.script_path}")
+            self.script_path = None
+            return
+
+    def on_login(self, context, connection):
+        if not hasattr(connection, "conn") or connection.conn is None:
+            context.log.error("[ephemeral] SSH client not found on connection.")
+            return
+
+        self.conn = connection.conn
+        self.transport = self.conn.get_transport()
+        if self.transport is None or not self.transport.is_active():
+            context.log.error("[ephemeral] SSH transport not active.")
+            return
+
+        context.log.display("[ephemeral] SSH login succeeded!")
+
+        # Determine script or command to run
+        if self.script_path:
+            with open(self.script_path, "r") as f:
+                script_content = f.read()
+        elif self.raw_command:
+            script_content = self.raw_command
+        elif getattr(connection.args, "execute", None):
+            # fallback to NetExec -x command
+            script_content = connection.args.execute
+        else:
+            context.log.error("[ephemeral] No commands to execute.")
+            return
+
+        # Run command in a separate thread
+        self.thread = threading.Thread(target=self._run_command, args=(context, script_content), daemon=True)
+        self.thread.start()
+
+        # Keep alive until execution completes
+        while self.thread.is_alive():
+            time.sleep(0.1)
+
+    def _run_command(self, context, script_content):
+        try:
+            chan = self.transport.open_session()
+            # Fully non-interactive
+            chan.exec_command("stdbuf -oL -eL bash -s")
+            chan.sendall(script_content.encode() + b"\n")
+            chan.shutdown_write()
+
+            # Stream stdout/stderr live
+            while not chan.exit_status_ready():
+                if chan.recv_ready():
+                    out = chan.recv(4096)
+                    if out:
+                        context.log.display(out.decode(errors="ignore").rstrip())
+                if chan.recv_stderr_ready():
+                    err = chan.recv_stderr(4096)
+                    if err:
+                        context.log.display(f"[ERR] {err.decode(errors='ignore').rstrip()}")
+                time.sleep(0.01)
+
+            # Drain remaining output
+            while chan.recv_ready():
+                out = chan.recv(4096)
+                if out:
+                    context.log.display(out.decode(errors="ignore").rstrip())
+            while chan.recv_stderr_ready():
+                err = chan.recv_stderr(4096)
+                if err:
+                    context.log.display(f"[ERR] {err.decode(errors='ignore').rstrip()}")
+
+            exit_code = chan.recv_exit_status()
+            context.log.display(f"[ephemeral] Finished with exit code: {exit_code}")
+            chan.close()
+            # Close SSH transport after execution
+            self.conn.close()
+            context.log.display("[ephemeral] SSH connection closed.")
+
+        except Exception as e:
+            context.log.error(f"[ephemeral] Execution error: {e}")
+            if self.conn:
+                self.conn.close()
+                context.log.display("[ephemeral] SSH connection closed due to error.")

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -291,6 +291,8 @@ netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --sudo-check --sudo-check-method mkfifo --get-output-tries 10
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --put-file TEST_NORMAL_FILE /tmp/test_file.txt --put-file TEST_NORMAL_FILE /tmp/test_file2.txt
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --get-file /tmp/test_file.txt /tmp/test_file.txt --get-file /tmp/test_file.txt /tmp/test_file2.txt
+##### SSH MODULES
+netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD -M ephemeral
 ##### FTP- Default test passwords and random key; switch these out if you want correct authentication
 netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD
 netexec ftp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD --ls


### PR DESCRIPTION
## Description

SSH module that allows for commands to be ran in Linux memory.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Ubuntu machine with ssh enabled


## Screenshots (if appropriate):

<img width="1669" height="218" alt="image" src="https://github.com/user-attachments/assets/656f8b5d-c5f9-4815-8556-3a600d42daf3" />

<img width="837" height="562" alt="image" src="https://github.com/user-attachments/assets/4d79ce0c-724c-43b5-879c-84c200c658a2" />


<img width="1476" height="434" alt="image" src="https://github.com/user-attachments/assets/207c6fdb-c124-4c6f-9ba2-249db1b0851e" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [X] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [X] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
