### PR TITLE
GhostSPN SMB module

### DIFF
--- a/nxc/modules/ghostspn.py
+++ b/nxc/modules/ghostspn.py
@@ -14,7 +14,7 @@ class NXCModule:
     category = CATEGORY.ENUMERATION
 
     # Reference table from MSRC report
-    # https://msrc.microsoft.com/update-guide/fr-FRS/vulnerability/CVE-2025-33073
+    # https://msrc.microsoft.com/update-guide/fr-FRS/vulnerability/CVE-2025-58726
     MSRC_PATCHES = {    # key = (major, minor, build), value = minimum patched UBR
         (6, 1, 7601): 23571,      # Windows Server 2008 SP2
         (6, 1, 7601): 27974,      # Windows Server 2008 R2 SP1


### PR DESCRIPTION
Module to scan SMB for GhostSPN vulnerability (CVE-2025-58726) based on build number (code taken from ntlm_reflection module).

I am not sure if there is a more accurate way to scan for it, but for the moment it does the job.

<img width="1896" height="966" alt="ghostspn" src="https://github.com/user-attachments/assets/36b8da52-96a1-4e6b-bdd4-b98bed1184eb" />
