### PR TITLE
enum_av module: add checkpoint indicators

### DIFF
--- a/nxc/modules/enum_av.py
+++ b/nxc/modules/enum_av.py
@@ -265,6 +265,17 @@ conf = {
             ]
         },
         {
+            "name": "Check Point Endpoint Security",
+            "services": [
+                {"name": "CPDA", "description": "Check Point Endpoint Agent"},
+                {"name": "vsmon", "description": "Check Point Endpoint Security Network Protection"},
+                {"name": "CPFileAnlyz", "description": "Check Point Endpoint Security File Analyzer"},
+                {"name": "EPClientUIService", "description": "Check Point Endpoint Security Client UI"}
+
+            ],
+            "pipes": []
+        },
+        {
             "name": "ESET",
             "services": [
                 {"name": "ekm", "description": "ESET"},


### PR DESCRIPTION
## Description

Added Check Point Endpoint Security indicators for `enum_av.py` module.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Tested `enum_av.py` module against a Windows machine with `Checkpoint Endpoint Security` installed.

## Screenshots (if appropriate):

<img width="1511" height="99" alt="image" src="https://github.com/user-attachments/assets/a9c9e276-2ec2-4de6-98ee-1cf16779f28d" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
