### PR TITLE
Update firefox.py for new AES-256-CBC encryption (fix dpapi error)

### DIFF
--- a/nxc/protocols/smb/firefox.py
+++ b/nxc/protocols/smb/firefox.py
@@ -216,7 +216,7 @@ class FirefoxTriage:
             for row in cursor:
                 try:
                     a11 = row[0]
-                    a102 = row[1]
+                    a102 = row[1]  # noqa: F841
 
                     decoded_a11 = decoder.decode(a11)
                     key = self.decrypt_3des(decoded_a11, master_password, global_salt)
@@ -225,7 +225,6 @@ class FirefoxTriage:
                         keys.append(key)
                 except Exception:
                     continue
-
             return keys
 
         except Exception as e:


### PR DESCRIPTION
## Description

Add Firefox 144+ password decryption support

- Support new AES-256-CBC encryption format (16-byte IV)
- Extract all master keys from NSS database (Firefox 144+ uses multiple)
- Expand keys to 32 bytes using SHA-256 when needed
- Maintain backward compatibility with legacy 3DES-CBC format
- Try all available keys until successful decryption

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
The test should try to dump dpapi using the command : 
```
nxc smb <ip> -u <user> -p <pass> --dpapi
```
The target is a machine with passwords in Firefox >144, and another with Firefox <144 (for backwards compatibility)

## Screenshots (if appropriate):
The issue was : 
<img width="2582" height="989" alt="image" src="https://github.com/user-attachments/assets/87c864b1-7a2b-4073-a4e0-2b8a666358f3" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
