### PR TITLE
enum_av : add WithSecure Elements detector

### DIFF
--- a/nxc/modules/enum_av.py
+++ b/nxc/modules/enum_av.py
@@ -471,7 +471,7 @@ conf = {
                 {"name": "wsulavprohoster", "description": "WithSecure Ultralight Protected AV Hoster"}
             ],
             "pipes": [
-                {"name": "FS_CCFIPC_*", "processes": ["fsatpn.exe","fsatpl.exe","fshoster32.exe","fsulprothoster.exe","fsulprothoster.exe","fshoster64.exe","FsPisces.exe","fsdevcon.exe"]}
+                {"name": "FS_CCFIPC_*", "processes": ["fsatpn.exe", "fsatpl.exe", "fshoster32.exe", "fsulprothoster.exe", "fsulprothoster.exe", "fshoster64.exe", "FsPisces.exe", "fsdevcon.exe"]}
             ]
         }
     ]


### PR DESCRIPTION
## Description
The module `enum_av.py` now detects WithSecure Elements agent.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Tested againts a Windows Server with WithSecure Elements agent installed and running.

## Screenshots (if appropriate):
<img width="1463" height="107" alt="image" src="https://github.com/user-attachments/assets/45033655-3209-4bd1-8248-a671443f0659" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
