### PR TITLE
add rusthound-ce integration

### DIFF
--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -45,5 +45,51 @@ def proto_args(parser, parents):
     bgroup = ldap_parser.add_argument_group("Bloodhound Scan", "Options to play with Bloodhoud")
     bgroup.add_argument("--bloodhound", action="store_true", help="Perform a Bloodhound scan")
     bgroup.add_argument("-c", "--collection", default="Default", help="Which information to collect. Supported: Group, LocalAdmin, Session, Trusts, Default, DCOnly, DCOM, RDP, PSRemote, LoggedOn, Container, ObjectProps, ACL, All. You can specify more than one by separating them with a comma")
+    rh = ldap_parser.add_argument_group("RustHound-CE")
+    rh.add_argument(
+        "--rusthound",
+        action="store_true",
+        help="Use RustHound-CE collector instead of BloodHound.py",
+    )
+    rh.add_argument(
+        "--rh-bin",
+        default="rusthound-ce",
+        help="Path/binary name for RustHound-CE (default: rusthound-ce)",
+    )
+    rh.add_argument(
+        "--rh-output",
+        default=None,
+        help="Output ZIP/dir path for RustHound results (default: temp dir)",
+    )
+    rh.add_argument(
+        "--rh-collection", default="All", help="RustHound collection set (default: All)"
+    )
+    rh.add_argument(
+        "--rh-domain",
+        default=None,
+        help="Override AD domain (auto-detected if omitted)",
+    )
+    rh.add_argument(
+        "--rh-zip",
+        action="store_true",
+        help="Ask RustHound to zip results if supported; otherwise NetExec zips",
+    )
+    rh.add_argument(
+        "--rh-extra",
+        default=None,
+        help="Extra args to pass through to RustHound (quoted string)",
+    )
 
+    # Ingest behavior: reuse existing BloodHound ingest to push results
+    rh.add_argument(
+        "--rh-ingest",
+        action="store_true",
+        help="After collection, reuse NetExec BloodHound ingest to push results",
+    )
+    rh.add_argument(
+        "--rh-timeout",
+        type=int,
+        default=900,
+        help="Timeout in seconds for RustHound collection (default: 900s)",
+    )
     return parser


### PR DESCRIPTION
## Description

This PR introduces RustHound-CE integration into NetExec’s LDAP module as an alternative to BloodHound collection.
When the --rusthound flag is used, NetExec will automatically invoke the rusthound-ce binary, passing mapped LDAP credentials, domain, DC target, and collection parameters from the active NetExec session.

If the user specifies a .zip path with --rh-output, JSON data from RustHound-CE is automatically packaged into a ZIP archive at the requested destination.
This change mirrors the existing BloodHound ingestion workflow while adding support for RustHound-CE’s enhanced enumeration and PKI collection capabilities.

Fixes/Implements: Enhancement to enable RustHound-CE support in NetExec
Dependencies:

Requires RustHound-CE binary (cargo install rusthound-ce or download from https://github.com/C-Sto/RustHound-CE

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Environment used for validation:

Host OS: Linux Mint 22.1


RustHound-CE: v2.4.0

Target: Windows Server 2019 domain controller (tombwatcher.htb)

Command tested:
## Screenshots (if appropriate):
<img width="2880" height="1288" alt="image" src="https://github.com/user-attachments/assets/388e256c-3814-4d15-8c7d-7450f55cbf27" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
