### PR TITLE
Fix import to fix sqlalchemy deprecation warning

### DIFF
--- a/nxc/protocols/ftp/database.py
+++ b/nxc/protocols/ftp/database.py
@@ -1,7 +1,7 @@
 
 from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, select, delete, func
 from sqlalchemy.dialects.sqlite import Insert
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger

--- a/nxc/protocols/ldap/database.py
+++ b/nxc/protocols/ldap/database.py
@@ -1,7 +1,7 @@
 
 from sqlalchemy import Boolean, Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, func, select, delete
 from sqlalchemy.dialects.sqlite import Insert  # used for upsert
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger

--- a/nxc/protocols/mssql/database.py
+++ b/nxc/protocols/mssql/database.py
@@ -3,7 +3,7 @@ import warnings
 from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, func, select, insert, update, delete
 from sqlalchemy.dialects.sqlite import Insert  # used for upsert
 from sqlalchemy.exc import SAWarning
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger

--- a/nxc/protocols/nfs/database.py
+++ b/nxc/protocols/nfs/database.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 
 from nxc.database import BaseDB

--- a/nxc/protocols/rdp/database.py
+++ b/nxc/protocols/rdp/database.py
@@ -1,6 +1,6 @@
 
 from sqlalchemy import Column, Integer, PrimaryKeyConstraint, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from nxc.database import BaseDB
 

--- a/nxc/protocols/smb/database.py
+++ b/nxc/protocols/smb/database.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.sqlite import Insert  # used for upsert
 from sqlalchemy.exc import (
     SAWarning
 )
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger

--- a/nxc/protocols/ssh/database.py
+++ b/nxc/protocols/ssh/database.py
@@ -2,7 +2,7 @@ import configparser
 
 from sqlalchemy import Boolean, Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, select, func, delete
 from sqlalchemy.dialects.sqlite import Insert
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger

--- a/nxc/protocols/vnc/database.py
+++ b/nxc/protocols/vnc/database.py
@@ -2,7 +2,7 @@ import warnings
 
 from sqlalchemy import Column, Integer, PrimaryKeyConstraint, String
 from sqlalchemy.exc import SAWarning
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from nxc.database import BaseDB
 

--- a/nxc/protocols/winrm/database.py
+++ b/nxc/protocols/winrm/database.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, select, func, delete
 from sqlalchemy.dialects.sqlite import Insert
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from nxc.database import BaseDB, format_host_query
 from nxc.logger import nxc_logger

--- a/nxc/protocols/wmi/database.py
+++ b/nxc/protocols/wmi/database.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, PrimaryKeyConstraint, String
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from nxc.database import BaseDB
 
 Base = declarative_base()


### PR DESCRIPTION
## Description

Fixes a deprecation warning from sqlalchemy.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Run with warnings enabled

## Screenshots (if appropriate):
<img width="1584" height="871" alt="image" src="https://github.com/user-attachments/assets/7da54e79-0c63-4227-b8b3-a41da46f967a" />
