### PR TITLE
Added --impersonate flag on mssql protocol

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -253,13 +253,12 @@ class connection:
 
             self.print_host_info()
             if self.login() or (self.username == "" and self.password == ""):
+                self.logger.debug("Calling command arguments")
+                self.call_cmd_args()
                 if hasattr(self.args, "module") and self.args.module:
                     self.load_modules()
                     self.logger.debug("Calling modules")
                     self.call_modules()
-                else:
-                    self.logger.debug("Calling command arguments")
-                    self.call_cmd_args()
             self.disconnect()
 
     def call_cmd_args(self):

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -44,6 +44,7 @@ class mssql(connection):
         self.lmhash = ""
         self.nthash = ""
         self.is_mssql = False
+        self.impersonation_applied = False
 
         connection.__init__(self, args, db, host)
 
@@ -156,6 +157,21 @@ class mssql(connection):
     def print_host_info(self):
         encryption = colored(f"EncryptionReq:{self.encryption}", host_info_colors[0 if self.encryption else 1], attrs=["bold"])
         self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.targetDomain}) ({encryption})")
+
+    def call_cmd_args(self):
+        if getattr(self.args, "impersonate", None) and not self.impersonation_applied and not self.impersonate():
+            return
+        for attr, value in vars(self.args).items():
+            if attr == "impersonate":
+                continue
+            if hasattr(self, attr) and callable(getattr(self, attr)) and value is not False and value is not None:
+                self.logger.debug(f"Calling {attr}()")
+                getattr(self, attr)()
+
+    def call_modules(self):
+        if getattr(self.args, "impersonate", None) and not self.impersonation_applied and not self.impersonate():
+            return
+        super().call_modules()
 
     @reconnect_mssql
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
@@ -275,6 +291,43 @@ class mssql(connection):
             error_msg = self.handle_mssql_reply()
             self.logger.fail(f"{self.domain}\\{self.username}:{process_secret(self.nthash)} {error_msg if error_msg else ''}")
             return False
+
+    def impersonate(self):
+        target = self.args.impersonate
+        if not target:
+            self.logger.error("No impersonation target specified")
+            return False
+
+        mode = "LOGIN"
+        raw_target = str(target)
+        lowered = raw_target.lower()
+        if lowered.startswith("login:"):
+            raw_target = raw_target.split(":", 1)[1]
+            mode = "LOGIN"
+        elif lowered.startswith("user:"):
+            raw_target = raw_target.split(":", 1)[1]
+            mode = "USER"
+
+        raw_target = raw_target.strip()
+        if not raw_target:
+            self.logger.error("Impersonation target is empty")
+            return False
+
+        safe_target = raw_target.replace("'", "''")
+        try:
+            self.conn.sql_query(f"EXECUTE AS {mode} = N'{safe_target}';")
+            if self.conn.lastError:
+                self.logger.fail(self.conn.lastError)
+                return False
+            self.logger.success(f"Impersonation set: {mode}={raw_target}")
+            self.impersonation_applied = True
+            if self.args.debug:
+                res = self.conn.sql_query("SELECT SYSTEM_USER, SUSER_SNAME();")
+                self.logger.debug(f"Impersonated context: {res}")
+        except Exception as e:
+            self.logger.fail(f"Failed to impersonate {mode} {raw_target}: {e}")
+            return False
+        return True
 
     def query(self):
         if self.conn.lastError:

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -160,7 +160,7 @@ class mssql(connection):
 
     def call_cmd_args(self):
         if getattr(self.args, "impersonate", None) and not self.impersonation_applied and not self.impersonate():
-            return
+            raise SystemExit
         for attr, value in vars(self.args).items():
             if attr == "impersonate":
                 continue
@@ -170,7 +170,7 @@ class mssql(connection):
 
     def call_modules(self):
         if getattr(self.args, "impersonate", None) and not self.impersonation_applied and not self.impersonate():
-            return
+            raise SystemExit
         super().call_modules()
 
     @reconnect_mssql

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -158,19 +158,6 @@ class mssql(connection):
         encryption = colored(f"EncryptionReq:{self.encryption}", host_info_colors[0 if self.encryption else 1], attrs=["bold"])
         self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.targetDomain}) ({encryption})")
 
-    def call_cmd_args(self):
-        if getattr(self.args, "impersonate", None) and not self.impersonation_applied and not self.impersonate():
-            raise SystemExit
-        for attr, value in vars(self.args).items():
-            if attr == "impersonate":
-                continue
-            if hasattr(self, attr) and callable(getattr(self, attr)) and value is not False and value is not None:
-                self.logger.debug(f"Calling {attr}()")
-                getattr(self, attr)()
-
-    def call_modules(self):
-        super().call_modules()
-
     @reconnect_mssql
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
         self.username = username

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -169,8 +169,6 @@ class mssql(connection):
                 getattr(self, attr)()
 
     def call_modules(self):
-        if getattr(self.args, "impersonate", None) and not self.impersonation_applied and not self.impersonate():
-            raise SystemExit
         super().call_modules()
 
     @reconnect_mssql

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -291,9 +291,8 @@ class mssql(connection):
             self.logger.error("Impersonation target is empty")
             return False
 
-        safe_target = target.replace("'", "''")
         try:
-            self.conn.sql_query(f"EXECUTE AS {mode} = N'{safe_target}';")
+            self.conn.sql_query(f"EXECUTE AS {mode} = N'{target}';")
             if self.conn.lastError:
                 self.logger.fail(self.conn.lastError)
                 return False

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -291,39 +291,32 @@ class mssql(connection):
             return False
 
     def impersonate(self):
-        target = self.args.impersonate
-        if not target:
-            self.logger.error("No impersonation target specified")
-            return False
-
         mode = "LOGIN"
-        raw_target = str(target)
-        lowered = raw_target.lower()
-        if lowered.startswith("login:"):
-            raw_target = raw_target.split(":", 1)[1]
+        target = self.args.impersonate.strip()
+        if target.lower().startswith("login:"):
+            target = target.split(":", 1)[1].strip()
             mode = "LOGIN"
-        elif lowered.startswith("user:"):
-            raw_target = raw_target.split(":", 1)[1]
+        elif target.lower().startswith("user:"):
+            target = target.split(":", 1)[1].strip()
             mode = "USER"
 
-        raw_target = raw_target.strip()
-        if not raw_target:
+        if not target:
             self.logger.error("Impersonation target is empty")
             return False
 
-        safe_target = raw_target.replace("'", "''")
+        safe_target = target.replace("'", "''")
         try:
             self.conn.sql_query(f"EXECUTE AS {mode} = N'{safe_target}';")
             if self.conn.lastError:
                 self.logger.fail(self.conn.lastError)
                 return False
-            self.logger.success(f"Impersonation set: {mode}={raw_target}")
+            self.logger.success(f"Impersonation set: {mode}={target}")
             self.impersonation_applied = True
             if self.args.debug:
                 res = self.conn.sql_query("SELECT SYSTEM_USER, SUSER_SNAME();")
                 self.logger.debug(f"Impersonated context: {res}")
         except Exception as e:
-            self.logger.fail(f"Failed to impersonate {mode} {raw_target}: {e}")
+            self.logger.fail(f"Failed to impersonate {mode} {target}: {e}")
             return False
         return True
 

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -279,7 +279,7 @@ class mssql(connection):
 
     def impersonate(self):
         mode = "LOGIN"
-        target = self.args.impersonate.strip()
+        target = self.args.impersonate[0].strip()
         if target.lower().startswith("login:"):
             target = target.split(":", 1)[1].strip()
             mode = "LOGIN"

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -312,9 +312,8 @@ class mssql(connection):
                 return False
             self.logger.success(f"Impersonation set: {mode}={target}")
             self.impersonation_applied = True
-            if self.args.debug:
-                res = self.conn.sql_query("SELECT SYSTEM_USER, SUSER_SNAME();")
-                self.logger.debug(f"Impersonated context: {res}")
+            res = self.conn.sql_query("SELECT SYSTEM_USER, SUSER_SNAME();")
+            self.logger.debug(f"Impersonated context: {res}")
         except Exception as e:
             self.logger.fail(f"Failed to impersonate {mode} {target}: {e}")
             return False

--- a/nxc/protocols/mssql/proto_args.py
+++ b/nxc/protocols/mssql/proto_args.py
@@ -6,6 +6,7 @@ def proto_args(parser, parents):
     mssql_parser.add_argument("-H", "--hash", metavar="HASH", dest="hash", nargs="+", default=[], help="NTLM hash(es) or file(s) containing NTLM hashes")
     mssql_parser.add_argument("--port", default=1433, type=int, metavar="PORT", help="MSSQL port")
     mssql_parser.add_argument("--mssql-timeout", help="SQL server connection timeout", type=int, default=5)
+    mssql_parser.add_argument("--impersonate", metavar="LOGIN|USER", type=str, help="impersonate a login or user (prefix with login: or user:, default: login)")
     mssql_parser.add_argument("-q", "--query", metavar="QUERY", type=str, help="execute the specified query against the mssql db")
     mssql_parser.add_argument("--database", nargs="?", const=True, metavar="NAME", help="list databases or list tables for NAME")
 

--- a/nxc/protocols/mssql/proto_args.py
+++ b/nxc/protocols/mssql/proto_args.py
@@ -6,7 +6,7 @@ def proto_args(parser, parents):
     mssql_parser.add_argument("-H", "--hash", metavar="HASH", dest="hash", nargs="+", default=[], help="NTLM hash(es) or file(s) containing NTLM hashes")
     mssql_parser.add_argument("--port", default=1433, type=int, metavar="PORT", help="MSSQL port")
     mssql_parser.add_argument("--mssql-timeout", help="SQL server connection timeout", type=int, default=5)
-    mssql_parser.add_argument("--impersonate", metavar="LOGIN|USER", type=str, help="impersonate a login or user (prefix with login: or user:, default: login)")
+    mssql_parser.add_argument("--impersonate", nargs=1, metavar="LOGIN|USER", type=str, help="impersonate a login or user (prefix with login: or user:, default: login)")
     mssql_parser.add_argument("-q", "--query", metavar="QUERY", type=str, help="execute the specified query against the mssql db")
     mssql_parser.add_argument("--database", nargs="?", const=True, metavar="NAME", help="list databases or list tables for NAME")
 

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -258,6 +258,7 @@ netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M aws-cr
 ##### MSSQL
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # Need a space at the end for kerb regex
 netexec {DNS} mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # Need a space at the end for kerb regex
+netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --impersonate LOGIN_USERNAME
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --rid-brute
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --database
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sam


### PR DESCRIPTION
## Description

The --impersonate flag has been introduced in the MSSQL protocol, adding a first-level protocol-level way to set EXECUTE AS before executing any command arguments or modules
The mssql_priv module is not included in the impersonation flow; this recovers direct impersonation so that users can execute queries/modules with another login/user without additional module modifications

A module-only approach would be limited to module execution, and arbitrary arguments cannot be combined with modules. A protocol-level flag is applied universally and consistently across all CLI actions and modules, without the need to change each module or overload its options

This might be better than modifying the actual modules, which would only affect the internal logic of that module and still not change the session context for other actions. --impersonate sets the session context once, so all subsequent operations are executed under the intended login/user, in a more predictable and reusable way

As you can see in the image, the modules and queries are executed in the context of the impersonated user


## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)


## Screenshots (if appropriate):

<img width="2889" height="1321" alt="imagen" src="https://github.com/user-attachments/assets/44561c5b-005d-4f4e-b672-877d5e030399" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
