### PR TITLE
Add dedent for easier reading

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -5,6 +5,7 @@ import re
 import struct
 import ipaddress
 from Cryptodome.Hash import MD4
+from textwrap import dedent
 
 from impacket.smbconnection import SMBConnection, SessionError
 from impacket.smb import SMB_DIALECT
@@ -314,23 +315,23 @@ class smb(connection):
                     self.logger.debug(f"Line added to {self.args.generate_hosts_file} {self.host}    {self.hostname}.{self.targetDomain}{dc_part} {self.hostname}")
             elif self.args.generate_krb5_file and self.isdc:
                 with open(self.args.generate_krb5_file, "w+") as host_file:
-                    data = f"""
-[libdefaults]
-    dns_lookup_kdc = false
-    dns_lookup_realm = false
-    default_realm = {self.domain.upper()}
+                    data = dedent(f"""
+                    [libdefaults]
+                        dns_lookup_kdc = false
+                        dns_lookup_realm = false
+                        default_realm = {self.domain.upper()}
 
-[realms]
-    {self.domain.upper()} = {{
-        kdc = {self.hostname.lower()}.{self.domain}
-        admin_server = {self.hostname.lower()}.{self.domain}
-        default_domain = {self.domain}
-    }}
+                    [realms]
+                        {self.domain.upper()} = {{
+                            kdc = {self.hostname.lower()}.{self.domain}
+                            admin_server = {self.hostname.lower()}.{self.domain}
+                            default_domain = {self.domain}
+                        }}
 
-[domain_realm]
-    .{self.domain} = {self.domain.upper()}
-    {self.domain} = {self.domain.upper()}
-"""
+                    [domain_realm]
+                        .{self.domain} = {self.domain.upper()}
+                        {self.domain} = {self.domain.upper()}
+                    """).strip()
                     host_file.write(data)
                     self.logger.debug(data)
                     self.logger.success(f"krb5 conf saved to: {self.args.generate_krb5_file}")


### PR DESCRIPTION
This simple PR adds the dedent function to file generation so that code is easier to read:

<img width="736" height="382" alt="image" src="https://github.com/user-attachments/assets/2136c628-cef3-49cb-b4a7-ba5f4c579195" />

Below the result:

<img width="636" height="310" alt="image" src="https://github.com/user-attachments/assets/3443218b-4662-492e-90fc-b01ed226aaa5" />
