### PR TITLE
[NTLM reflection] Fix false assumption over smb signing

### DIFF
--- a/nxc/modules/ntlm_reflection.py
+++ b/nxc/modules/ntlm_reflection.py
@@ -72,7 +72,7 @@ class NXCModule:
             vuln = self.is_vulnerable(connection.server_os_major, connection.server_os_minor, connection.server_os_build, ubr)
             if vuln:
                 if not connection.conn.isSigningRequired():  # Not vulnerable if SMB signing is enabled
-                    context.log.highlight(f"VULNERABLE (can relay SMB to any protocols on {self.context.log.extra['host']})")
+                    context.log.highlight(f"VULNERABLE (can relay SMB to any protocol on {self.context.log.extra['host']})")
                 else:
                     context.log.highlight(f"VULNERABLE (can relay SMB to other protocols except SMB on {self.context.log.extra['host']})")
         except SessionError as e:


### PR DESCRIPTION
This PR fixes a false assumption following https://github.com/Pennyw0rth/NetExec/issues/928 discussion. Relayng from SMB even when SMB signing is required is actually doable. Except it can only be relayed to others protocols located on the same coerced server bypassing signing AND CBT constraints.

As such I removed the false If condition and added a different message depending of if smb signing is enabled or not:

<img width="1177" height="201" alt="image" src="https://github.com/user-attachments/assets/6ba5ceab-ce70-4f7a-9dbf-723f4a08b484" />

