### PR TITLE
Fix encoding issue and use proper LDAP attr parsing in SCCM module

### DIFF
--- a/nxc/modules/sccm.py
+++ b/nxc/modules/sccm.py
@@ -1,4 +1,4 @@
-from impacket.ldap import ldap, ldaptypes, ldapasn1 as ldapasn1_impacket
+from impacket.ldap import ldap, ldaptypes
 from impacket.ldap.ldap import LDAPSearchError
 from ldap3.protocol.microsoft import security_descriptor_control
 from nxc.helpers.misc import CATEGORY


### PR DESCRIPTION
## Description

Due to bad parsing of ldap results in #993 was a parsing issue of the securityDescriptor reported. This is fixed now by parsing the result properly.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Run SCCM module against a lab with a specific SD.

## Screenshots (if appropriate):
Before&After:
<img width="1580" height="1142" alt="image" src="https://github.com/user-attachments/assets/b6851f7c-5600-4fc0-b4e2-76aa14a3a0c5" />
