### PR TITLE
Implement shadow copy dumping for SAM and LSA

### DIFF
--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -31,8 +31,8 @@ def proto_args(parser, parents):
     delegate_spn_arg.make_required = [delegate_arg]
 
     cred_gathering_group = smb_parser.add_argument_group("Credential Gathering")
-    cred_gathering_group.add_argument("--sam", choices={"regdump", "secdump", "vss"}, nargs="?", const="regdump", help="dump SAM hashes from target systems using the specifed method")
-    cred_gathering_group.add_argument("--lsa", choices={"regdump", "secdump", "vss"}, nargs="?", const="regdump", help="dump LSA secrets from target systems using the specifed method")
+    cred_gathering_group.add_argument("--sam", choices={"regdump", "secdump", "vss"}, nargs="?", const="regdump", help="dump SAM hashes from target systems using the specifed method (default: %(const)s)")
+    cred_gathering_group.add_argument("--lsa", choices={"regdump", "secdump", "vss"}, nargs="?", const="regdump", help="dump LSA secrets from target systems using the specifed method (default: %(const)s)")
     ntds_arg = cred_gathering_group.add_argument("--ntds", choices={"vss", "drsuapi"}, nargs="?", const="drsuapi", help="dump the NTDS.dit from target DCs using the specifed method")
     # NTDS options
     kerb_keys_arg = cred_gathering_group.add_argument("--kerberos-keys", action=get_conditional_action(_StoreTrueAction), make_required=[], help="Also dump Kerberos AES and DES keys from target DC (NTDS.dit)")


### PR DESCRIPTION
## Description

This PR extends the shadow copy implementation. Previously, this method was only available for NTDS dumping. I have added support for dumping SAM and LSA secrets using shadow copies as well

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)


## Screenshots (if appropriate):

SAM : 

<img width="1383" height="213" alt="1" src="https://github.com/user-attachments/assets/6dd60430-62ef-4461-93aa-7d37e0782a00" />

LSA : 

<img width="1897" height="343" alt="lsa" src="https://github.com/user-attachments/assets/152221af-0d1f-48d5-aa93-9f5c7c6a61e5" />



## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
