### PR TITLE
add AES key dumping to ntds

### DIFF
--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -39,6 +39,8 @@ def proto_args(parser, parents):
     cred_gathering_group.add_argument("--pvk", action="store", help="DPAPI option. File with domain backupkey")
     cred_gathering_group.add_argument("--enabled", action="store_true", help="Only dump enabled targets from DC")
     cred_gathering_group.add_argument("--user", dest="userntds", type=str, help="Dump selected user from DC")
+    cred_gathering_group.add_argument("--aes128", action="store_true", help="Also dump Kerberos AES-128 keys from target DC (NTDS.dit)")
+    cred_gathering_group.add_argument("--aes256", action="store_true", help="Also dump Kerberos AES-256 keys from target DC (NTDS.dit)")
 
     mapping_enum_group = smb_parser.add_argument_group("Mapping/Enumeration")
     mapping_enum_group.add_argument("--shares", type=str, nargs="?", const="", help="Enumerate shares and access, filter on specified argument (read ; write ; read,write)")


### PR DESCRIPTION
## Description

This PR adds support for extracting **Kerberos AES keys** (AES-128 / AES-256) from **NTDS.dit** during the `--ntds` credential gathering phase.

It directly addresses the enhancement requested in [**#947**,](https://github.com/Pennyw0rth/NetExec/issues/947) which asked for AES key extraction when dumping NTDS secrets.

### Why this enhancement?

* Windows Server 2025, where RC4 is disabled by default, now relies on AES-only Kerberos keys.
* The raisechild module only supports RC4, so it doesn’t work on Windows Server 2025 domain controllers where RC4 is disabled by default. Extracting AES keys fixes this limitation.
* With this improvement, NetExec can now:

  * Extract AES-128 and/or AES-256 keys via `--aes128` and `--aes256`
  * Preserve legacy **NTLM-only behavior by default** (no change unless the user explicitly requests AES)

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):

`aes128` : 

<img width="1566" height="940" alt="1" src="https://github.com/user-attachments/assets/9a39195f-f3ac-46a4-b8fb-478f4d368487" />


`aes256` : 

<img width="1544" height="963" alt="2" src="https://github.com/user-attachments/assets/4a9b4551-aa62-4c8e-86ef-15bbf49b7ddb" />

`both` : 

<img width="1214" height="1011" alt="3" src="https://github.com/user-attachments/assets/684b233c-2f9a-4995-86c3-1c5c0f272efb" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
