### PR TITLE
Fix nxcdb signing export

### DIFF
--- a/nxc/protocols/smb/database.py
+++ b/nxc/protocols/smb/database.py
@@ -461,18 +461,18 @@ class database(BaseDB):
             return [results]
         # if we're filtering by domain controllers
         elif filter_term == "dc":
-            q = q.filter(self.HostsTable.c.dc is True)
+            q = q.filter(self.HostsTable.c.dc == True)  # noqa: E712
             if domain:
                 q = q.filter(func.lower(self.HostsTable.c.domain) == func.lower(domain))
         elif filter_term == "signing":
             # generally we want hosts that are vulnerable, so signing disabled
-            q = q.filter(self.HostsTable.c.signing is False)
+            q = q.filter(self.HostsTable.c.signing == False)  # noqa: E712
         elif filter_term == "spooler":
-            q = q.filter(self.HostsTable.c.spooler is True)
+            q = q.filter(self.HostsTable.c.spooler == True)  # noqa: E712
         elif filter_term == "zerologon":
-            q = q.filter(self.HostsTable.c.zerologon is True)
+            q = q.filter(self.HostsTable.c.zerologon == True)  # noqa: E712
         elif filter_term == "petitpotam":
-            q = q.filter(self.HostsTable.c.petitpotam is True)
+            q = q.filter(self.HostsTable.c.petitpotam == True)  # noqa: E712
         elif filter_term is not None and filter_term.startswith("domain"):
             domain = filter_term.split()[1]
             like_term = func.lower(f"%{domain}%")


### PR DESCRIPTION
## Description

As report in #976 when chosing the `signing` export option nothing was exported. This is due to the way sqlalchemy handles filtering in sql requests. In python it is possible to replace `if x == y` with `if x is y`, while in sqlalchemy it is not:
<img width="1318" height="165" alt="image" src="https://github.com/user-attachments/assets/ef7bd332-b6c1-4c69-834b-81c37b9f0ef3" />
<img width="1284" height="164" alt="image" src="https://github.com/user-attachments/assets/7a60af5f-491f-4bae-83db-1d023b0d507c" />

This is fixed by this PR, rolling back linting changes that introduced the bug.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Export hosts with signing options from the db

## Screenshots (if appropriate):
Before&After:
<img width="1545" height="793" alt="image" src="https://github.com/user-attachments/assets/192b548a-89ac-4390-b9ce-871d87d1d882" />
<img width="1530" height="969" alt="image" src="https://github.com/user-attachments/assets/05ca58bd-129f-4764-b2be-7f720a4ccdcb" />
