### PR TITLE
Fix bug when using delegation

### DIFF
--- a/nxc/protocols/smb/kerberos.py
+++ b/nxc/protocols/smb/kerberos.py
@@ -156,7 +156,7 @@ def kerberos_login_with_S4U(domain, hostname, username, password, nthash, lmhash
         tgs_formated["KDC_REP"] = r
         tgs_formated["cipher"] = cipher
         tgs_formated["sessionKey"] = new_session_key
-        return tgs_formated
+        return tgs_formated, session_key
 
     ################################################################################
     # Up until here was all the S4USelf stuff. Now let's start with S4U2Proxy


### PR DESCRIPTION
## Description

With the merge of https://github.com/Pennyw0rth/NetExec/pull/825 there was a bug introduced that is triggered when using `--delegate` and `--self`. This is now fixed by returning the session key as well, as expected by the caller.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
`nxc smb --delegate Admin --self`

## Screenshots (if appropriate):
Before:
<img width="1568" height="1131" alt="image" src="https://github.com/user-attachments/assets/ebe8ec54-6265-430e-8d63-ac8c9e6444a5" />
After:
<img width="1567" height="84" alt="image" src="https://github.com/user-attachments/assets/b201767c-7ca2-42ec-aea5-ef556aa113b5" />
