### PR TITLE
Fix NetBIOS resolution in raisechild

### DIFF
--- a/nxc/modules/raisechild.py
+++ b/nxc/modules/raisechild.py
@@ -18,7 +18,7 @@ from impacket.krb5.pac import VALIDATION_INFO, KERB_VALIDATION_INFO, PAC_LOGON_I
 from impacket.dcerpc.v5.ndr import NDRULONG
 from impacket.dcerpc.v5.samr import GROUP_MEMBERSHIP, SE_GROUP_MANDATORY, SE_GROUP_ENABLED_BY_DEFAULT, SE_GROUP_ENABLED, USER_NORMAL_ACCOUNT, USER_DONT_EXPIRE_PASSWORD
 from impacket.dcerpc.v5.dtypes import SID, RPC_SID, NULL
-from nxc.parsers.ldap_results import ldapasn1_impacket, parse_result_attributes
+from nxc.parsers.ldap_results import parse_result_attributes
 from nxc.helpers.misc import CATEGORY
 
 
@@ -147,19 +147,8 @@ class NXCModule:
         return smb
 
     def _get_domain_netbios(self, ldap_conn):
-        root_dse = parse_result_attributes(
-            ldap_conn.ldap_connection.search(
-                scope=ldapasn1_impacket.Scope("baseObject"),
-                searchBase="",
-                searchFilter="(objectClass=*)",
-                attributes=["configurationNamingContext"],
-                sizeLimit=0,
-            )
-        )[0]
-        forrest_root_dn = root_dse["configurationNamingContext"]
-
         resp = ldap_conn.search(
-            baseDN=f"CN=Partitions,{forrest_root_dn}",
+            baseDN=f"CN=Partitions,{ldap_conn.configuration_context}",
             searchFilter=f"(&(objectCategory=crossRef)(dnsRoot={ldap_conn.targetDomain})(nETBIOSName=*))",
             attributes=["nETBIOSName"],
         )

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -157,6 +157,7 @@ class ldap(connection):
         self.no_ntlm = False
         self.sid_domain = ""
         self.scope = None
+        self.configuration_context = ""
 
         connection.__init__(self, args, db, host)
 
@@ -268,11 +269,12 @@ class ldap(connection):
         try:
             resp = self.ldap_connection.search(
                 scope=ldapasn1_impacket.Scope("baseObject"),
-                attributes=["defaultNamingContext", "dnsHostName"],
+                attributes=["dnsHostName", "defaultNamingContext", "configurationNamingContext"],
                 sizeLimit=0,
             )
             resp_parsed = parse_result_attributes(resp)[0]
 
+            self.configuration_context = resp_parsed["configurationNamingContext"]
             target = resp_parsed["dnsHostName"]
             base_dn = resp_parsed["defaultNamingContext"]
             target_domain = sub(


### PR DESCRIPTION
## Description

This PR fixes how the `raisechild` module resolves the domain NetBIOS name.

Previously, the module was using `ldap_conn.domain.split(".")[0]` to derive the NetBIOS name from the FQDN. This works only when the NetBIOS name matches the first label of the FQDN, and fails as soon as the domain uses a different NetBIOS name.

The new implementation queries LDAP to retrieve the actual NetBIOS name from the directory instead of guessing it from the FQDN. This makes DCSync and ticket forging reliable even when the NetBIOS name differs from the DNS domain name.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
