### PR TITLE
Catch dns resolver issue when domain can't be resolved

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1648,7 +1648,11 @@ class ldap(connection):
         self.logger.highlight("Resolved collection methods: " + ", ".join(list(collect)))
 
         self.logger.debug("Using DNS to retrieve domain information")
-        ad.dns_resolve(domain=self.domain)
+        try:
+            ad.dns_resolve(domain=self.domain)
+        except resolver.LifetimeTimeout:
+            self.logger.fail("Bloodhound-python failed to resolve domain information, try specifying the DNS server.")
+            return None
 
         if self.args.kerberos:
             self.logger.highlight("Using kerberos auth without ccache, getting TGT")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1665,16 +1665,21 @@ class ldap(connection):
         bloodhound = BloodHound(ad, self.hostname, self.host, self.port)
         bloodhound.connect()
 
-        bloodhound.run(
-            collect=collect,
-            num_workers=10,
-            disable_pooling=False,
-            timestamp=timestamp,
-            fileNamePrefix=self.output_filename.split("/")[-1],
-            computerfile=None,
-            cachefile=None,
-            exclude_dcs=False,
-        )
+        try:
+            bloodhound.run(
+                collect=collect,
+                num_workers=10,
+                disable_pooling=False,
+                timestamp=timestamp,
+                fileNamePrefix=self.output_filename.split("/")[-1],
+                computerfile=None,
+                cachefile=None,
+                exclude_dcs=False,
+            )
+        except Exception as e:
+            self.logger.fail(f"BloodHound collection failed: {e.__class__.__name__} - {e}")
+            self.logger.debug(f"BloodHound collection failed: {e.__class__.__name__} - {e}", exc_info=True)
+            return None
 
         self.output_filename += f"_{timestamp}"
 

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1650,7 +1650,7 @@ class ldap(connection):
         self.logger.debug("Using DNS to retrieve domain information")
         try:
             ad.dns_resolve(domain=self.domain)
-        except resolver.LifetimeTimeout:
+        except (resolver.LifetimeTimeout, resolver.NoNameservers):
             self.logger.fail("Bloodhound-python failed to resolve domain information, try specifying the DNS server.")
             return None
 


### PR DESCRIPTION
## Description

When the DNS of the attacker machine is not correctly configured bloodhound-python tends to throw an Exception because the DNS resolution times out. 
This PR will catch these stack traces and display an appropriate error message.

Also catches Exceptions which are raised while bloodhound-python is running, e.g. LDAPSocketOpenError.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Run the bloodhound collector against a lab machine without dns resolution of the domain

## Screenshots (if appropriate):
Before&After:
<img width="1532" height="1103" alt="image" src="https://github.com/user-attachments/assets/57b1c9fa-c411-47ab-b81e-ec56b1b0bf93" />
Before&After:

<img width="1584" height="1094" alt="image" src="https://github.com/user-attachments/assets/880c8147-6067-4e0e-9723-67c2f3a9b5c9" />
