### PR TITLE
Readd removed code

### DIFF
--- a/nxc/modules/backup_operator.py
+++ b/nxc/modules/backup_operator.py
@@ -118,3 +118,11 @@ class NXCModule:
             context.log.display("netexec smb dc_ip -u user -p pass -x \"del C:\\Windows\\sysvol\\sysvol\\SECURITY && del C:\\Windows\\sysvol\\sysvol\\SAM && del C:\\Windows\\sysvol\\sysvol\\SYSTEM\"")  # noqa: Q003
         else:
             context.log.display("Successfully deleted dump files !")
+
+    def _strip_root_key(self, dce, key_name):
+        # Let's strip the root key
+        key_name.split("\\")[0]
+        sub_key = "\\".join(key_name.split("\\")[1:])
+        ans = rrp.hOpenLocalMachine(dce)
+        h_root_key = ans["phKey"]
+        return h_root_key, sub_key


### PR DESCRIPTION
## Description

Accidentally removed a function in the backup_operators module in PR https://github.com/Pennyw0rth/NetExec/pull/918. This PR fixes the issue.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Try the module

## Screenshots (if appropriate):
Before&After:
<img width="1593" height="1103" alt="image" src="https://github.com/user-attachments/assets/27d683ec-6909-4605-948c-9b85b6952556" />
