### PR TITLE
Switch impacket back to fortra

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -233,7 +233,7 @@ class ldap(connection):
         ldap_url = f"ldaps://{self.target}"
         try:
             ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
-            ldap_connection._LDAPConnection__channel_binding_value = None
+            ldap_connection.channel_binding_value = None
             ldap_connection.login(user=" ", domain=self.domain)
         except ldap_impacket.LDAPSessionError as e:
             if str(e).find("data 80090346") >= 0:
@@ -242,9 +242,9 @@ class ldap(connection):
             # Login failed (wrong credentials). test if we get an error with an existing, but wrong CBT -> When supported
             elif str(e).find("data 52e") >= 0:
                 ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
-                new_cbv = bytearray(ldap_connection._LDAPConnection__channel_binding_value)
+                new_cbv = bytearray(ldap_connection.channel_binding_value)
                 new_cbv[15] = (new_cbv[3] + 1) % 256
-                ldap_connection._LDAPConnection__channel_binding_value = bytes(new_cbv)
+                ldap_connection.channel_binding_value = bytes(new_cbv)
                 try:
                     ldap_connection.login(user=" ", domain=self.domain)
                 except ldap_impacket.LDAPSessionError as e:

--- a/poetry.lock
+++ b/poetry.lock
@@ -430,18 +430,21 @@ beautifulsoup4 = ">=4.13.4,<4.14.0"
 cryptography = ">=42.0.8,<42.1.0"
 dnspython = ">=2.7.0,<2.8.0"
 httpx = ">=0.28.1,<0.29.0"
-impacket = ">=0.12.0,<0.13.0"
+impacket = ">=0.12.0"
 ldap3 = ">=2.9.1,<2.10.0"
 pyasn1 = ">=0.6.1,<0.7.0"
 pycryptodome = ">=3.22.0,<3.23.0"
 pyopenssl = ">=24.0.0,<24.1.0"
 requests = ">=2.32.3,<2.33.0"
 
+[package.extras]
+bloodhound = ["neo4j (>=5.28.1,<5.29.0)"]
+
 [package.source]
 type = "git"
 url = "https://github.com/Pennyw0rth/Certipy"
 reference = "HEAD"
-resolved_reference = "a51fbf0f11be5896815afbaa7162b0fee0a4f14c"
+resolved_reference = "017dab8ff4d4447976b2a0c2b2203fd61b888681"
 
 [[package]]
 name = "cffi"
@@ -990,7 +993,7 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "impacket"
-version = "0.13.0.dev0+20250813.95021.3e63daef"
+version = "0.14.0.dev0+20251114.155318.8925c2ce"
 description = "Network protocols Constructors and Dissectors"
 optional = false
 python-versions = "*"
@@ -1006,16 +1009,16 @@ ldapdomaindump = ">=0.9.0"
 pyasn1 = ">=0.2.3"
 pyasn1_modules = "*"
 pycryptodomex = "*"
-pyOpenSSL = "24.0.0"
+pyOpenSSL = "*"
 pyreadline3 = {version = "*", markers = "sys_platform == \"win32\""}
 setuptools = "*"
 six = "*"
 
 [package.source]
 type = "git"
-url = "https://github.com/Pennyw0rth/impacket.git"
+url = "https://github.com/fortra/impacket"
 reference = "HEAD"
-resolved_reference = "3e63daef1dbb29bcbed0414f801403158f0e07d2"
+resolved_reference = "8925c2ce4657a5cecd57c2d0b08acb846d94c236"
 
 [[package]]
 name = "iniconfig"
@@ -2610,4 +2613,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "7c01423c83aa79d27df1351d930d185feac3e4a0d275f868406f4081bbc52f61"
+content-hash = "b25390c3a761b0c374a68e53c836ef07fd0a3abb3efbe8a4bcb4f2d3dae1c159"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "xmltodict>=0.13.0",
     # Git Dependencies
     "certipy-ad @ git+https://github.com/Pennyw0rth/Certipy",
-    "impacket @ git+https://github.com/Pennyw0rth/impacket.git",
+    "impacket @ git+https://github.com/fortra/impacket",
     "oscrypto @ git+https://github.com/wbond/oscrypto",
     "pynfsclient @ git+https://github.com/Pennyw0rth/NfsClient",
 ]


### PR DESCRIPTION
## Description

As all PRs have been merged we can swap the impacket source back to the fortra repo.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [x] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
`nxc ldap <ip>`

## Screenshots (if appropriate):
<img width="1305" height="85" alt="image" src="https://github.com/user-attachments/assets/c6d17911-886d-45e4-905d-29b4422dda8c" />
