### PR TITLE
Fix accidental creation of empty workspace

### DIFF
--- a/nxc/nxcdb.py
+++ b/nxc/nxcdb.py
@@ -510,7 +510,7 @@ class NXCDBMenu(cmd.Cmd):
     @staticmethod
     def help_workspace():
         help_string = """
-        workspace [create <targetName> | workspace list | workspace <targetName>]
+        workspace [workspace create <targetName> | workspace list | workspace <targetName>]
         """
         print_help(help_string)
 


### PR DESCRIPTION
## Description

After printing the help we didn't return leading to the creation of a workspace with an empty name, breaking everything else.
Fixes #1032.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Open nxcdb and run `workspace`. That will create an empty workspace which breaks the path to the workspaces.
