### PR TITLE
Remove useless option group subtitles

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -27,14 +27,14 @@ def gen_cli_args():
     CODENAME = "SmoothOperator"
 
     generic_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
-    generic_group = generic_parser.add_argument_group("Generic", "Generic options for nxc across protocols")
+    generic_group = generic_parser.add_argument_group("Generic Options")
     generic_group.add_argument("--version", action="store_true", help="Display nxc version")
     generic_group.add_argument("-t", "--threads", type=int, dest="threads", default=256, help="set how many concurrent threads to use")
     generic_group.add_argument("--timeout", default=None, type=int, help="max timeout in seconds of each thread")
     generic_group.add_argument("--jitter", metavar="INTERVAL", type=str, help="sets a random delay between each authentication")
 
     output_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
-    output_group = output_parser.add_argument_group("Output", "Options to set verbosity levels and control output")
+    output_group = output_parser.add_argument_group("Output Options")
     output_group.add_argument("--no-progress", action="store_true", help="do not displaying progress bar during scan")
     output_group.add_argument("--log", metavar="LOG", help="export result into a custom file")
     log_level = output_group.add_mutually_exclusive_group()
@@ -74,7 +74,7 @@ def gen_cli_args():
 
     # we do module arg parsing here so we can reference the module_list attribute below
     module_parser = argparse.ArgumentParser(add_help=False, formatter_class=DisplayDefaultsNotNone)
-    mgroup = module_parser.add_argument_group("Modules", "Options for nxc modules")
+    mgroup = module_parser.add_argument_group("Modules")
     mgroup.add_argument("-M", "--module", choices=get_module_names(), action="append", metavar="MODULE", help="module to use")
     mgroup.add_argument("-o", metavar="MODULE_OPTION", nargs="+", default=[], dest="module_options", help="module options")
     mgroup.add_argument("-L", "--list-modules", nargs="?", type=str, const="", help="list available modules")
@@ -84,7 +84,7 @@ def gen_cli_args():
 
     std_parser = argparse.ArgumentParser(add_help=False, parents=[generic_parser, output_parser, dns_parser], formatter_class=DisplayDefaultsNotNone)
     std_parser.add_argument("target", nargs="+" if not (module_parser.parse_known_args()[0].list_modules is not None or module_parser.parse_known_args()[0].show_module_options or generic_parser.parse_known_args()[0].version) else "*", type=str, help="the target IP(s), range(s), CIDR(s), hostname(s), FQDN(s), file(s) containing a list of targets, NMap XML or .Nessus file(s)")
-    credential_group = std_parser.add_argument_group("Authentication", "Options for authenticating")
+    credential_group = std_parser.add_argument_group("Authentication")
     credential_group.add_argument("-u", "--username", metavar="USERNAME", dest="username", nargs="+", default=[], help="username(s) or file(s) containing usernames")
     credential_group.add_argument("-p", "--password", metavar="PASSWORD", dest="password", nargs="+", default=[], help="password(s) or file(s) containing passwords")
     credential_group.add_argument("-id", metavar="CRED_ID", nargs="+", default=[], type=str, dest="cred_id", help="database credential ID(s) to use for authentication")
@@ -95,13 +95,13 @@ def gen_cli_args():
     credential_group.add_argument("--ufail-limit", metavar="LIMIT", type=int, help="max number of failed login attempts per username")
     credential_group.add_argument("--fail-limit", metavar="LIMIT", type=int, help="max number of failed login attempts per host")
 
-    kerberos_group = std_parser.add_argument_group("Kerberos", "Options for Kerberos authentication")
+    kerberos_group = std_parser.add_argument_group("Kerberos Authentication")
     kerberos_group.add_argument("-k", "--kerberos", action="store_true", help="Use Kerberos authentication")
     kerberos_group.add_argument("--use-kcache", action="store_true", help="Use Kerberos authentication from ccache file (KRB5CCNAME)")
     kerberos_group.add_argument("--aesKey", metavar="AESKEY", nargs="+", help="AES key to use for Kerberos Authentication (128 or 256 bits)")
     kerberos_group.add_argument("--kdcHost", metavar="KDCHOST", help="FQDN of the domain controller. If omitted it will use the domain part (FQDN) specified in the target parameter")
 
-    certificate_group = std_parser.add_argument_group("Certificate", "Options for certificate authentication")
+    certificate_group = std_parser.add_argument_group("Certificate Authentication")
     certificate_group.add_argument("--pfx-cert", metavar="PFXCERT", help="Use certificate authentication from pfx file .pfx")
     certificate_group.add_argument("--pfx-base64", metavar="PFXB64", help="Use certificate authentication from pfx file encoded in base64")
     certificate_group.add_argument("--pfx-pass", metavar="PFXPASS", help="Password of the pfx certificate")

--- a/nxc/protocols/ftp/proto_args.py
+++ b/nxc/protocols/ftp/proto_args.py
@@ -5,7 +5,7 @@ def proto_args(parser, parents):
     ftp_parser = parser.add_parser("ftp", help="own stuff using FTP", parents=parents, formatter_class=DisplayDefaultsNotNone)
     ftp_parser.add_argument("--port", type=int, default=21, help="FTP port")
 
-    cgroup = ftp_parser.add_argument_group("File Operations", "Options for enumerating and interacting with files on the target")
+    cgroup = ftp_parser.add_argument_group("File Operations")
     cgroup.add_argument("--ls", metavar="DIRECTORY", nargs="?", const=".", help="List files in the directory")
     cgroup.add_argument("--get", metavar="FILE", help="Download a file")
     cgroup.add_argument("--put", metavar=("LOCAL_FILE", "REMOTE_FILE"), nargs=2, help="Upload a file")

--- a/nxc/protocols/mssql/proto_args.py
+++ b/nxc/protocols/mssql/proto_args.py
@@ -13,23 +13,23 @@ def proto_args(parser, parents):
     dgroup.add_argument("-d", metavar="DOMAIN", dest="domain", type=str, help="domain name")
     dgroup.add_argument("--local-auth", action="store_true", help="authenticate locally to each target")
 
-    cgroup = mssql_parser.add_argument_group("Command Execution", "options for executing commands")
+    cgroup = mssql_parser.add_argument_group("Command Execution")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     xgroup = cgroup.add_mutually_exclusive_group()
     xgroup.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified command")
     xgroup.add_argument("-X", metavar="PS_COMMAND", dest="ps_execute", help="execute the specified PowerShell command")
 
-    psgroup = mssql_parser.add_argument_group("Powershell Options", "Options for PowerShell execution")
+    psgroup = mssql_parser.add_argument_group("Powershell Options")
     psgroup.add_argument("--force-ps32", action="store_true", default=False, help="Force the PowerShell command to run in a 32-bit process via a job; WARNING: depends on the job completing quickly, so you may have to increase the timeout")
     psgroup.add_argument("--obfs", action="store_true", default=False, help="Obfuscate PowerShell ran on target; WARNING: Defender will almost certainly trigger on this")
     psgroup.add_argument("--amsi-bypass", nargs=1, metavar="FILE", type=str, help="File with a custom AMSI bypass")
     psgroup.add_argument("--clear-obfscripts", action="store_true", help="Clear all cached obfuscated PowerShell scripts")
     psgroup.add_argument("--no-encode", action="store_true", default=False, help="Do not encode the PowerShell command ran on target")
 
-    tgroup = mssql_parser.add_argument_group("Files", "Options for put and get remote files")
+    tgroup = mssql_parser.add_argument_group("File Operations")
     tgroup.add_argument("--put-file", nargs=2, metavar=("SRC_FILE", "DEST_FILE"), help="Put a local file into remote target, ex: whoami.txt C:\\\\Windows\\\\Temp\\\\whoami.txt")
     tgroup.add_argument("--get-file", nargs=2, metavar=("SRC_FILE", "DEST_FILE"), help="Get a remote file, ex: C:\\\\Windows\\\\Temp\\\\whoami.txt whoami.txt")
 
-    mapping_enum_group = mssql_parser.add_argument_group("Mapping/Enumeration", "Options for Mapping/Enumerating")
+    mapping_enum_group = mssql_parser.add_argument_group("Mapping/Enumeration")
     mapping_enum_group.add_argument("--rid-brute", nargs="?", type=int, const=4000, metavar="MAX_RID", help="enumerate users by bruteforcing RIDs")
     return parser

--- a/nxc/protocols/nfs/proto_args.py
+++ b/nxc/protocols/nfs/proto_args.py
@@ -3,7 +3,7 @@ def proto_args(parser, parents):
     nfs_parser.add_argument("--port", type=int, default=111, help="NFS portmapper port (default: %(default)s)")
     nfs_parser.add_argument("--nfs-timeout", type=int, default=5, help="NFS connection timeout (default: %(default)ss)")
 
-    dgroup = nfs_parser.add_argument_group("NFS Mapping/Enumeration", "Options for Mapping/Enumerating NFS")
+    dgroup = nfs_parser.add_argument_group("NFS Mapping/Enumeration")
     dgroup.add_argument("--share", help="Specify a share, e.g. for --ls, --get-file, --put-file")
     dgroup.add_argument("--shares", action="store_true", help="List NFS shares")
     dgroup.add_argument("--enum-shares", nargs="?", type=int, const=3, help="Authenticate and enumerate exposed shares recursively (default depth: %(const)s)")

--- a/nxc/protocols/rdp/proto_args.py
+++ b/nxc/protocols/rdp/proto_args.py
@@ -17,7 +17,7 @@ def proto_args(parser, parents):
     egroup.add_argument("--screentime", type=int, default=10, help="Time to wait for desktop image")
     egroup.add_argument("--res", default="1024x768", help="Resolution in WIDTHxHEIGHT format")
 
-    cgroup = rdp_parser.add_argument_group("Command Execution", "Options for executing commands")
+    cgroup = rdp_parser.add_argument_group("Command Execution")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified command")
     cgroup.add_argument("-X", metavar="PS_COMMAND", dest="ps_execute", help="execute the specified PowerShell command")
     cgroup.add_argument("--cmd-delay", type=int, default=5, help="Sleep time before executing command")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -29,7 +29,7 @@ def proto_args(parser, parents):
     generate_st.make_required = [delegate_arg]
     delegate_spn_arg.make_required = [delegate_arg]
 
-    cred_gathering_group = smb_parser.add_argument_group("Credential Gathering", "Options for gathering credentials")
+    cred_gathering_group = smb_parser.add_argument_group("Credential Gathering")
     cred_gathering_group.add_argument("--sam", choices={"regdump", "secdump"}, nargs="?", const="regdump", help="dump SAM hashes from target systems")
     cred_gathering_group.add_argument("--lsa", choices={"regdump", "secdump"}, nargs="?", const="regdump", help="dump LSA secrets from target systems")
     cred_gathering_group.add_argument("--ntds", choices={"vss", "drsuapi"}, nargs="?", const="drsuapi", help="dump the NTDS.dit from target DCs using the specifed method")
@@ -40,7 +40,7 @@ def proto_args(parser, parents):
     cred_gathering_group.add_argument("--enabled", action="store_true", help="Only dump enabled targets from DC")
     cred_gathering_group.add_argument("--user", dest="userntds", type=str, help="Dump selected user from DC")
 
-    mapping_enum_group = smb_parser.add_argument_group("Mapping/Enumeration", "Options for Mapping/Enumerating")
+    mapping_enum_group = smb_parser.add_argument_group("Mapping/Enumeration")
     mapping_enum_group.add_argument("--shares", type=str, nargs="?", const="", help="Enumerate shares and access, filter on specified argument (read ; write ; read,write)")
     mapping_enum_group.add_argument("--dir", nargs="?", type=str, const="", help="List the content of a path (default path: '%(const)s')")
     mapping_enum_group.add_argument("--interfaces", action="store_true", help="Enumerate network interfaces")
@@ -62,11 +62,11 @@ def proto_args(parser, parents):
     mapping_enum_group.add_argument("--tasklist", type=str, nargs="?", const=True, help="Enumerate running processes and filter for the specified one if specified")
     mapping_enum_group.add_argument("--taskkill", type=str, help="Kills a specific PID or a proces name's PID's")
 
-    wmi_group = smb_parser.add_argument_group("WMI", "Options for WMI Queries")
+    wmi_group = smb_parser.add_argument_group("WMI Queries")
     wmi_group.add_argument("--wmi", metavar="QUERY", type=str, help="issues the specified WMI query")
     wmi_group.add_argument("--wmi-namespace", metavar="NAMESPACE", default="root\\cimv2", help="WMI Namespace")
 
-    spidering_group = smb_parser.add_argument_group("Spidering", "Options for spidering shares")
+    spidering_group = smb_parser.add_argument_group("Spidering Shares")
     spidering_group.add_argument("--spider", metavar="SHARE", type=str, help="share to spider")
     spidering_group.add_argument("--spider-folder", metavar="FOLDER", default=".", type=str, help="folder to spider")
     spidering_group.add_argument("--content", action="store_true", help="enable file content searching")
@@ -78,12 +78,12 @@ def proto_args(parser, parents):
     segroup.add_argument("--pattern", nargs="+", help="pattern(s) to search for in folders, filenames and file content")
     segroup.add_argument("--regex", nargs="+", help="regex(s) to search for in folders, filenames and file content")
 
-    files_group = smb_parser.add_argument_group("Files", "Options for remote file interaction")
+    files_group = smb_parser.add_argument_group("File Operations")
     files_group.add_argument("--put-file", action="append", nargs=2, metavar="FILE", help="Put a local file into remote target, ex: whoami.txt \\\\Windows\\\\Temp\\\\whoami.txt")
     files_group.add_argument("--get-file", action="append", nargs=2, metavar="FILE", help="Get a remote file, ex: \\\\Windows\\\\Temp\\\\whoami.txt whoami.txt")
     files_group.add_argument("--append-host", action="store_true", help="append the host to the get-file filename")
 
-    cmd_exec_group = smb_parser.add_argument_group("Command Execution", "Options for executing commands")
+    cmd_exec_group = smb_parser.add_argument_group("Command Execution")
     cmd_exec_group.add_argument("--exec-method", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
     cmd_exec_group.add_argument("--dcom-timeout", help="DCOM connection timeout", type=int, default=5)
     cmd_exec_group.add_argument("--get-output-tries", help="Number of times atexec/smbexec/mmcexec tries to get results", type=int, default=10)
@@ -94,7 +94,7 @@ def proto_args(parser, parents):
     cmd_exec_method_group.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified CMD command")
     cmd_exec_method_group.add_argument("-X", metavar="PS_COMMAND", dest="ps_execute", help="execute the specified PowerShell command")
 
-    posh_group = smb_parser.add_argument_group("Powershell Obfuscation", "Options for PowerShell script obfuscation")
+    posh_group = smb_parser.add_argument_group("Powershell Script Obfuscation")
     posh_group.add_argument("--obfs", action="store_true", help="Obfuscate PowerShell scripts")
     posh_group.add_argument("--amsi-bypass", nargs=1, metavar="FILE", help="File with a custom AMSI bypass")
     posh_group.add_argument("--clear-obfscripts", action="store_true", help="Clear all cached obfuscated PowerShell scripts")

--- a/nxc/protocols/ssh/proto_args.py
+++ b/nxc/protocols/ssh/proto_args.py
@@ -12,11 +12,11 @@ def proto_args(parser, parents):
     ssh_parser.add_argument("--get-output-tries", type=int, default=5, help="Number of times with sudo command tries to get results")
     sudo_check_method_arg.make_required.append(sudo_check_arg)
 
-    files_group = ssh_parser.add_argument_group("Files", "Options for remote file interaction")
+    files_group = ssh_parser.add_argument_group("File Operations")
     files_group.add_argument("--put-file", action="append", nargs=2, metavar="FILE", help="Put a local file into remote target, ex: whoami.txt /tmp/whoami.txt")
     files_group.add_argument("--get-file", action="append", nargs=2, metavar="FILE", help="Get a remote file, ex: /tmp/whoami.txt whoami.txt")
 
-    cgroup = ssh_parser.add_argument_group("Command Execution", "Options for executing commands")
+    cgroup = ssh_parser.add_argument_group("Command Execution")
     cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target, map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified command")

--- a/nxc/protocols/winrm/proto_args.py
+++ b/nxc/protocols/winrm/proto_args.py
@@ -13,12 +13,12 @@ def proto_args(parser, parents):
     dgroup.add_argument("-d", metavar="DOMAIN", dest="domain", type=str, default=None, help="domain to authenticate to")
     dgroup.add_argument("--local-auth", action="store_true", help="authenticate locally to each target")
 
-    cgroup = winrm_parser.add_argument_group("Credential Gathering", "Options for gathering credentials")
+    cgroup = winrm_parser.add_argument_group("Credential Gathering")
     cgroup.add_argument("--dump-method", action="store", default="cmd", choices={"cmd", "powershell"}, help="Select shell type in hashes dump")
     cgroup.add_argument("--sam", action="store_true", help="dump SAM hashes from target systems")
     cgroup.add_argument("--lsa", action="store_true", help="dump LSA secrets from target systems")
 
-    cgroup = winrm_parser.add_argument_group("Command Execution", "Options for executing commands")
+    cgroup = winrm_parser.add_argument_group("Command Execution")
     cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified command")

--- a/nxc/protocols/wmi/proto_args.py
+++ b/nxc/protocols/wmi/proto_args.py
@@ -9,11 +9,11 @@ def proto_args(parser, parents):
     dgroup.add_argument("-d", metavar="DOMAIN", dest="domain", default=None, type=str, help="Domain to authenticate to")
     dgroup.add_argument("--local-auth", action="store_true", help="Authenticate locally to each target")
 
-    egroup = wmi_parser.add_argument_group("Mapping/Enumeration", "Options for Mapping/Enumerating")
+    egroup = wmi_parser.add_argument_group("Mapping/Enumeration")
     egroup.add_argument("--wmi", metavar="QUERY", dest="wmi", type=str, help="Issues the specified WMI query")
     egroup.add_argument("--wmi-namespace", metavar="NAMESPACE", type=str, default="root\\cimv2", help="WMI Namespace (default: root\\cimv2)")
 
-    cgroup = wmi_parser.add_argument_group("Command Execution", "Options for executing commands")
+    cgroup = wmi_parser.add_argument_group("Command Execution")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", type=str, help="Creates a new cmd process and executes the specified command with output")
     cgroup.add_argument("-X", metavar="COMMAND", dest="execute_psh", type=str, help="Creates a new PowerShell process and executes the specified command with output")


### PR DESCRIPTION
## Description

The help page is bugging me since the beginning of time. Imo there is just a LOT of information and finding args you are looking for is sometimes really hard. One factor of this are "group subtitles" which are added to most groups like `Command Execution` and take up 2 lines without adding any value. 

Therefore i removed nearly all subtitles for argparse group because most of the time it was `Command Execution: Options for [Command Execution]` anyway. This removes a ton of space and empty lines making the help page easier to read (see side by side comparison below).

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] QOL

## Setup guide for the review
`nxc smb --help`

## Screenshots (if appropriate):
Side by side comparison of `nxc mssql --help`:
<img width="2076" height="1087" alt="2025-11-18_19-50" src="https://github.com/user-attachments/assets/89eae999-aaf5-4840-b8e0-e78a0c9d335b" />
SMB help page:
<img width="2055" height="1081" alt="image" src="https://github.com/user-attachments/assets/285845a8-dc24-4fdf-b27b-11993e0bd561" />
