### PR TITLE
Fix missing ,

### DIFF
--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -116,7 +116,7 @@ class TSCH_EXEC:
             "C:\\Windows\\System32\\cmd.exe",
             "C:\\Windows\\System32\\..\\System32\\cmd",
             "C:\\Windows\\System32\\..\\System32\\cmd.exe",
-            "C:\\Windows\\..\\Windows\\System32\\cmd"
+            "C:\\Windows\\..\\Windows\\System32\\cmd",
             "C:\\Windows\\..\\Windows\\System32\\cmd.exe",
         ]
         cmd_path = random.choice(random_cmd_path)


### PR DESCRIPTION
This pr fixes atexec that was running random.choices(cmd_paths) with the missing ",":

<img width="510" height="214" alt="image" src="https://github.com/user-attachments/assets/569e84e2-13b3-4fe7-ac64-a592a1591cf4" />

Leading for strange cmd_path to be computed and ruining the scheduled task:

<img width="957" height="93" alt="image" src="https://github.com/user-attachments/assets/c393f7ce-1788-4864-8525-6b67ac5b0261" />
