### PR TITLE
Fix incorrect exception handling

### DIFF
--- a/nxc/modules/add-computer.py
+++ b/nxc/modules/add-computer.py
@@ -177,9 +177,10 @@ class NXCModule:
                 self.context.db.add_credential("plaintext", self.__domain, self.__computerName, self.__computerPassword)
             except Exception as e:
                 self.context.log.debug(f"samrCreateUser2InDomain failed: {e}")
-                if "doesn't have the right to create a new machine account" in str(e):
+                # See error codes at: https://github.com/fortra/impacket/blob/8c155a5b492e8b0f9d08e5ca82b72c91d76f5c7f/impacket/dcerpc/v5/samr.py#L2591
+                if "Authenticating account doesn't have the right to create a new machine account!" in str(e):
                     self.context.log.fail(f"The following user does not have the right to create a computer account: {self.__username}")
-                elif "machine account quota exceeded!":
+                elif "Authenticating account's machine account quota exceeded!" in str(e):
                     self.context.log.fail(f"The following user exceeded their machine account quota: {self.__username}")
                 return
 


### PR DESCRIPTION
## Description

This resolves an issue where exception catching could fail when a machine account creation attempt exceeds the domain’s Machine Account Quota, due to incorrect handling of the raised exception.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
OS: Linux (Debian-based)
Python version: Python 3.11
Target environment: Active Directory domain
Domain Controller: Windows Server 2022 (standard AD configuration)
Default domain settings, no custom GPOs required

## Screenshots (if appropriate):

<img width="1045" height="274" alt="image" src="https://github.com/user-attachments/assets/d7cd5613-bd1e-4b4d-9b7a-e44063603a0a" />

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
