### PR TITLE
enum_av module: add FortiClient and FortiEDR indicators

### DIFF
--- a/nxc/modules/enum_av.py
+++ b/nxc/modules/enum_av.py
@@ -289,7 +289,7 @@ conf = {
             ],
             "pipes": [{"name": "nod_scriptmon_pipe", "processes": [""]}],
         },
-	{
+        {
             "name": "FortiClient",
             "services": [
                 {"name": "FA_Scheduler", "description": "FortiClient Service Scheduler"},


### PR DESCRIPTION
## Description

Added FortiClient and FortiEDR indicators for `enum_av.py` module.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Tested `enum_av.py` module against a Windows machine with FortiClient and FortiEDR installed.

## Screenshots (if appropriate):
<img width="1561" height="132" alt="forti_installed" src="https://github.com/user-attachments/assets/b92a9263-c131-4a19-b294-c1f25894c6ed" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
