### PR TITLE
Update dump-computers.py

### DIFF
--- a/nxc/modules/dump-computers.py
+++ b/nxc/modules/dump-computers.py
@@ -4,7 +4,7 @@ from nxc.parsers.ldap_results import parse_result_attributes
 
 class NXCModule:
     name = "dump-computers"
-    description = "Dumps all computers in the domain"
+    description = "Dumps FQDN and OS of all computers in the domain"
     supported_protocols = ["ldap"]
     category = CATEGORY.ENUMERATION
 


### PR DESCRIPTION
## Description
added samaccountname fallback to dump-computers.py in case of dnshostname fails.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Setup guide for the review
in latest netexec (1.4.0 - SmoothOperator - 800bc5ec - 980), dump-computers module fails if there's no dns entry for at least one machine in target active directory environment.

screenshot of error (debug):
<img width="1725" height="861" alt="image" src="https://github.com/user-attachments/assets/3b4b7ee0-8758-47a3-ae39-d5c70d221363" />

root cause:
<img width="1142" height="638" alt="image" src="https://github.com/user-attachments/assets/26c0ce43-d0ae-4e14-a676-84aa4b0408fb" />

## Screenshots (if appropriate):
screenshot of fixed code output:
<img width="1379" height="479" alt="image" src="https://github.com/user-attachments/assets/5766aa01-c9cb-43c1-be75-be8b44c4d371" />

## Checklist:
- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
