### PR TITLE
Add stderr printing to winrm execution

### DIFF
--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -5,7 +5,6 @@ import urllib3
 import logging
 import xml.etree.ElementTree as ET
 
-from io import StringIO
 from datetime import datetime
 from pypsrp.wsman import NAMESPACES
 from pypsrp.client import Client


### PR DESCRIPTION
## Description

The winrm execution returns the `return code` as parameter 3 of the tuple. The tuple is of form `("stdout", "stderr", returnCode)`. Therefore, to get errors we need to display `result[1]` when the return code is != 0.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Execute a command that would fail

## Screenshots
Before&After:
<img width="1193" height="320" alt="image" src="https://github.com/user-attachments/assets/574739ee-9316-4270-ba38-1ab67a2ccee7" />


