### PR TITLE
enum_av module: add Malwarebytes EDR Agent indicator

### DIFF
--- a/nxc/modules/enum_av.py
+++ b/nxc/modules/enum_av.py
@@ -350,6 +350,18 @@ conf = {
             ]
         },
         {
+            "name": "Malwarebytes",
+            "services": [
+                {"name": "MBAMService", "description": "Malwarebytes Service"},
+                {"name": "MBEndpointAgent", "description": "Malwarebytes Cloud Endpoint Agent Service"}
+            ],
+            "pipes": [
+                {"name": "MBLG", "processes": ["MBAMService.exe"]},
+                {"name": "MBEA2_R", "processes": ["MBCloudEA.exe"]},
+                {"name": "MBEA2_W", "processes": ["MBCloudEA.exe"]}
+            ]
+        },
+        {
             "name": "Panda Adaptive Defense 360",
             "services": [
                 {"name": "PandaAetherAgent", "description": "Panda Endpoint Agent"},


### PR DESCRIPTION
## Description

Added Malwarebytes indicators for `enum_av.py` module.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Tested `enum_av.py` module against a Windows machine with Malwarebytes installed.

## Screenshots (if appropriate):
<img width="1633" height="139" alt="Malwarebytes" src="https://github.com/user-attachments/assets/9b4bd876-db84-4d75-9bbd-67d2bb26d217" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
