### PR TITLE
Make --debug and --verbose mutually exclusive

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -35,10 +35,11 @@ def gen_cli_args():
 
     output_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
     output_group = output_parser.add_argument_group("Output", "Options to set verbosity levels and control output")
-    output_group.add_argument("--verbose", action="store_true", help="enable verbose output")
-    output_group.add_argument("--debug", action="store_true", help="enable debug level information")
     output_group.add_argument("--no-progress", action="store_true", help="do not displaying progress bar during scan")
     output_group.add_argument("--log", metavar="LOG", help="export result into a custom file")
+    log_level = output_group.add_mutually_exclusive_group()
+    log_level.add_argument("--verbose", action="store_true", help="enable verbose output")
+    log_level.add_argument("--debug", action="store_true", help="enable debug level information")
 
     dns_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
     dns_group = dns_parser.add_argument_group("DNS")


### PR DESCRIPTION
## Description

To prevent errors such as enabling both verbose&debug mode which overwrites each other, make them mutually exclusive.
Fix #999

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Try `--verbose --debug`

## Screenshots (if appropriate):
Before&After:
<img width="1581" height="596" alt="image" src="https://github.com/user-attachments/assets/5648841d-8771-403b-8452-e5bc5a683d9e" />

