### PR TITLE
Fix ls arg in nfs

### DIFF
--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -658,6 +658,9 @@ class nfs(connection):
             if "resfail" in res and res["status"] == NFS3ERR_NOENT:
                 self.logger.fail(f"Unknown path: {self.args.ls!r}")
                 return
+            elif "resfail" in res:
+                self.logger.fail(f"Error on looking up path '{sub_path}': {NFSSTAT3[res['status']]}")
+                return
             # If file then break and only display file
             if res["resok"]["obj_attributes"]["attributes"]["type"] == NF3REG:
                 is_file = True


### PR DESCRIPTION
## Description

In #1049 it was reported that auths in NFS fail if the sub dir has different permissions than the share. Furthermore, when we don't have access to a dir the command raises an exception instead of cleanly display the issue and exiting. This is solved now.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Create an nfs dir with different permissions than the exported share and try `--ls`. On that path:
<img width="461" height="348" alt="image" src="https://github.com/user-attachments/assets/ab67b93b-b310-4d28-b3c8-858930ec5f84" />


## Screenshots (if appropriate):
Properly updates uid and gid for sub paths:
<img width="998" height="229" alt="image" src="https://github.com/user-attachments/assets/ebe21477-9540-4178-8077-25e578ac04be" />
Cleanly exits on access denied:
<img width="895" height="98" alt="image" src="https://github.com/user-attachments/assets/8d32816f-5df4-42c9-b54d-b14253aab415" />
