### PR TITLE
Adding OpenGraph export functionality for BloodHound

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -50,7 +50,10 @@ def gen_cli_args():
 
     opengraph_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
     opengraph_group = dns_parser.add_argument_group("OpenGraph")
-    opengraph_group.add_argument("--opengraph", metavar="JSON_PATH", help="Enable OpenGraph, takes path to bloudhound computer json file as arguments")
+    opengraph_group.add_argument("-og", "--opengraph", action="store_true", help="Enable OpenGraph, takes path to bloudhound computer json file as arguments")
+    og_exclusive = opengraph_group.add_mutually_exclusive_group()
+    og_exclusive.add_argument("--og-path", metavar="og_path", help="Path to BloodHound directory or ZIP file for resolving OIDs.")
+    og_exclusive.add_argument("--og-ldap", action="store_true", help="Resolve OIDs via LDAP instead of using BloodHound data.")
 
     parser = argparse.ArgumentParser(
         description=rf"""

--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -48,6 +48,10 @@ def gen_cli_args():
     dns_group.add_argument("--dns-tcp", action="store_true", help="Use TCP instead of UDP for DNS queries")
     dns_group.add_argument("--dns-timeout", action="store", type=int, default=3, help="DNS query timeout in seconds")
 
+    opengraph_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
+    opengraph_group = dns_parser.add_argument_group("OpenGraph")
+    opengraph_group.add_argument("--opengraph", metavar="JSON_PATH", help="Enable OpenGraph, takes path to bloudhound computer json file as arguments")
+
     parser = argparse.ArgumentParser(
         description=rf"""
      .   .
@@ -82,7 +86,7 @@ def gen_cli_args():
 
     subparsers = parser.add_subparsers(title="Available Protocols", dest="protocol")
 
-    std_parser = argparse.ArgumentParser(add_help=False, parents=[generic_parser, output_parser, dns_parser], formatter_class=DisplayDefaultsNotNone)
+    std_parser = argparse.ArgumentParser(add_help=False, parents=[generic_parser, output_parser, dns_parser, opengraph_parser], formatter_class=DisplayDefaultsNotNone)
     std_parser.add_argument("target", nargs="+" if not (module_parser.parse_known_args()[0].list_modules is not None or module_parser.parse_known_args()[0].show_module_options or generic_parser.parse_known_args()[0].version) else "*", type=str, help="the target IP(s), range(s), CIDR(s), hostname(s), FQDN(s), file(s) containing a list of targets, NMap XML or .Nessus file(s)")
     credential_group = std_parser.add_argument_group("Authentication")
     credential_group.add_argument("-u", "--username", metavar="USERNAME", dest="username", nargs="+", default=[], help="username(s) or file(s) containing usernames")

--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -53,7 +53,7 @@ def gen_cli_args():
     opengraph_group.add_argument("-og", "--opengraph", action="store_true", help="Enable OpenGraph, takes path to bloudhound computer json file as arguments")
     og_exclusive = opengraph_group.add_mutually_exclusive_group()
     og_exclusive.add_argument("--og-path", metavar="og_path", help="Path to BloodHound directory or ZIP file for resolving OIDs.")
-    og_exclusive.add_argument("--og-ldap", action="store_true", help="Resolve OIDs via LDAP instead of using BloodHound data.")
+    og_exclusive.add_argument("--og-ldap", metavar="og_ldap_host", help="IP/hostname of an LDAP server to resolve OIDs against (uses the same credentials).")
 
     parser = argparse.ArgumentParser(
         description=rf"""

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -20,6 +20,7 @@ from nxc.context import Context
 from nxc.paths import NXC_PATH
 from nxc.protocols.ldap.laps import laps_search
 from nxc.helpers.pfx import pfx_auth
+from nxc.helpers.opengraph import opengraph
 
 from impacket.dcerpc.v5 import transport
 from impacket.krb5.ccache import CCache
@@ -220,6 +221,9 @@ class connection:
     def print_host_info(self):
         return
 
+    def opengraph_host_info(self):
+        pass
+
     def create_conn_obj(self):
         return
 
@@ -246,6 +250,10 @@ class connection:
         else:
             self.logger.debug("Created connection object")
             self.enum_host_info()
+
+            # adding host info to opengraph file
+            if self.args.opengraph is not None:
+                self.opengraph_host_info()
 
             # Construct the output file template using os.path.join for OS compatibility
             base_log_dir = os.path.join(NXC_PATH, "logs")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -20,7 +20,6 @@ from nxc.context import Context
 from nxc.paths import NXC_PATH
 from nxc.protocols.ldap.laps import laps_search
 from nxc.helpers.pfx import pfx_auth
-from nxc.helpers.opengraph import opengraph
 
 from impacket.dcerpc.v5 import transport
 from impacket.krb5.ccache import CCache

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -250,10 +250,6 @@ class connection:
             self.logger.debug("Created connection object")
             self.enum_host_info()
 
-            # adding host info to opengraph file
-            if self.args.opengraph is not None:
-                self.opengraph_host_info()
-
             # Construct the output file template using os.path.join for OS compatibility
             base_log_dir = os.path.join(NXC_PATH, "logs")
             filename_pattern = f"{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}".replace(":", "-")
@@ -263,6 +259,9 @@ class connection:
 
             self.print_host_info()
             if self.login() or (self.username == "" and self.password == "" and self.protocol != "mssql"):
+                # Collect host info for opengraph
+                if self.args.opengraph:
+                    self.opengraph_host_info()
                 self.logger.debug("Calling command arguments")
                 self.call_cmd_args()
                 if self.args.module:

--- a/nxc/data/opengraph/netexec_opengraph_queries.md
+++ b/nxc/data/opengraph/netexec_opengraph_queries.md
@@ -1,0 +1,109 @@
+# NetExec OpenGraph - BloodHound-CE custom queries
+
+Copy/paste these Cypher queries into BloodHound-CE (Explore → Cypher, or save them as
+Custom Queries). They filter on the **tags** NetExec adds via OpenGraph.
+
+> Tag keys from `enum_cve` contain spaces/slashes, so they are wrapped in backticks
+> (e.g. `` c.`NTLM reflection` ``).
+
+## Vulnerabilities
+
+**All computers with any NetExec vulnerability tag**
+```cypher
+MATCH (c:Computer) WHERE c.zerologon = true OR c.nopac = true OR c.ms17_010 = true OR c.smbghost = true OR c.cve_2019_1040 = true OR c.printnightmare = true OR c.webclientrunning = true OR c.ntlm_reflection = true OR c.`NTLM reflection` = true OR c.`Ghost SPN` = true OR c.`NTLM MIC Bypass` = true OR c.`BadSuccessor` = true OR c.`ESC15 / EKUwu` = true RETURN c
+```
+
+**Zerologon vulnerable (CVE-2020-1472)**
+```cypher
+MATCH (c:Computer) WHERE c.zerologon = true RETURN c
+```
+
+**noPac vulnerable (CVE-2021-42278/42287)**
+```cypher
+MATCH (c:Computer) WHERE c.nopac = true RETURN c
+```
+
+**MS17-010 / EternalBlue vulnerable**
+```cypher
+MATCH (c:Computer) WHERE c.ms17_010 = true RETURN c
+```
+
+**SMBGhost vulnerable (CVE-2020-0796)**
+```cypher
+MATCH (c:Computer) WHERE c.smbghost = true RETURN c
+```
+
+**Drop-the-MIC vulnerable (CVE-2019-1040)**
+```cypher
+MATCH (c:Computer) WHERE c.cve_2019_1040 = true RETURN c
+```
+
+**PrintNightmare vulnerable (CVE-2021-34527)**
+```cypher
+MATCH (c:Computer) WHERE c.printnightmare = true RETURN c
+```
+
+**WebClient / WebDAV running (relay to ADCS/LDAP)**
+```cypher
+MATCH (c:Computer) WHERE c.webclientrunning = true RETURN c
+```
+
+**NTLM reflection vulnerable (CVE-2025-33073)**
+```cypher
+MATCH (c:Computer) WHERE c.ntlm_reflection = true OR c.`NTLM reflection` = true RETURN c
+```
+
+**Ghost SPN vulnerable (CVE-2025-58726)**
+```cypher
+MATCH (c:Computer) WHERE c.`Ghost SPN` = true RETURN c
+```
+
+**NTLM MIC Bypass vulnerable (CVE-2025-54918)**
+```cypher
+MATCH (c:Computer) WHERE c.`NTLM MIC Bypass` = true RETURN c
+```
+
+**BadSuccessor vulnerable (CVE-2025-53779)**
+```cypher
+MATCH (c:Computer) WHERE c.`BadSuccessor` = true RETURN c
+```
+
+**ESC15 / EKUwu vulnerable (CVE-2024-49019)**
+```cypher
+MATCH (c:Computer) WHERE c.`ESC15 / EKUwu` = true RETURN c
+```
+
+## Host configuration
+
+**SMB signing NOT required (relay targets)**
+```cypher
+MATCH (c:Computer) WHERE c.smbsigning = false RETURN c
+```
+
+**LDAP signing NOT required**
+```cypher
+MATCH (c:Computer) WHERE c.ldapsigning = false RETURN c
+```
+
+**LDAPS channel binding NOT enforced**
+```cypher
+MATCH (c:Computer) WHERE c.ldaps_channel_binding IS NOT NULL AND c.ldaps_channel_binding <> 'Always' RETURN c
+```
+
+**RDP NLA disabled**
+```cypher
+MATCH (c:Computer) WHERE c.rdp_nla = false RETURN c
+```
+
+
+## MSSQL
+
+**MSSQL servers**
+```cypher
+MATCH (c:Computer) WHERE c.mssql_present = true RETURN c
+```
+
+**MSSQL servers with encryption disabled**
+```cypher
+MATCH (c:Computer) WHERE c.mssql_present = true AND c.mssql_encryption = false RETURN c
+```

--- a/nxc/data/opengraph/netexec_opengraph_queries.md
+++ b/nxc/data/opengraph/netexec_opengraph_queries.md
@@ -1,109 +1,95 @@
 # NetExec OpenGraph - BloodHound-CE custom queries
 
-Copy/paste these Cypher queries into BloodHound-CE (Explore → Cypher, or save them as
-Custom Queries). They filter on the **tags** NetExec adds via OpenGraph.
+Copy/paste these Cypher queries into BloodHound-CE (Explore → Cypher, or save as Custom
+Queries). They combine the **tags** NetExec adds via OpenGraph with BloodHound's native
+graph so you can prioritize targets and find attack paths.
 
-> Tag keys from `enum_cve` contain spaces/slashes, so they are wrapped in backticks
-> (e.g. `` c.`NTLM reflection` ``).
 
-## Vulnerabilities
+---
 
-**All computers with any NetExec vulnerability tag**
+## 1. Servers with specific roles vulnerable
+
+**All DCs vulnerable**
 ```cypher
-MATCH (c:Computer) WHERE c.zerologon = true OR c.nopac = true OR c.ms17_010 = true OR c.smbghost = true OR c.cve_2019_1040 = true OR c.printnightmare = true OR c.webclientrunning = true OR c.ntlm_reflection = true OR c.`NTLM reflection` = true OR c.`Ghost SPN` = true OR c.`NTLM MIC Bypass` = true OR c.`BadSuccessor` = true OR c.`ESC15 / EKUwu` = true RETURN c
+MATCH (c:Computer)-[:MemberOf*1..]->(dc:Group)
+WHERE dc.objectid ENDS WITH '-516' AND (c.zerologon = true OR c.nopac = true OR c.`NTLM MIC Bypass` = true OR c.`BadSuccessor`)
+RETURN c
 ```
 
-**Zerologon vulnerable (CVE-2020-1472)**
-```cypher
-MATCH (c:Computer) WHERE c.zerologon = true RETURN c
+**All CAs vulnerable**
+```
+MATCH (c:Computer)-[:HostsCAService]->(:EnterpriseCA)
+WHERE c.`ESC15 / EKUwu`=true OR c.Certighost=true
+RETURN c
 ```
 
-**noPac vulnerable (CVE-2021-42278/42287)**
+---
+
+## 2. All vulnerable hosts → Domain Admins 
+
+
+**All hosts with any NetExec vulnerability tag**
 ```cypher
-MATCH (c:Computer) WHERE c.nopac = true RETURN c
+MATCH (c:Computer)
+WHERE c.ms17_010 = true OR c.smbghost = true OR c.cve_2019_1040 = true OR c.printnightmare = true OR c.webclientrunning = true OR c.`NTLM reflection` = true OR c.`Ghost SPN` = true
+RETURN c
 ```
 
-**MS17-010 / EternalBlue vulnerable**
+**Vulnerable hosts where a Domain Admin has a session**
 ```cypher
-MATCH (c:Computer) WHERE c.ms17_010 = true RETURN c
+MATCH p = (c:Computer)-[:HasSession]->(u)-[:MemberOf*1..]->(g:Group)
+WHERE (c.ms17_010 = true OR c.smbghost = true OR c.cve_2019_1040 = true OR c.printnightmare = true OR c.webclientrunning = true OR c.`NTLM reflection` = true OR c.`Ghost SPN` = true)
+  AND g.objectid ENDS WITH '-512'
+RETURN p
 ```
 
-**SMBGhost vulnerable (CVE-2020-0796)**
+**Shortest path from any vulnerable host to Domain Admins**
 ```cypher
-MATCH (c:Computer) WHERE c.smbghost = true RETURN c
+MATCH (c:Computer)
+WHERE cc.ms17_010 = true OR c.smbghost = true OR c.cve_2019_1040 = true OR c.printnightmare = true OR c.webclientrunning = true OR c.`NTLM reflection` = true OR c.`Ghost SPN` = true
+MATCH p = shortestPath((c)-[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|ForceChangePassword|AllExtendedRights|AddMember|HasSession|GPLink|AllowedToDelegate|CoerceToTGT|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|HasSIDHistory|AddSelf|DCSync|ReadLAPSPassword|ReadGMSAPassword|DumpSMSAPassword|SQLAdmin|AddAllowedToAct|WriteSPN|AddKeyCredentialLink|SyncLAPSPassword|WriteAccountRestrictions|WriteGPLink|GoldenCert|ADCSESC1|ADCSESC3|ADCSESC4|ADCSESC6a|ADCSESC6b|ADCSESC9a|ADCSESC9b|ADCSESC10a|ADCSESC10b|ADCSESC13|HasTrustKeys|ManageCA|ManageCertificates|Contains|SameForestTrust|SpoofSIDHistory|AbuseTGTDelegation*1..]->(g:Group))
+WHERE g.objectid ENDS WITH '-512'
+RETURN p
 ```
 
-**Drop-the-MIC vulnerable (CVE-2019-1040)**
+---
+
+## 3. Coercion / NTLM-relay quick lists
+
+
+**SMB signing NOT required — shortest path to Domain Admins**
 ```cypher
-MATCH (c:Computer) WHERE c.cve_2019_1040 = true RETURN c
+MATCH (c:Computer)
+WHERE c.smbsigning = false
+MATCH p = shortestPath((c)-[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|ForceChangePassword|AllExtendedRights|AddMember|HasSession|GPLink|AllowedToDelegate|CoerceToTGT|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|HasSIDHistory|AddSelf|DCSync|ReadLAPSPassword|ReadGMSAPassword|DumpSMSAPassword|SQLAdmin|AddAllowedToAct|WriteSPN|AddKeyCredentialLink|SyncLAPSPassword|WriteAccountRestrictions|WriteGPLink|GoldenCert|ADCSESC1|ADCSESC3|ADCSESC4|ADCSESC6a|ADCSESC6b|ADCSESC9a|ADCSESC9b|ADCSESC10a|ADCSESC10b|ADCSESC13|HasTrustKeys|ManageCA|ManageCertificates|Contains|SameForestTrust|SpoofSIDHistory|AbuseTGTDelegation*1..]->(g:Group))
+WHERE g.objectid ENDS WITH '-512'
+RETURN p
 ```
 
-**PrintNightmare vulnerable (CVE-2021-34527)**
+**LDAP signing not required / LDAPS channel binding not enforced**
 ```cypher
-MATCH (c:Computer) WHERE c.printnightmare = true RETURN c
+MATCH (c:Computer) WHERE c.ldapsigning = false OR (c.ldaps_channel_binding IS NOT NULL AND c.ldaps_channel_binding <> 'Always') RETURN c
 ```
 
-**WebClient / WebDAV running (relay to ADCS/LDAP)**
-```cypher
-MATCH (c:Computer) WHERE c.webclientrunning = true RETURN c
-```
+---
 
-**NTLM reflection vulnerable (CVE-2025-33073)**
-```cypher
-MATCH (c:Computer) WHERE c.ntlm_reflection = true OR c.`NTLM reflection` = true RETURN c
-```
-
-**Ghost SPN vulnerable (CVE-2025-58726)**
-```cypher
-MATCH (c:Computer) WHERE c.`Ghost SPN` = true RETURN c
-```
-
-**NTLM MIC Bypass vulnerable (CVE-2025-54918)**
-```cypher
-MATCH (c:Computer) WHERE c.`NTLM MIC Bypass` = true RETURN c
-```
-
-**BadSuccessor vulnerable (CVE-2025-53779)**
-```cypher
-MATCH (c:Computer) WHERE c.`BadSuccessor` = true RETURN c
-```
-
-**ESC15 / EKUwu vulnerable (CVE-2024-49019)**
-```cypher
-MATCH (c:Computer) WHERE c.`ESC15 / EKUwu` = true RETURN c
-```
-
-## Host configuration
-
-**SMB signing NOT required (relay targets)**
-```cypher
-MATCH (c:Computer) WHERE c.smbsigning = false RETURN c
-```
-
-**LDAP signing NOT required**
-```cypher
-MATCH (c:Computer) WHERE c.ldapsigning = false RETURN c
-```
-
-**LDAPS channel binding NOT enforced**
-```cypher
-MATCH (c:Computer) WHERE c.ldaps_channel_binding IS NOT NULL AND c.ldaps_channel_binding <> 'Always' RETURN c
-```
-
-**RDP NLA disabled**
-```cypher
-MATCH (c:Computer) WHERE c.rdp_nla = false RETURN c
-```
-
-
-## MSSQL
+## 4. MSSQL
 
 **MSSQL servers**
 ```cypher
 MATCH (c:Computer) WHERE c.mssql_present = true RETURN c
 ```
 
-**MSSQL servers with encryption disabled**
+**MSSQL servers with encryption disabled (sniff/relay TDS)**
 ```cypher
 MATCH (c:Computer) WHERE c.mssql_present = true AND c.mssql_encryption = false RETURN c
+```
+
+**Shortest path from an MSSQL server to Domain Admins (prioritize SQL footholds)**
+```cypher
+MATCH (c:Computer)
+WHERE c.mssql_present = true
+MATCH p = shortestPath((c)-[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|AddMember|HasSession|AllowedToDelegate|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|DCSync|ReadLAPSPassword|ReadGMSAPassword|SQLAdmin|AddKeyCredentialLink|Contains*1..]->(g:Group))
+WHERE g.objectid ENDS WITH '-512'
+RETURN p
 ```

--- a/nxc/helpers/opengraph.py
+++ b/nxc/helpers/opengraph.py
@@ -78,9 +78,6 @@ class OpenGraph:
     def to_dict(self):
         """Return the full OpenGraph dict."""
         return {
-            "metadata": {
-                "source_kind": "NetExec"
-            },
             "graph": {
                 "nodes": [
                     {"id": nid, **ndata} for nid, ndata in self.nodes.items()

--- a/nxc/helpers/opengraph.py
+++ b/nxc/helpers/opengraph.py
@@ -1,0 +1,98 @@
+import json
+import os
+from nxc.paths import NXC_PATH
+from datetime import datetime
+from nxc.logger import nxc_logger
+
+
+class OpenGraph:
+    # Collects nodes and properties for BloodHound-CE OpenGraph import.
+
+    def __init__(self):
+        self.nodes = {}  # id -> node
+        self.fqdn2oid = {}  # fqdn -> Object ID
+
+    def add_node(self, node_id: str, kinds=None, properties=None):
+        """Add a new node, or merge with an existing one."""
+        node_id = node_id.strip().lower()
+        if node_id not in self.nodes:
+            self.nodes[node_id] = {
+                "kinds": kinds or ["Computer", "Base"],
+                "properties": {},
+            }
+        else:
+            node = self.nodes[node_id]
+            if kinds:
+                for k in kinds:
+                    if k not in node["kinds"]:
+                        node["kinds"].append(k)
+            if properties:
+                node["properties"].update(properties)
+
+    def add_tag(self, node_id: str, tag_name: str, value=True):
+        node_id = node_id.strip().lower()
+        # Add a property/tag
+        self.add_node(node_id)  # ensure node exists
+        self.nodes[node_id]["properties"][tag_name] = value
+
+    def simple_bh_mapping(self, path):
+        """
+        Build a mapping from host identifiers -> BloodHound node ID
+        using *_computers.json files.
+        """
+        mapping = {}
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        for computers in data.get("data", {}):
+            oid = computers.get("ObjectIdentifier")
+            props = computers.get("Properties", {})
+            mapping[props["name"].strip().lower()] = oid
+        return mapping
+
+    def update_node_ids_to_guids(self, path):
+        """
+        Replace node 'id' values that match resolved hostnames with GUIDs.
+        Does not alter properties or kinds.
+        """
+        self.fqdn2oid = self.simple_bh_mapping(path)
+        updated_nodes = {}
+        for nid, ndata in self.nodes.items():
+            new_id = self.fqdn2oid.get(nid.strip().lower(), nid)
+            updated_nodes[new_id] = ndata
+        self.nodes = updated_nodes
+
+    def to_dict(self):
+        """Return the full OpenGraph dict"""
+        return {
+            "graph": {
+                "nodes": [
+                    {"id": nid, **ndata} for nid, ndata in self.nodes.items()
+                ]
+            }
+        }
+
+    def to_json(self, indent=2):
+        """Return JSON string"""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def save(self):
+        """Write JSON to file"""
+        if self.nodes == {}:
+            nxc_logger.display("Nothing to add to OpenGaph file")
+
+        # Construct the output file template using os.path.join for OS compatibility
+        base_log_dir = os.path.join(NXC_PATH, "logs")
+        filename_pattern = f"OpenGraph_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.json".replace(":", "-")
+        self.output_file_template = os.path.join(base_log_dir, filename_pattern)
+        # Default output filename for logs
+        self.output_filename = os.path.join(base_log_dir, filename_pattern)
+        try:
+            with open(self.output_filename, "w", encoding="utf-8") as f:
+                json.dump(self.to_dict(), f, indent=2)
+            nxc_logger.display(f"OpenGraph file successfully saved at {self.output_filename}")
+        except Exception as e:
+            nxc_logger.fail(f"Failed to save OpenGraph file: {e}")
+
+
+# Global instance usable anywhere
+opengraph = OpenGraph()

--- a/nxc/helpers/opengraph.py
+++ b/nxc/helpers/opengraph.py
@@ -6,15 +6,16 @@ from nxc.logger import nxc_logger
 
 
 class OpenGraph:
-    # Collects nodes and properties for BloodHound-CE OpenGraph import.
+    # Collects nodes, edges, and properties for BloodHound-CE OpenGraph import.
 
     def __init__(self):
         self.nodes = {}  # id -> node
+        self.edges = []  # list of edges
         self.fqdn2oid = {}  # fqdn -> Object ID
 
-    def add_node(self, node_id: str, kinds=None, properties=None):
+    def add_node(self, node_id, kinds=None, properties=None):
         """Add a new node, or merge with an existing one."""
-        node_id = node_id.strip().lower()
+        node_id = node_id.strip()
         if node_id not in self.nodes:
             self.nodes[node_id] = {
                 "kinds": kinds or ["Computer", "Base"],
@@ -29,17 +30,42 @@ class OpenGraph:
             if properties:
                 node["properties"].update(properties)
 
-    def add_tag(self, node_id: str, tag_name: str, value=True):
+    def add_tag(self, node_id, tag_name, value):
+        """Add a property/tag (e.g., module vulnerability flag)."""
         node_id = node_id.strip().lower()
-        # Add a property/tag
+        if node_id in self.fqdn2oid:
+            node_id = self.fqdn2oid[node_id]
         self.add_node(node_id)  # ensure node exists
         self.nodes[node_id]["properties"][tag_name] = value
 
+    def add_edge(self, kind, start, end, start_match_by="id", end_match_by="id"):
+        """
+        Add a relationship (edge) between two nodes.
+
+        Automatically replaces FQDNs with GUIDs if:
+          - match_by == "id"
+          - and the value doesn't start with "S-1-5-21"
+        """
+        def resolve_if_needed(value, match_by):
+            if match_by == "id" and not value.strip().startswith("S-1-5-21"):  # if match by id and value is not an oid
+                # Try to map FQDN -> ObjectIdentifier if available
+                lookup = value.strip().lower()
+                if lookup in self.fqdn2oid:
+                    return self.fqdn2oid[lookup]
+            return value.strip()
+
+        resolved_start = resolve_if_needed(start, start_match_by)
+        resolved_end = resolve_if_needed(end, end_match_by)
+
+        edge = {
+            "kind": kind,
+            "start": {"value": resolved_start, "match_by": start_match_by},
+            "end": {"value": resolved_end, "match_by": end_match_by},
+        }
+        self.edges.append(edge)
+
     def simple_bh_mapping(self, path):
-        """
-        Build a mapping from host identifiers -> BloodHound node ID
-        using *_computers.json files.
-        """
+        """Build a mapping from host identifiers -> BloodHound node ID."""
         mapping = {}
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
@@ -47,45 +73,33 @@ class OpenGraph:
             oid = computers.get("ObjectIdentifier")
             props = computers.get("Properties", {})
             mapping[props["name"].strip().lower()] = oid
-        return mapping
-
-    def update_node_ids_to_guids(self, path):
-        """
-        Replace node 'id' values that match resolved hostnames with GUIDs.
-        Does not alter properties or kinds.
-        """
-        self.fqdn2oid = self.simple_bh_mapping(path)
-        updated_nodes = {}
-        for nid, ndata in self.nodes.items():
-            new_id = self.fqdn2oid.get(nid.strip().lower(), nid)
-            updated_nodes[new_id] = ndata
-        self.nodes = updated_nodes
+        self.fqdn2oid = mapping
 
     def to_dict(self):
-        """Return the full OpenGraph dict"""
+        """Return the full OpenGraph dict."""
         return {
             "graph": {
                 "nodes": [
                     {"id": nid, **ndata} for nid, ndata in self.nodes.items()
-                ]
+                ],
+                "edges": self.edges,
             }
         }
 
     def to_json(self, indent=2):
-        """Return JSON string"""
+        """Return JSON string."""
         return json.dumps(self.to_dict(), indent=indent)
 
     def save(self):
-        """Write JSON to file"""
-        if self.nodes == {}:
-            nxc_logger.display("Nothing to add to OpenGaph file")
+        """Write JSON to file."""
+        if not self.nodes and not self.edges:
+            nxc_logger.display("Nothing to add to OpenGraph file")
+            return
 
-        # Construct the output file template using os.path.join for OS compatibility
         base_log_dir = os.path.join(NXC_PATH, "logs")
-        filename_pattern = f"OpenGraph_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.json".replace(":", "-")
-        self.output_file_template = os.path.join(base_log_dir, filename_pattern)
-        # Default output filename for logs
+        filename_pattern = f"OpenGraph_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.json"
         self.output_filename = os.path.join(base_log_dir, filename_pattern)
+
         try:
             with open(self.output_filename, "w", encoding="utf-8") as f:
                 json.dump(self.to_dict(), f, indent=2)

--- a/nxc/helpers/opengraph.py
+++ b/nxc/helpers/opengraph.py
@@ -78,6 +78,9 @@ class OpenGraph:
     def to_dict(self):
         """Return the full OpenGraph dict."""
         return {
+            "metadata": {
+                "source_kind": "NetExec"
+            },
             "graph": {
                 "nodes": [
                     {"id": nid, **ndata} for nid, ndata in self.nodes.items()

--- a/nxc/helpers/opengraph.py
+++ b/nxc/helpers/opengraph.py
@@ -3,6 +3,7 @@ import os
 import zipfile
 import tempfile
 import shutil
+import contextlib
 
 from nxc.paths import NXC_PATH, TMP_PATH
 from datetime import datetime
@@ -16,8 +17,9 @@ class OpenGraph:
         self.nodes = {}
         self.edges = []
         self.name2oid = {}
+        self._ldap_loaded = False
 
-# ------------------------- MAPPINF ----------------------------
+# ------------------------- MAPPING ----------------------------
 
     def _load_json(self, path):
         with open(path, encoding="utf-8") as f:
@@ -64,7 +66,7 @@ class OpenGraph:
                 user_file = os.path.join(bh_path, entry)
 
         nxc_logger.debug(f"user file is {user_file}")
-        nxc_logger.debug(f"user file is {comp_file}")
+        nxc_logger.debug(f"computer file is {comp_file}")
 
         # Load mappings
         if comp_file:
@@ -80,9 +82,116 @@ class OpenGraph:
         if os.path.exists(tempdir):
             shutil.rmtree(tempdir)
 
-    def ldap_mapping(self):
-        # TODO
-        pass
+    def ldap_mapping(self, args):
+        """Populate name->OID mappings by querying an LDAP server directly.
+
+        This is protocol-agnostic: it opens its own LDAP connection to the host
+        given in `--og-ldap` reusing the same credentials passed on the command
+        line (plaintext, NTLM hash or Kerberos). Every user and computer
+        sAMAccountName is resolved to its objectSid so add_tag/add_edge can
+        reference nodes by their BloodHound OID.
+        """
+        if self._ldap_loaded:
+            return
+        self._ldap_loaded = True
+
+        from impacket.ldap import ldap as ldap_impacket
+        from impacket.ldap import ldapasn1 as ldapasn1_impacket
+        from nxc.parsers.ldap_results import parse_result_attributes
+
+        target = args.og_ldap
+
+        # Extract the first credential set from the run
+        username = args.username[0] if getattr(args, "username", None) else ""
+        password = args.password[0] if getattr(args, "password", None) else ""
+        domain = getattr(args, "domain", None) or ""
+        aeskey = args.aesKey[0] if getattr(args, "aesKey", None) else ""
+        kdc_host = getattr(args, "kdcHost", None)
+        use_kcache = bool(getattr(args, "use_kcache", False))
+        use_kerberos = bool(getattr(args, "kerberos", False) or aeskey or use_kcache)
+
+        # Parse NTLM hash (accepts "LM:NT" or just "NT")
+        lmhash = nthash = ""
+        hashes = getattr(args, "hash", None)
+        if hashes:
+            h = hashes[0]
+            lmhash, _, nthash = h.partition(":") if ":" in h else ("", "", h)
+
+        try:
+            connection = self._ldap_connect(
+                ldap_impacket, ldapasn1_impacket, target, username, password,
+                domain, lmhash, nthash, aeskey, kdc_host, use_kcache, use_kerberos
+            )
+        except Exception as e:
+            nxc_logger.fail(f"Failed to connect/bind to LDAP server {target}: {e}")
+            return
+
+        if connection is None:
+            return
+
+        # Resolve the base DN from the RootDSE
+        try:
+            root = connection.search(
+                scope=ldapasn1_impacket.Scope("baseObject"),
+                attributes=["defaultNamingContext"],
+                sizeLimit=0,
+            )
+            base_dn = parse_result_attributes(root)[0]["defaultNamingContext"]
+        except Exception as e:
+            nxc_logger.fail(f"Failed to retrieve base DN from {target}: {e}")
+            return
+
+        # SAM_NORMAL_USER_ACCOUNT (805306368) + SAM_MACHINE_ACCOUNT (805306369)
+        search_filter = "(|(sAMAccountType=805306368)(sAMAccountType=805306369))"
+        attributes = ["sAMAccountName", "objectSid"]
+
+        try:
+            paged = [ldapasn1_impacket.SimplePagedResultsControl(criticality=True, size=1000)]
+            resp = connection.search(
+                searchBase=base_dn,
+                searchFilter=search_filter,
+                attributes=attributes,
+                sizeLimit=0,
+                searchControls=paged,
+            )
+            resp_parsed = parse_result_attributes(resp)
+        except Exception as e:
+            nxc_logger.fail(f"Failed to resolve OIDs via LDAP: {e}")
+            return
+        finally:
+            with contextlib.suppress(Exception):
+                connection.close()
+
+        count = 0
+        for item in resp_parsed:
+            sam = item.get("sAMAccountName")
+            sid = item.get("objectSid")
+            if sam and sid:
+                self.name2oid[sam.upper()] = sid
+                count += 1
+
+        nxc_logger.display(f"Loaded {count} name\u2192OID mappings from LDAP ({target})")
+
+    def _ldap_connect(self, ldap_impacket, ldapasn1_impacket, target, username, password,
+                      domain, lmhash, nthash, aeskey, kdc_host, use_kcache, use_kerberos):
+        """Open and bind an impacket LDAPConnection, trying LDAP then LDAPS."""
+        for proto in ("ldap", "ldaps"):
+            url = f"{proto}://{target}"
+            try:
+                nxc_logger.debug(f"OpenGraph: connecting to {url}")
+                conn = ldap_impacket.LDAPConnection(url, dstIp=target)
+                if use_kerberos:
+                    conn.kerberosLogin(
+                        username, password, domain, lmhash, nthash, aeskey,
+                        kdcHost=kdc_host, useCache=use_kcache
+                    )
+                else:
+                    conn.login(username, password, domain, lmhash, nthash)
+                return conn
+            except Exception as e:
+                nxc_logger.debug(f"OpenGraph: {proto} bind to {target} failed: {e}")
+                last_error = e
+        raise last_error
 
 # ------------------------- NODES AND EDGES ----------------------------
 
@@ -124,15 +233,51 @@ class OpenGraph:
             if match_by == "id" and not v.startswith("S-1-5-21"):
                 lookup = v.upper()
                 if lookup in self.name2oid:
-                    return self.name2oid[lookup]
-            return v
+                    return self.name2oid[lookup], match_by
+                # Unresolved name: it can't be matched by "id", fall back to
+                # matching on the node "name" property instead.
+                return v, "name"
+            return v, match_by
 
+        start_value, start_match_by = resolve(start, start_match_by)
+        end_value, end_match_by = resolve(end, end_match_by)
         edge = {
             "kind": kind,
-            "start": {"value": resolve(start, start_match_by), "match_by": start_match_by},
-            "end": {"value": resolve(end, end_match_by), "match_by": end_match_by},
+            "start": {"value": start_value, "match_by": start_match_by},
+            "end": {"value": end_value, "match_by": end_match_by},
         }
         self.edges.append(edge)
+
+    def add_local_group_membership(self, principal, hostname, local_rid, ura_edge=None):
+        """Emit the supporting edges for a local group membership.
+
+        AdminTo (rid 544) and CanRDP (rid 555) are post-processed edges that
+        BloodHound deletes/regenerates on ingest, so injecting them directly
+        does not persist. Instead we add the supporting chain:
+
+            principal -MemberOfLocalGroup-> LocalGroup -LocalToComputer-> Computer
+
+        and BloodHound's post-processing synthesizes AdminTo (544) / CanPSRemote
+        (580) / ExecuteDCOM (562) from it.
+
+        CanRDP (555) additionally requires the SeRemoteInteractiveLogonRight URA,
+        so pass ura_edge="RemoteInteractiveLogonRight" to also grant it to the
+        local group; BloodHound then synthesizes CanRDP for the members.
+        """
+        comp = hostname.strip().split(".")[0]  # strip domain if FQDN
+        comp = comp if comp.endswith("$") else f"{comp}$"
+        comp = comp.upper()
+        comp_sid = self.name2oid.get(comp, comp)
+        group_id = f"{comp_sid}-{local_rid}"
+
+        # Declare the local group node and its LocalToComputer link so the chain
+        # is complete even when the target data was collected without local
+        # group enumeration.
+        self.add_node(group_id, ["Group"])
+        self.add_edge("LocalToComputer", group_id, comp_sid, start_match_by="id", end_match_by="id")
+        self.add_edge("MemberOfLocalGroup", principal, group_id, end_match_by="id")
+        if ura_edge:
+            self.add_edge(ura_edge, group_id, comp_sid, start_match_by="id", end_match_by="id")
 
 # ------------------------- EXPORT ----------------------------
 

--- a/nxc/modules/enum_cve.py
+++ b/nxc/modules/enum_cve.py
@@ -3,6 +3,7 @@ from impacket.dcerpc.v5.rpcrt import DCERPCException
 from impacket.smbconnection import SessionError
 from nxc.helpers.misc import CATEGORY
 from nxc.helpers.rpc import NXCRPCConnection
+from nxc.helpers.opengraph import opengraph
 from impacket.nmb import NetBIOSError
 
 
@@ -89,6 +90,7 @@ class NXCModule:
                     context.log.info(f"Skipping {self.CVE_PATCHES[cve]['alias']} - only applicable to Domain Controllers")
                     continue
                 if self.is_vulnerable(connection.server_os_major, connection.server_os_minor, connection.server_os_build, ubr, self.CVE_PATCHES[cve]["patches"]):
+                    opengraph.add_tag(connection.hostname, ["Computer"], self.CVE_PATCHES[cve]["alias"], True)
                     if connection.conn.isSigningRequired() and "signing_message" in self.CVE_PATCHES[cve]:  # Special conditional message for some CVEs
                         context.log.highlight(f"{cve.upper()} - {self.CVE_PATCHES[cve]['alias']} - {self.CVE_PATCHES[cve]['signing_message']}")
                     else:

--- a/nxc/modules/ms17-010.py
+++ b/nxc/modules/ms17-010.py
@@ -6,6 +6,7 @@ from ctypes import c_uint8, c_uint16, c_uint32, c_uint64, Structure
 import socket
 import struct
 from nxc.helpers.misc import CATEGORY
+from nxc.helpers.opengraph import opengraph
 from nxc.logger import nxc_logger
 
 
@@ -66,6 +67,7 @@ class NXCModule:
             if self.check(connection.host):
                 context.log.highlight("VULNERABLE")
                 context.log.highlight("Next step: https://www.rapid7.com/db/modules/exploit/windows/smb/ms17_010_eternalblue/")
+                opengraph.add_tag(connection.hostname, ["Computer"], "ms17_010", True)
         except ConnectionResetError as e:
             context.log.debug(f"Error connecting to host when checking for MS17-010: {e!s}")
         except ValueError as e:

--- a/nxc/modules/nopac.py
+++ b/nxc/modules/nopac.py
@@ -7,6 +7,7 @@ from impacket.krb5.kerberosv5 import getKerberosTGT
 from impacket.krb5 import constants
 from impacket.krb5.types import Principal
 from nxc.helpers.misc import CATEGORY
+from nxc.helpers.opengraph import opengraph
 
 
 class NXCModule:
@@ -51,5 +52,6 @@ class NXCModule:
                 context.log.highlight("")
                 context.log.highlight("VULNERABLE")
                 context.log.highlight("Next step: https://github.com/Ridter/noPac")
+                opengraph.add_tag(connection.hostname, ["Computer"], "nopac", True)
         except OSError:
             context.log.debug(f"Error connecting to Kerberos (port 88) on {connection.host}")

--- a/nxc/modules/ntlm_reflection.py
+++ b/nxc/modules/ntlm_reflection.py
@@ -74,7 +74,7 @@ class NXCModule:
                 return
             vuln = self.is_vulnerable(connection.server_os_major, connection.server_os_minor, connection.server_os_build, ubr)
             if vuln:
-                opengraph.add_tag(f"{connection.hostname}.{connection.domain}", "ntlm_reflection", True)
+                opengraph.add_tag(connection.hostname, ["Computer"], "ntlm_reflection", True)
                 if not connection.conn.isSigningRequired():  # Not vulnerable if SMB signing is enabled
                     context.log.highlight(f"VULNERABLE (can relay SMB to any protocol on {self.context.log.extra['host']})")
                 else:

--- a/nxc/modules/ntlm_reflection.py
+++ b/nxc/modules/ntlm_reflection.py
@@ -3,6 +3,7 @@ from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 from impacket.smbconnection import SessionError
 from nxc.helpers.misc import CATEGORY
 from impacket.nmb import NetBIOSError
+from nxc.helpers.opengraph import opengraph
 
 
 class NXCModule:
@@ -73,6 +74,7 @@ class NXCModule:
                 return
             vuln = self.is_vulnerable(connection.server_os_major, connection.server_os_minor, connection.server_os_build, ubr)
             if vuln:
+                opengraph.add_tag(f"{connection.hostname}.{connection.domain}", "ntlm_reflection", True)
                 if not connection.conn.isSigningRequired():  # Not vulnerable if SMB signing is enabled
                     context.log.highlight(f"VULNERABLE (can relay SMB to any protocol on {self.context.log.extra['host']})")
                 else:

--- a/nxc/modules/ntlm_reflection.py
+++ b/nxc/modules/ntlm_reflection.py
@@ -3,7 +3,6 @@ from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 from impacket.smbconnection import SessionError
 from nxc.helpers.misc import CATEGORY
 from impacket.nmb import NetBIOSError
-from nxc.helpers.opengraph import opengraph
 
 
 class NXCModule:
@@ -74,7 +73,6 @@ class NXCModule:
                 return
             vuln = self.is_vulnerable(connection.server_os_major, connection.server_os_minor, connection.server_os_build, ubr)
             if vuln:
-                opengraph.add_tag(connection.hostname, ["Computer"], "ntlm_reflection", True)
                 if not connection.conn.isSigningRequired():  # Not vulnerable if SMB signing is enabled
                     context.log.highlight(f"VULNERABLE (can relay SMB to any protocol on {self.context.log.extra['host']})")
                 else:

--- a/nxc/modules/printnightmare.py
+++ b/nxc/modules/printnightmare.py
@@ -7,6 +7,7 @@ from impacket.dcerpc.v5.ndr import NDRCALL, NDRPOINTER, NDRSTRUCT, NDRUNION, NUL
 from impacket.dcerpc.v5.dtypes import DWORD, LPWSTR, ULONG, WSTR
 from impacket.dcerpc.v5.rprn import checkNullString, STRING_HANDLE, PBYTE_ARRAY
 from nxc.helpers.misc import CATEGORY
+from nxc.helpers.opengraph import opengraph
 
 
 class NXCModule:
@@ -67,6 +68,7 @@ class NXCModule:
                 return False
             # If vulnerable, 'ERROR_INVALID_PARAMETER' will be returned
             if e.error_code == system_errors.ERROR_INVALID_PARAMETER:
+                opengraph.add_tag(f"{connection.hostname}.{connection.domain}", "printnightmare", True)
                 context.log.highlight("Vulnerable, next step https://github.com/ly4k/PrintNightmare")
                 return True
             context.log.fail(f"Unexpected error: {e}")
@@ -75,6 +77,7 @@ class NXCModule:
                 context.log.info("Not vulnerable :'(")
                 return False
             context.log.fail(f"Unexpected error: {e}")
+        opengraph.add_tag(f"{connection.hostname}.{connection.domain}", "printnightmare", True)
         context.log.highlight("Vulnerable, next step https://github.com/ly4k/PrintNightmare")
         return True
 

--- a/nxc/modules/printnightmare.py
+++ b/nxc/modules/printnightmare.py
@@ -68,7 +68,7 @@ class NXCModule:
                 return False
             # If vulnerable, 'ERROR_INVALID_PARAMETER' will be returned
             if e.error_code == system_errors.ERROR_INVALID_PARAMETER:
-                opengraph.add_tag(f"{connection.hostname}.{connection.domain}", "printnightmare", True)
+                opengraph.add_tag(connection.hostname, ["Computer"], "printnightmare", True)
                 context.log.highlight("Vulnerable, next step https://github.com/ly4k/PrintNightmare")
                 return True
             context.log.fail(f"Unexpected error: {e}")
@@ -77,7 +77,7 @@ class NXCModule:
                 context.log.info("Not vulnerable :'(")
                 return False
             context.log.fail(f"Unexpected error: {e}")
-        opengraph.add_tag(f"{connection.hostname}.{connection.domain}", "printnightmare", True)
+        opengraph.add_tag(connection.hostname, ["Computer"], "printnightmare", True)
         context.log.highlight("Vulnerable, next step https://github.com/ly4k/PrintNightmare")
         return True
 

--- a/nxc/modules/remove-mic.py
+++ b/nxc/modules/remove-mic.py
@@ -20,6 +20,7 @@ from impacket import ntlm
 from impacket import nt_errors
 from impacket.smbconnection import SessionError
 from nxc.helpers.misc import CATEGORY
+from nxc.helpers.opengraph import opengraph
 
 
 class NXCModule:
@@ -51,6 +52,7 @@ class NXCModule:
                 context.log.info("Unexpected Exception while authentication")
         else:
             context.log.highlight("Potentially vulnerable to CVE-2019-1040, next step: https://dirkjanm.io/exploiting-CVE-2019-1040-relay-vulnerabilities-for-rce-and-domain-admin/")
+            opengraph.add_tag(connection.hostname, ["Computer"], "cve_2019_1040", True)
 
 
 class Modify_Func:

--- a/nxc/modules/smbghost.py
+++ b/nxc/modules/smbghost.py
@@ -4,6 +4,7 @@
 import socket
 import struct
 from nxc.helpers.misc import CATEGORY
+from nxc.helpers.opengraph import opengraph
 
 # Constants
 MAX_ATTEMPTS = 2000  # False negative chance: 0.04%
@@ -30,6 +31,7 @@ class NXCModule:
         self.context = context
         if self.perform_attack(connection.host):
             self.context.log.highlight("Potentially vulnerable to SMBGhost (CVE-2020-0796)")
+            opengraph.add_tag(connection.hostname, ["Computer"], "smbghost", True)
 
     def perform_attack(self, target_ip):
         self.context.log.debug("Performing SMBGhost check...")

--- a/nxc/modules/webdav.py
+++ b/nxc/modules/webdav.py
@@ -34,12 +34,12 @@ class NXCModule:
         Check whether the 'DAV RPC Service' pipe exists within the 'IPC$' share. This indicates
         that the WebClient service is running on the target.
         """
-        opengraph.add_tag(str.upper(f"{connection.hostname}.{connection.domain}"), "webclientrunning", True)
         try:
             remote_file = RemoteFile(connection.conn, "DAV RPC Service", "IPC$", access=FILE_READ_DATA)
             remote_file.open_file()
 
             context.log.highlight(self.output.format(connection.conn.getRemoteHost()))
+            opengraph.add_tag(f"{connection.hostname}.{connection.domain}", "webclientrunning", True)
         except SessionError as e:
             if e.getErrorCode() == nt_errors.STATUS_OBJECT_NAME_NOT_FOUND:
                 return

--- a/nxc/modules/webdav.py
+++ b/nxc/modules/webdav.py
@@ -5,6 +5,7 @@ from impacket.smb3structs import FILE_READ_DATA
 from impacket.smbconnection import SessionError
 from impacket.nmb import NetBIOSError
 import contextlib
+from nxc.helpers.opengraph import opengraph
 
 
 class NXCModule:
@@ -33,6 +34,7 @@ class NXCModule:
         Check whether the 'DAV RPC Service' pipe exists within the 'IPC$' share. This indicates
         that the WebClient service is running on the target.
         """
+        opengraph.add_tag(str.upper(f"{connection.hostname}.{connection.domain}"), "webclientrunning", True)
         try:
             remote_file = RemoteFile(connection.conn, "DAV RPC Service", "IPC$", access=FILE_READ_DATA)
             remote_file.open_file()

--- a/nxc/modules/webdav.py
+++ b/nxc/modules/webdav.py
@@ -39,7 +39,7 @@ class NXCModule:
             remote_file.open_file()
 
             context.log.highlight(self.output.format(connection.conn.getRemoteHost()))
-            opengraph.add_tag(f"{connection.hostname}.{connection.domain}", "webclientrunning", True)
+            opengraph.add_tag(connection.hostname, ["Computer"], "webclientrunning", True)
         except SessionError as e:
             if e.getErrorCode() == nt_errors.STATUS_OBJECT_NAME_NOT_FOUND:
                 return

--- a/nxc/modules/zerologon.py
+++ b/nxc/modules/zerologon.py
@@ -6,6 +6,7 @@ from impacket.dcerpc.v5.rpcrt import DCERPCException
 import sys
 from nxc.helpers.misc import CATEGORY
 from nxc.helpers.rpc import NXCRPCConnection
+from nxc.helpers.opengraph import opengraph
 from nxc.logger import nxc_logger
 
 # Give up brute-forcing after this many attempts. If vulnerable, 256 attempts are expected to be necessary on average.
@@ -30,6 +31,7 @@ class NXCModule:
         if self.perform_attack(connection, "\\\\" + connection.hostname, connection.host, connection.hostname, connection.host):
             self.context.log.highlight("VULNERABLE")
             self.context.log.highlight("Next step: https://github.com/dirkjanm/CVE-2020-1472")
+            opengraph.add_tag(connection.hostname, ["Computer"], "zerologon", True)
             try:
                 host = self.context.db.get_hosts(connection.host)[0]
                 self.context.db.add_host(

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -29,6 +29,9 @@ import platform
 if sys.stdout.encoding == "cp1252":
     sys.stdout.reconfigure(encoding="utf-8")
 
+
+from nxc.helpers.opengraph import opengraph
+
 # Increase file_limit to prevent error "Too many open files"
 if platform.system() != "Windows":
     import resource
@@ -224,6 +227,10 @@ def main():
     try:
         asyncio.run(start_run(protocol_object, args, db, targets))
     finally:
+        if args.opengraph is not None:
+            opengraph.update_node_ids_to_guids(args.opengraph)
+            nxc_logger.debug(opengraph.to_json())
+            opengraph.save()
         db_engine.dispose()
 
 

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -225,10 +225,11 @@ def main():
         nxc_logger.highlight(highlight("[!] Jitter is only throttling authentications per target!", "red"))
 
     try:
+        if args.opengraph is not None:
+            opengraph.simple_bh_mapping(args.opengraph)  # load fqdn 2 oid mapping
         asyncio.run(start_run(protocol_object, args, db, targets))
     finally:
         if args.opengraph is not None:
-            opengraph.update_node_ids_to_guids(args.opengraph)
             nxc_logger.debug(opengraph.to_json())
             opengraph.save()
         db_engine.dispose()

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -229,12 +229,12 @@ def main():
             if args.og_path is not None:
                 opengraph.bh_mapping(args.og_path)
             elif args.og_ldap:
-                opengraph.ldap_mapping()
+                opengraph.ldap_mapping(args)
             else:
-                nxc_logger.warning("No method was given to resolve OIDs!")
+                nxc_logger.warning("No method was given to resolve OIDs, nodes will be matched by name")
         asyncio.run(start_run(protocol_object, args, db, targets))
     finally:
-        if args.opengraph is not None:
+        if args.opengraph:
             nxc_logger.debug(opengraph.to_json())
             nxc_logger.debug(opengraph.name2oid)
             opengraph.save()

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -225,12 +225,18 @@ def main():
         nxc_logger.highlight(highlight("[!] Jitter is only throttling authentications per target!", "red"))
 
     try:
-        if args.opengraph is not None:
-            opengraph.simple_bh_mapping(args.opengraph)  # load fqdn 2 oid mapping
+        if args.opengraph:
+            if args.og_path is not None:
+                opengraph.bh_mapping(args.og_path)
+            elif args.og_ldap:
+                opengraph.ldap_mapping()
+            else:
+                nxc_logger.warning("No method was given to resolve OIDs!")
         asyncio.run(start_run(protocol_object, args, db, targets))
     finally:
         if args.opengraph is not None:
             nxc_logger.debug(opengraph.to_json())
+            nxc_logger.debug(opengraph.name2oid)
             opengraph.save()
         db_engine.dispose()
 

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -288,7 +288,9 @@ class ldap(connection):
         if detect_if_ip(self.host):
             opengraph.add_tag(self.hostname, ["Computer"], "IP_Address", self.host)
         opengraph.add_tag(self.hostname, ["Computer"], "ldapsigning", self.signing_required)
-        opengraph.add_tag(self.hostname, ["Computer"], "ldaps_channel_binding", self.signing_required)
+        opengraph.add_tag(self.hostname, ["Computer"], "ldaps_channel_binding", self.cbt_status)
+        if self.admin_privs and self.username:
+            opengraph.add_local_group_membership(self.username, self.hostname, 544)
 
     def print_host_info(self):
         self.logger.debug("Printing host info for LDAP")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -14,6 +14,7 @@ from termcolor import colored
 from dns import resolver
 from dateutil.relativedelta import relativedelta as rd
 
+
 from OpenSSL.SSL import SysCallError
 from bloodhound.ad.authentication import ADAuthentication
 from bloodhound.ad.domain import AD
@@ -48,6 +49,8 @@ from nxc.protocols.ldap.gmsa import MSDS_MANAGEDPASSWORD_BLOB
 from nxc.protocols.ldap.kerberos import KerberosAttacks
 from nxc.parsers.ldap_results import parse_result_attributes
 from nxc.helpers.negotiate_parser import parse_challenge
+from nxc.helpers.opengraph import opengraph
+from nxc.helpers.misc import detect_if_ip
 from nxc.paths import CONFIG_PATH
 
 ldap_error_status = {
@@ -280,6 +283,11 @@ class ldap(connection):
             )
         except Exception as e:
             self.logger.debug(f"Error adding host {self.host} into db: {e!s}")
+
+    def opengraph_host_info(self):
+        if detect_if_ip(self.host):
+            opengraph.add_tag(f"{self.hostname}.{self.domain}", "IP_Address", self.host)
+        opengraph.add_tag(f"{self.hostname}.{self.domain}", "ldapsigning", self.signing_required)
 
     def print_host_info(self):
         self.logger.debug("Printing host info for LDAP")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -286,9 +286,9 @@ class ldap(connection):
 
     def opengraph_host_info(self):
         if detect_if_ip(self.host):
-            opengraph.add_tag(f"{self.hostname}.{self.domain}", "IP_Address", self.host)
-        opengraph.add_tag(f"{self.hostname}.{self.domain}", "ldapsigning", self.signing_required)
-        opengraph.add_tag(f"{self.hostname}.{self.domain}", "ldaps_channel_binding", self.signing_required)
+            opengraph.add_tag(self.hostname, ["Computer"], "IP_Address", self.host)
+        opengraph.add_tag(self.hostname, ["Computer"], "ldapsigning", self.signing_required)
+        opengraph.add_tag(self.hostname, ["Computer"], "ldaps_channel_binding", self.signing_required)
 
     def print_host_info(self):
         self.logger.debug("Printing host info for LDAP")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -288,6 +288,7 @@ class ldap(connection):
         if detect_if_ip(self.host):
             opengraph.add_tag(f"{self.hostname}.{self.domain}", "IP_Address", self.host)
         opengraph.add_tag(f"{self.hostname}.{self.domain}", "ldapsigning", self.signing_required)
+        opengraph.add_tag(f"{self.hostname}.{self.domain}", "ldaps_channel_binding", self.signing_required)
 
     def print_host_info(self):
         self.logger.debug("Printing host info for LDAP")

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -6,7 +6,8 @@ from termcolor import colored
 from nxc.config import process_secret, host_info_colors
 from nxc.connection import connection
 from nxc.connection import requires_admin
-from nxc.helpers.misc import gen_random_string
+from nxc.helpers.misc import gen_random_string, detect_if_ip
+from nxc.helpers.opengraph import opengraph
 from nxc.logger import NXCAdapter
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.negotiate_parser import parse_challenge, login7_integrated_auth_error_message
@@ -167,6 +168,17 @@ class mssql(connection):
             result = self.resolver(self.domain)
             self.kdcHost = result["host"] if result else None
             self.logger.info(f"Resolved domain: {self.domain} with dns, kdcHost: {self.kdcHost}")
+
+    def opengraph_host_info(self):
+        if detect_if_ip(self.host):
+            opengraph.add_tag(self.hostname, ["Computer"], "IP_Address", self.host)
+        opengraph.add_tag(self.hostname, ["Computer"], "mssql_present", True)
+        opengraph.add_tag(self.hostname, ["Computer"], "mssql_version", self.version)
+        opengraph.add_tag(self.hostname, ["Computer"], "mssql_edition", self.edition)
+        opengraph.add_tag(self.hostname, ["Computer"], "mssql_encryption", self.encryption)
+        opengraph.add_tag(self.hostname, ["Computer"], "mssql_instances", len(self.mssql_instances))
+        if self.admin_privs and self.username:
+            opengraph.add_edge("SQLAdmin", self.username, f"{self.hostname}$")
 
     def print_host_info(self):
         encryption = colored(f"EncryptionReq:{self.encryption}", host_info_colors[0 if self.encryption else 1], attrs=["bold"])

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -9,6 +9,8 @@ from impacket.krb5.ccache import CCache
 
 from nxc.connection import connection
 from nxc.helpers.bloodhound import add_user_bh
+from nxc.helpers.misc import detect_if_ip
+from nxc.helpers.opengraph import opengraph
 from nxc.logger import NXCAdapter
 from nxc.config import host_info_colors, process_secret
 from nxc.paths import NXC_PATH
@@ -102,6 +104,13 @@ class rdp(connection):
                 "hostname": self.hostname,
             }
         )
+
+    def opengraph_host_info(self):
+        if detect_if_ip(self.host):
+            opengraph.add_tag(self.hostname, ["Computer"], "IP_Address", self.host)
+        opengraph.add_tag(self.hostname, ["Computer"], "rdp_nla", self.nla)
+        if self.admin_privs and self.username:
+            opengraph.add_local_group_membership(self.username, self.hostname, 555, ura_edge="RemoteInteractiveLogonRight")
 
     def print_host_info(self):
         nla = colored(f"nla:{self.nla}", host_info_colors[3], attrs=["bold"]) if self.nla else colored(f"nla:{self.nla}", host_info_colors[2], attrs=["bold"])
@@ -217,6 +226,7 @@ class rdp(connection):
             await self.terminate_conn()
 
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
+        self.username = username
         try:
             lmhash = ""
             nthash = ""
@@ -317,6 +327,7 @@ class rdp(connection):
             return False
 
     def plaintext_login(self, domain, username, password):
+        self.username = username
         try:
             self.auth = NTLMCredential(
                 secret=password,
@@ -351,6 +362,7 @@ class rdp(connection):
             return False
 
     def hash_login(self, domain, username, ntlm_hash):
+        self.username = username
         try:
             self.auth = NTLMCredential(
                 secret=ntlm_hash,

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -322,6 +322,8 @@ class smb(connection):
         if detect_if_ip(self.host):
             opengraph.add_tag(self.hostname, ["Computer"], "IP_Address", self.host)
         opengraph.add_tag(self.hostname, ["Computer"], "smbsigning", self.signing)
+        if self.admin_privs and self.username:
+            opengraph.add_local_group_membership(self.username, self.hostname, 544)
 
     def print_host_info(self):
         signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -320,8 +320,8 @@ class smb(connection):
 
     def opengraph_host_info(self):
         if detect_if_ip(self.host):
-            opengraph.add_tag(f"{self.hostname}.{self.domain}", "IP_Address", self.host)
-        opengraph.add_tag(f"{self.hostname}.{self.domain}", "smbsigning", self.signing)
+            opengraph.add_tag(self.hostname, ["Computer"], "IP_Address", self.host)
+        opengraph.add_tag(self.hostname, ["Computer"], "smbsigning", self.signing)
 
     def print_host_info(self):
         signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
@@ -1375,7 +1375,7 @@ class smb(connection):
                     row = template.format(USERNAME=user_full, SID=sid)
                     result.append(row)
                     if sid.startswith("S-1-5-21"):  # remove virtual/service accounts
-                        opengraph.add_edge("HasSession", f"{self.hostname}.{self.domain}", sid)
+                        opengraph.add_edge("HasSession", f"{self.hostname}$", sid)
 
                 self.logger.success("Remote Registry enumerated sessions")
                 for row in result:
@@ -1895,6 +1895,8 @@ class smb(connection):
                             self.logger.highlight(f"{user_info[0]}\\{user_info[1]:<25} logon_server: {user_info[2]}")
                     else:
                         self.logger.highlight(f"{user_info[0]}\\{user_info[1]:<25} logon_server: {user_info[2]}")
+                    if user_info[1] != f"{self.hostname}$":
+                        opengraph.add_edge("HasSession", f"{self.hostname}$", user_info[1])
         except Exception as e:
             self.logger.fail(f"Error enumerating logged on users: {e}")
 

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -75,6 +75,7 @@ from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.rpc import NXCRPCConnection
 from nxc.helpers.powershell import create_ps_command
 from nxc.helpers.misc import detect_if_ip
+from nxc.helpers.opengraph import opengraph
 from nxc.protocols.ldap.resolution import LDAPResolution
 
 from dploot.triage.vaults import VaultsTriage
@@ -316,6 +317,11 @@ class smb(connection):
             result = self.resolver(self.domain)
             self.kdcHost = result["host"] if result else None
             self.logger.info(f"Resolved domain: {self.domain} with dns, kdcHost: {self.kdcHost}")
+
+    def opengraph_host_info(self):
+        if detect_if_ip(self.host):
+            opengraph.add_tag(f"{self.hostname}.{self.domain}", "IP_Address", self.host)
+        opengraph.add_tag(f"{self.hostname}.{self.domain}", "smbsigning", self.signing)
 
     def print_host_info(self):
         signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
@@ -1368,6 +1374,8 @@ class smb(connection):
 
                     row = template.format(USERNAME=user_full, SID=sid)
                     result.append(row)
+                    if sid.startswith("S-1-5-21"):  # remove virtual/service accounts
+                        opengraph.add_edge("HasSession", f"{self.hostname}.{self.domain}", sid)
 
                 self.logger.success("Remote Registry enumerated sessions")
                 for row in result:


### PR DESCRIPTION
## Description

This work in Progress PR aims to add the possibility to generate an OpenGraph json file to enriched  BloodHound datas after an NetExec run. *(Only works for bloudhound-CE)*

**I made this PR even if it is still work in progress to have some feedback, in particular about the implementation as I am not sure about creating the global object in opengraph.py or modifying netexec.py and proto_flow workflow so let me know if there is any better ways. :)**

The goal is to be able to easily add new tags/edges to bloodhound

* *--opengraph path/to/bloudhound/computers.json*  is used to generate the json. Computers.json data is used to resolve fqdn to Object ID as this is how BloudHound matches nodes. This resolution could later be also done directly with an ldap query or via bloudhound API. However, it is imo the best compromise as it avoids the need of a new ldap connection and the need to have the BloudHound instance reachable.

* The json file is then generated in the NXCPath/log/ and can be imported directly in BloudHound via the direct import feature.
 
### Example

Adding edges for HasSession when running --reg-sessions and adding host info such as IPs or SMB signing status

<img width="945" height="466" alt="image" src="https://github.com/user-attachments/assets/10739c4c-4183-4f69-a339-b59c50b43e48" />

Generated OpenGraph json
```
{
  "graph": {
    "nodes": [
      {
        "id": "S-1-5-21-2593841013-2027981200-818290452-1001",
        "kinds": [
          "Computer",
          "Base"
        ],
        "properties": {
          "IP_Address": "192.168.57.11",
          "smbsigning": true
        }
      },
      {
        "id": "S-1-5-21-2593841013-2027981200-818290452-1105",
        "kinds": [
          "Computer",
          "Base"
        ],
        "properties": {
          "IP_Address": "192.168.57.22",
          "smbsigning": false
        }
      }
    ],
    "edges": [
      {
        "kind": "HasSession",
        "start": {
          "value": "S-1-5-21-2593841013-2027981200-818290452-1001",
          "match_by": "id"
        },
        "end": {
          "value": "S-1-5-21-2593841013-2027981200-818290452-1000",
          "match_by": "id"
        }
      },
      {
        "kind": "HasSession",
        "start": {
          "value": "S-1-5-21-2593841013-2027981200-818290452-1105",
          "match_by": "id"
        },
        "end": {
          "value": "S-1-5-21-2593841013-2027981200-818290452-1113",
          "match_by": "id"
        }
      },
      {
        "kind": "HasSession",
        "start": {
          "value": "S-1-5-21-2593841013-2027981200-818290452-1105",
          "match_by": "id"
        },
        "end": {
          "value": "S-1-5-21-2593841013-2027981200-818290452-1121",
          "match_by": "id"
        }
      }
    ]
  }
}
```
After import in bloodhound:

<img width="1567" height="978" alt="image" src="https://github.com/user-attachments/assets/ef89ff70-e1b7-428e-ba03-2af07aeea782" />


An example of adding a tag with a module can be found in ntlm_reflection.py for example.

### Implementation

New helper class OpenGraph that create a new global object opengraph.
This exposed 2 main methods:
* opengraph.add_tag(id, name, value)
* opengraph.add_edge(kind, start, end) (optional match by value arguments)

Host info are extrated by adding a new optional proto_flow() step opengraph_host_info() and module can directly call add_*() to add new info.

### TODOs
- [ ] Custom cypher cheatsheet for nxc new tags
- [ ] Implementation for other modules
- [ ] Improve CLI flags
- [ ] Optional auto upload of the json  via the bloodhound api
- [ ] Currently only add tags to computers' account
- [ ] Other things?



## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Test were done on GOAD-Light, run bloodhound first then you can import opengraph json data as any bloudhound data.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
