### PR TITLE
Fix winrm output for powershell

### DIFF
--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -265,19 +265,14 @@ class winrm(connection):
                     result: tuple[str, PSDataStreams, bool]
                     if result[2]:
                         self.logger.fail("Error executing powershell command, non-zero return code")
-                    # Display all channels of the PSDataStreams
-                    for msg in result[1].debug:
-                        self.logger.debug(str(msg).rstrip())
-                    for msg in result[1].verbose:
-                        self.logger.display(str(msg).rstrip())
-                    for msg in result[1].information:
-                        self.logger.display(str(msg).rstrip())
-                    for msg in result[1].progress:
-                        self.logger.display(str(msg).rstrip())
-                    for msg in result[1].warning:
-                        self.logger.display(str(msg).rstrip())
-                    for msg in result[1].error:
-                        self.logger.fail(str(msg).rstrip())
+                    for out_type in ["debug", "verbose", "information", "progress", "warning", "error"]:
+                        stream: list[str] = getattr(result[1], out_type)
+                        for msg in stream:
+                            if str(msg) != "None":
+                                if out_type == "error":
+                                    self.logger.fail(str(msg).rstrip())
+                                else:
+                                    self.logger.display(str(msg).rstrip())
                     # Display stdout
                     for line in result[0].splitlines():
                         self.logger.highlight(line.rstrip())


### PR DESCRIPTION
## Description

When executing powershell over winrm the returned object also contains a PS Datastream object which has several streams for debug/info/warning etc. This PR implements these streams now.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
E.g. execute a non valid command over winrm powershell

## Screenshots (if appropriate):
Before&After:
<img width="1588" height="1105" alt="image" src="https://github.com/user-attachments/assets/1740cc9c-8123-4ee6-b9ca-94d33fbc0660" />
