### PR TITLE
Insert FQDN instead of NETBIOS name into winrm db

### DIFF
--- a/nxc/protocols/winrm/database.py
+++ b/nxc/protocols/winrm/database.py
@@ -83,7 +83,6 @@ class database(BaseDB):
         Check if this host has already been added to the database, if not, add it in.
         TODO: return inserted or updated row ids as a list
         """
-        domain = domain.split(".")[0].upper()
         hosts = []
 
         q = select(self.HostsTable).filter(self.HostsTable.c.ip == ip)


### PR DESCRIPTION
## Description

For reasons the original winrm database implementation added the NetBIOS name to the host entry instead of the FQDN of the domain. Reported in #582 and fixed here.

Fixes #582 

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Scan host with winrm and check db.

## Screenshots:
Before&After:
<img width="1030" height="227" alt="image" src="https://github.com/user-attachments/assets/04fb749c-14a8-4b83-95ff-98a9fc62a87f" />

