### PR TITLE
Fix/mssql xpcmdshell permission check

### DIFF
--- a/nxc/modules/enable_cmdshell.py
+++ b/nxc/modules/enable_cmdshell.py
@@ -46,8 +46,7 @@ class NXCModule:
 
     def backup_show_advanced_options(self):
         """Backs up the current state of 'show advanced options'."""
-        query = "SELECT CAST(value AS INT) AS value FROM sys.configurations WHERE name = 'show advanced options'"
-        res = self.mssql_conn.sql_query(query)
+        res = self.mssql_conn.sql_query("SELECT CAST(value AS INT) AS value FROM sys.configurations WHERE name = 'show advanced options'")
         if res:
             self.advanced_options_backup = int(res[0]["value"])  # Convert to integer
 


### PR DESCRIPTION
## Description

This PR fixes issue [#959](https://github.com/Pennyw0rth/NetExec/issues/959), where the `enable_cmdshell` MSSQL module displayed `xp_cmdshell successfully enabled` even when the user lacked `RECONFIGURE` permissions.

Now, before attempting to enable `xp_cmdshell`, the module performs:

A silent permission check using
`HAS_PERMS_BY_NAME(NULL, 'SERVER', 'ALTER SETTINGS')` and `IS_SRVROLEMEMBER('sysadmin')`.

A verification of `sys.configurations.value_in_use` to confirm the actual runtime state.

If the user lacks the required permissions, NetExec will now correctly display:
```
[-] You do not have permission to enable xp_cmdshell.
```

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)


## Screenshots (if appropriate):

Before :
<img width="1908" height="714" alt="1" src="https://github.com/user-attachments/assets/4f1fa290-1df7-4e13-a3b8-9c58a38b34dd" />

After : 
<img width="1911" height="642" alt="2" src="https://github.com/user-attachments/assets/6c7b0645-71f2-4ec3-b474-2d59729d6c95" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
