### PR TITLE
Add --summary flag for authentication results overview

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -37,6 +37,7 @@ def gen_cli_args():
     output_group = output_parser.add_argument_group("Output Options")
     output_group.add_argument("--no-progress", action="store_true", help="do not displaying progress bar during scan")
     output_group.add_argument("--log", metavar="LOG", help="export result into a custom file")
+    output_group.add_argument("--summary", action="store_true", help="display a summary of authentication results at the end")
     log_level = output_group.add_mutually_exclusive_group()
     log_level.add_argument("--verbose", action="store_true", help="enable verbose output")
     log_level.add_argument("--debug", action="store_true", help="enable debug level information")

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -11,7 +11,7 @@ from nxc.loaders.moduleloader import ModuleLoader
 from nxc.first_run import first_run_setup
 from nxc.paths import NXC_PATH, WORKSPACE_DIR
 from nxc.console import nxc_console
-from nxc.logger import nxc_logger
+from nxc.logger import nxc_logger, NXCAdapter
 from nxc.config import nxc_config, nxc_workspace, config_log
 from nxc.database import create_db_engine
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -207,11 +207,16 @@ def main():
     if args.jitter and len(targets) > 1:
         nxc_logger.highlight(highlight("[!] Jitter is only throttling authentications per target!", "red"))
 
+    if hasattr(args, "summary") and args.summary:
+        NXCAdapter.summary_enabled = True
+
     try:
         asyncio.run(start_run(protocol_object, args, db, targets))
     except KeyboardInterrupt:
         nxc_logger.debug("Got keyboard interrupt")
     finally:
+        if NXCAdapter.summary_enabled:
+            nxc_logger.display_summary()
         db_engine.dispose()
 
 


### PR DESCRIPTION
## Summary

Reimplementation of #886 by @Cyb3rC3lt  with improvements addressing reviewer feedback from @NeffIsBack and @Marshall-Hallenbeck :

- **All protocols**: Supports SMB, LDAP, RDP, WMI, MSSQL, WinRM, SSH, FTP, VNC (not just SMB/LDAP/RDP)
- **Central hook**: Captures results in `try_credentials()` after login returns, minimizing per-protocol changes while preserving `admin_privs` context
- **Interesting failures**: Detects password-expired, account-locked, and similar errors that reveal valid usernames
- **Respects config**: Uses `pwn3d_label` from user's nxc.conf

### Usage

```bash
nxc smb 192.168.1.0/24 -u users.txt -p passwords.txt --summary
```

### Example Output

```
NXC    Finished, 2 success, 1 interesting, 47 failed
[+] Successful Authentications (2):
[+]   SMB    10.0.73.130:445 DESKTOP-8NUT61P\Administrator (Admin!)
[+]   SMB    10.0.73.131:445 CORP\svc_backup
[*] Interesting Failures (1):
[*]   SMB    10.0.73.130:445 CORP\old_admin - STATUS_PASSWORD_EXPIRED
```
<img width="1256" height="257" alt="image" src="https://github.com/user-attachments/assets/7605da70-ff86-411d-93fd-6bf349666965" />
## Test Plan

- [x] Tested with SMB protocol using multiple credentials
- [x] Verified admin flag displays correctly with custom `pwn3d_label`
- [x] Ruff lint checks pass

Closes #886

cc @Marshall-Hallenbeck @Cyb3rC3lt @NeffIsBack