### PR TITLE
Fix Not Listing All User on Groups

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -838,7 +838,7 @@ class ldap(connection):
             else:
                 for item in resp_parsed:
                     # Display sAMAccountName or CN if sAMAccountName not present (could be a group)
-                    self.logger.highlight(item.get("sAMAccountName", item.get("cn", "")))
+                    self.logger.highlight(item["sAMAccountName"] if "group" not in item["objectClass"] else item["cn"])
         else:
             # Display all groups
             self.logger.highlight(f"{'-Group-':<40} {'-Members-':<9} {'-Description-':<60}")


### PR DESCRIPTION
## Description

The previous implementation relied on reading the group’s member attribute, which is subject to Active Directory’s MaxValRange limitation and therefore returns incomplete results for large groups. In addition, this approach does not resolve nested group membership, causing users who inherit membership through sub-groups to be missed. Another limitation is that users whose membership is defined via primaryGroupID do not appear in either member or memberOf, leading to further false negatives.

To address these issues, the logic was updated to enumerate users directly instead of parsing group attributes. Membership resolution now uses the LDAP matching rule memberOf:1.2.840.113556.1.4.1941, which correctly expands nested group relationships. The group’s objectSid is retrieved and its RID is dynamically extracted to include users whose membership is defined through primaryGroupID.

Tested on 3000+ users in real life test.

Important Details:

- Also confirmed for RDP to DC and listed all DA Users (7) on "Users and Groups Management".
- Bloodhound only shows for RID 512 for Domain Admins. In this real life scenario it shows only 2 users but there are 7. Maybe this is only for tihs case but it looks like important right now.


Before - Listing 5 DA Users
<img width="1573" height="142" alt="image" src="https://github.com/user-attachments/assets/37208f47-01e1-4672-8386-190c69e99f27" />


After - Listing 7 DA Users
<img width="1634" height="179" alt="image" src="https://github.com/user-attachments/assets/b31e5978-44f4-4a9b-bd26-cc6e31507849" />

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
