### PR TITLE
Add `--generate-hosts-file` support to LDAP protocol

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -357,6 +357,17 @@ class ldap(connection):
         self.logger.extra["hostname"] = self.hostname
         self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({cbt_status}) {ntlm}")
 
+        # Génération du fichier hosts avec le même format que SMB
+        if hasattr(self.args, 'generate_hosts_file') and self.args.generate_hosts_file:
+            with open(self.args.generate_hosts_file, "a+") as host_file:
+                # Format identique à SMB: IP     FQDN [domain si DC] hostname
+                fqdn = f"{self.hostname}.{self.targetDomain}" if self.targetDomain else self.hostname
+                # Pour LDAP on peut détecter basiquement si c'est un DC par le nom ou supposer que oui
+                dc_part = f" {self.targetDomain}" if self.targetDomain else ""
+                host_file.write(f"{self.host}     {fqdn}{dc_part} {self.hostname}\n")
+                self.logger.debug(f"Line added to {self.args.generate_hosts_file}: {self.host}    {fqdn}{dc_part} {self.hostname}")
+
+
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
         self.username = username if not self.args.use_kcache else self.username    # With ccache we get the username from the ticket
         self.password = password

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -7,6 +7,9 @@ def proto_args(parser, parents):
     ldap_parser.add_argument("-H", "--hash", metavar="HASH", dest="hash", nargs="+", default=[], help="NTLM hash(es) or file(s) containing NTLM hashes")
     ldap_parser.add_argument("--port", type=int, default=389, action=DefaultTrackingAction, help="LDAP port")
 
+    # Ajout des arguments de génération de fichiers (inspirés de SMB)
+    ldap_parser.add_argument("--generate-hosts-file", type=str, help="Generate a hosts file from LDAP domain information")
+
     dgroup = ldap_parser.add_mutually_exclusive_group()
     dgroup.add_argument("-d", metavar="DOMAIN", dest="domain", type=str, default=None, help="domain to authenticate to")
     dgroup.add_argument("--local-auth", action="store_true", help="authenticate locally to each target")

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -194,6 +194,7 @@ netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ntds-dum
 netexec wmi TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ntds-dump-raw -o TARGET=SAM,LSA,NTDS
 ##### LDAP
 netexec {DNS} ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS
+netexec ldap TARGET_HOST --generate-hosts-file /tmp/hostsfile
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --users
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --users-export /tmp/userlistOutputFilename.txt
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --groups


### PR DESCRIPTION
## Description

This PR adds the `--generate-hosts-file` functionality to the LDAP protocol, addressing a critical limitation where SMB fails to retrieve proper domain information and generates unusable hosts files.

**Problem Solved:**
SMB protocol frequently falls back to using IP addresses as hostnames/domains when DNS resolution fails, resulting in invalid entries like:
```
10.10.11.75    10.10.11.75 10.10.11.75.10.10.11.75 10.10.11.75
```

**Solution:**
LDAP queries the directory service directly and provides accurate domain information, generating proper hosts files like:
```
10.10.11.75     DC.rustykey.htb rustykey.htb DC
```

**Changes Made:**
- Add `--generate-hosts-file` argument to LDAP proto_args.py
- Implement hosts file generation in print_host_info() method
- Uses LDAP domain enumeration for accurate FQDN information
- Maintains format consistency with SMB implementation
- Useful when SMB returns incomplete domain information

Closes #926

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

**Testing Environment:**
- Python version: 3.11+
- OS: Linux (tested on Kali Linux)
- Target: Windows Domain Controller / Active Directory environment

**Setup Requirements:**
- Target with LDAP service (port 389/636) accessible
- No authentication required for basic testing
- For authenticated testing: valid domain credentials

**Test Cases:**
1. **Basic functionality (no auth):**
   ```bash
   nxc ldap <target_ip> --generate-hosts-file ./hosts
   ```

2. **With authentication:**
   ```bash
   nxc ldap <target_ip> -u username -p password --generate-hosts-file ./hosts
   ```

3. **Compare with SMB behavior:**
   ```bash
   # Test SMB (may produce invalid entries)
   nxc smb <target_ip> --generate-hosts-file ./hosts_smb
   
   # Test LDAP (should produce valid entries)
   nxc ldap <target_ip> --generate-hosts-file ./hosts_ldap
   ```

**Expected Results:**
- Hosts file should contain valid FQDN entries
- Format: `IP     FQDN domain hostname`
- Should work even when SMB hostname resolution fails

**Tested Against:**
- HackTheBox lab environment (rustykey.htb domain)
- Windows Server 2019/2022 Domain Controllers
- Various AD configurations with DNS resolution issues

## Screenshots (if appropriate):

**Before (SMB with broken hostname resolution):**
```bash
$ nxc smb 10.10.11.75 --generate-hosts-file ./hosts
SMB         10.10.11.75     445    10.10.11.75      [*]  x64 (name:10.10.11.75) (domain:10.10.11.75)

$ cat ./hosts
10.10.11.75    10.10.11.75 10.10.11.75.10.10.11.75 10.10.11.75
```

**After (LDAP with proper domain info):**
```bash
$ nxc ldap 10.10.11.75 --generate-hosts-file ./hosts
LDAP        10.10.11.75     389    DC               [*] None (name:DC) (domain:rustykey.htb)

$ cat ./hosts
10.10.11.75     DC.rustykey.htb rustykey.htb DC
```

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are *required* to be added to the e2e tests)
- [x] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)