### PR TITLE
Add SeMachineAccountPrivilege to maq module

### DIFF
--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -83,14 +83,14 @@ class NXCModule:
 
         for guid in guids:
             # Accessing the GPO in the SYSVOL share to parse GptTmpl.inf
-            path = ntpath.join(connection.domain, "Policies", f"{{{guid}}}", "MACHINE", "Microsoft", "Windows NT", "SecEdit", "GptTmpl.inf",)
+            path = ntpath.join(connection.targetDomain, "Policies", f"{{{guid}}}", "MACHINE", "Microsoft", "Windows NT", "SecEdit", "GptTmpl.inf",)
             try:
                 buf = BytesIO()
                 smb.getFile("SYSVOL", path, buf.write)
                 buf.seek(0)
                 GptTmpl = buf.read().decode("utf-16le", errors="ignore")
             except Exception as e:
-                context.log.debug(f"({guid}) no GptTmpl.inf or not reachable: {e}")
+                context.log.debug(f'({guid}) no GptTmpl.inf or not reachable: \n gpo_path:"{path}"\nException: {e}')
                 continue
 
             # Parse the GptTmpl.inf to find SeMachineAccountPrivilege

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -37,7 +37,7 @@ class NXCModule:
 
         def resolve_gpo(context, connection, guid):
             gpo_dn = f"CN={{{guid}}},CN=Policies,CN=System,{connection.baseDN}"
-            
+
             try:
                 resp = connection.search(
                         baseDN=gpo_dn,
@@ -53,8 +53,6 @@ class NXCModule:
             except Exception as e:
                 context.logger.debug(f"Exception raised while looking for groupPolicyContainer: {e}")
                 return ""
-
-
 
         # Just handle smb connection
         def connect_smb(connection):
@@ -106,7 +104,6 @@ class NXCModule:
 
         smb = connect_smb(connection)
 
-
         for guid in guids:
             # Accessing the GPO in the SYSVOL share to parse GptTmpl.inf
             path = ntpath.join(connection.targetDomain, "Policies", f"{{{guid}}}", "MACHINE", "Microsoft", "Windows NT", "SecEdit", "GptTmpl.inf",)
@@ -132,10 +129,9 @@ class NXCModule:
                     sids = re.findall(r"\*?(S-\d+(?:-\d+)+)", line)
                     break
 
-            if found == False:
+            if not found:
                 context.log.debug(f"SeMachineAccountPrivilege not in {path}")
                 continue
-
 
             if sids != []:
                 sessions = {}
@@ -183,8 +179,6 @@ class NXCModule:
                 context.log.fail("No SID(s) found in SeMachineAccountPrivilege")
 
         return
-
-                
 
     def on_login(self, context, connection):
         context.log.display("Getting the MachineAccountQuota")

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -1,6 +1,11 @@
+import re 
+import ntpath
+
+from io import BytesIO
 from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
+from impacket.smbconnection import SMBConnection
 
 class NXCModule:
     """
@@ -19,9 +24,86 @@ class NXCModule:
         """No options available"""
 
     name = "maq"
-    description = "Retrieves the MachineAccountQuota domain-level attribute"
+    description = "Retrieves the MachineAccountQuota domain-level attribute and check SeMachineAccountPrivilege (GPO/SYSVOL)"
     supported_protocols = ["ldap"]
     category = CATEGORY.ENUMERATION
+
+    def get_SeMachineAccountPrivilege(self, context, connection):
+
+        def connect_smb(connection):
+            smb = SMBConnection(
+                    remoteName=connection.hostname,
+                    remoteHost=connection.host,
+                    sess_port=445,
+            )
+
+            if connection.kerberos:
+                smb.kerberosLogin(
+                        user=connection.username,
+                        password=connection.password,
+                        domain=connection.domain,
+                        lmhash=connection.lmhash,
+                        nthash=connection.lmhash,
+                        aesKey=connection.aesKey,
+                        kdcHost=connection.kdcHost,
+                        useCache=connection.use_kcache,
+                    )
+            
+            elif connection.nthash or connection.lmhash:
+                smb.login(connection.username, "", connection.domain, lmhash=connection.lmhash, nthash=connection.nthash)
+
+            else:
+                smb.login(connection.username, connection.password, connection.domain)
+
+            return smb
+
+        context.log.display("Getting the SeMachineAccountPrivilege")
+        base = f"OU=Domain Controllers,{connection.baseDN}"
+        ldap_response = connection.search(
+            searchFilter="(objectClass=*)",
+            baseDN=base,
+            attributes=["gPLink"]
+        )
+        entries = parse_result_attributes(ldap_response)
+
+        if not entries:
+            context.log.fail("No gPLink entries returned.")
+            return
+
+        guids = re.findall(r"(?i)cn=\{([0-9a-f\-]{36})\}", entries[0]["gPLink"])
+        context.log.debug(f"GUID founds: {guids}")
+        
+        smb = connect_smb(connection)
+
+        for guid in guids:
+            path = ntpath.join(
+                    connection.domain,
+                    "Policies",
+                    f"{{{guid.upper()}}}",
+                    "MACHINE",
+                    "Microsoft",
+                    "Windows NT",
+                    "SecEdit",
+                    "GptTmpl.inf",
+                    )
+            
+            try:
+                buf = BytesIO()
+                smb.getFile("SYSVOL", path, buf.write)
+                buf.seek(0)
+                GptTmpl = buf.read().decode("utf-16le", errors="ignore")
+
+            except Exception as e:
+                context.log.debug(f"{guid}: no GptTmpl.inf / not reachable ({e})")
+                continue
+            
+            for line in GptTmpl.splitlines():
+                if "SeMachineAccountPrivilege" in line:
+                    context.log.highlight(f"{line}")
+                    # Ajouter la traduction du/des sid(s)
+                    # ldap_response = connection.search("")
+                    return
+
 
     def on_login(self, context, connection):
         context.log.display("Getting the MachineAccountQuota")
@@ -33,4 +115,7 @@ class NXCModule:
             context.log.fail("No LDAP entries returned.")
             return
 
-        context.log.highlight(f"MachineAccountQuota: {entries[0]['ms-DS-MachineAccountQuota']}")
+        context.log.highlight(f"MachineAccountQuota: {entries[0]['ms-DS-MachineAccountQuota']}\n")
+
+        self.get_SeMachineAccountPrivilege(context, connection)
+        

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -94,12 +94,14 @@ class NXCModule:
                 continue
 
             # Parse the GptTmpl.inf to find SeMachineAccountPrivilege
+            sids = []
             for line in GptTmpl.splitlines():
                 if "SeMachineAccountPrivilege" in line:
                     context.log.highlight(f"{line}")
                     # extract all the sid concerns by the SeMachineAccountPrivilege
                     sids = re.findall(r"\*?(S-\d+(?:-\d+)+)", line)
                     break
+
 
             if sids != []:
                 sessions = {}

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -5,7 +5,9 @@ from io import BytesIO
 from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
-from impacket.smbconnection import SMBConnection
+from impacket.smbconnection import SMBConnection, SessionError
+from impacket.nmb import NetBIOSError, NetBIOSTimeout
+from impacket.krb5.kerberosv5 import KerberosError
 
 
 class NXCModule:
@@ -62,6 +64,7 @@ class NXCModule:
                 remoteName=connection.hostname,
                 remoteHost=connection.host,
                 sess_port=445,
+                timeout=connection.args.timeout or 3,
         )
 
         if connection.kerberos:
@@ -111,7 +114,13 @@ class NXCModule:
         guids = re.findall(r"(?i)cn=\{([0-9a-f\-]{36})\}", gplink)
         context.log.debug(f"GUID founds: {guids}")
 
-        smb = self.connect_smb(connection)
+        try:
+            smb = self.connect_smb(connection)
+        except (OSError, SessionError, NetBIOSError, NetBIOSTimeout, KerberosError) as e:
+            context.log.debug(f"Unable to connect to SYSVOL through SMB: {e}")
+            return
+
+        context.log.display("Getting SeMachineAccountPrivilege")
 
         for guid in guids:
             # Accessing the GPO in the SYSVOL share to parse GptTmpl.inf
@@ -176,7 +185,5 @@ class NXCModule:
             return
 
         context.log.highlight(f"MachineAccountQuota: {entries[0]['ms-DS-MachineAccountQuota']}")
-
-        context.log.display("Getting SeMachineAccountPrivilege")
 
         self.get_SeMachineAccountPrivilege(context, connection)

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -6,10 +6,6 @@ from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
 from impacket.smbconnection import SMBConnection
-from impacket.dcerpc.v5 import lsat, lsad
-from impacket.dcerpc.v5.rpcrt import DCERPCException, RPC_C_AUTHN_LEVEL_PKT_PRIVACY, RPC_C_AUTHN_GSS_NEGOTIATE
-from impacket.dcerpc.v5.transport import DCERPCTransportFactory
-from impacket.dcerpc.v5.dtypes import MAXIMUM_ALLOWED
 
 
 class NXCModule:
@@ -25,61 +21,61 @@ class NXCModule:
       Podalirius: @podalirius_
     """
 
-    def options(self, context, module_options):
-        """No options available"""
-
     name = "maq"
     description = "Retrieves the MachineAccountQuota domain-level attribute and check SeMachineAccountPrivilege (GPO/SYSVOL)"
     supported_protocols = ["ldap"]
     category = CATEGORY.ENUMERATION
 
-    def get_SeMachineAccountPrivilege(self, context, connection):
+    def options(self, context, module_options):
+        """No options available"""
 
-        def resolve_gpo(context, connection, guid):
-            gpo_dn = f"CN={{{guid}}},CN=Policies,CN=System,{connection.baseDN}"
+    def resolve_gpo(self, context, connection, guid):
+        gpo_dn = f"CN={{{guid}}},CN=Policies,CN=System,{connection.baseDN}"
 
-            try:
-                resp = connection.search(
-                        baseDN=gpo_dn,
-                        searchFilter="(objectClass=groupPolicyContainer)",
-                        attributes=["displayName", "name"]
-                        )
-
-                results = parse_result_attributes(resp)
-                if results:
-                    return results[0].get("displayName") or results[0].get("name")
-                else:
-                    return ""
-            except Exception as e:
-                context.logger.debug(f"Exception raised while looking for groupPolicyContainer: {e}")
-                return ""
-
-        # Just handle smb connection
-        def connect_smb(connection):
-            smb = SMBConnection(
-                    remoteName=connection.hostname,
-                    remoteHost=connection.host,
-                    sess_port=445,
-            )
-
-            if connection.kerberos:
-                smb.kerberosLogin(
-                        user=connection.username,
-                        password=connection.password,
-                        domain=connection.domain,
-                        lmhash=connection.lmhash,
-                        nthash=connection.nthash,
-                        aesKey=connection.aesKey,
-                        kdcHost=connection.kdcHost,
-                        useCache=connection.use_kcache,
+        try:
+            resp = connection.search(
+                    baseDN=gpo_dn,
+                    searchFilter="(objectClass=groupPolicyContainer)",
+                    attributes=["displayName", "name"]
                     )
-            elif connection.nthash or connection.lmhash:
-                smb.login(connection.username, "", connection.domain, lmhash=connection.lmhash, nthash=connection.nthash)
 
+            results = parse_result_attributes(resp)
+            if results:
+                return results[0].get("displayName") or results[0].get("name")
             else:
-                smb.login(connection.username, connection.password, connection.domain)
+                return ""
+        except Exception as e:
+            context.logger.debug(f"Exception raised while looking for groupPolicyContainer: {e}")
+            return ""
 
-            return smb
+    # Just handle smb connection
+    def connect_smb(self, connection):
+        smb = SMBConnection(
+                remoteName=connection.hostname,
+                remoteHost=connection.host,
+                sess_port=445,
+        )
+
+        if connection.kerberos:
+            smb.kerberosLogin(
+                    user=connection.username,
+                    password=connection.password,
+                    domain=connection.domain,
+                    lmhash=connection.lmhash,
+                    nthash=connection.nthash,
+                    aesKey=connection.aesKey,
+                    kdcHost=connection.kdcHost,
+                    useCache=connection.use_kcache,
+                )
+        elif connection.nthash or connection.lmhash:
+            smb.login(connection.username, "", connection.domain, lmhash=connection.lmhash, nthash=connection.nthash)
+
+        else:
+            smb.login(connection.username, connection.password, connection.domain)
+
+        return smb
+
+    def get_SeMachineAccountPrivilege(self, context, connection):
 
         # Getting the gPLink applies to Domain Controllers OU
         try:
@@ -92,21 +88,26 @@ class NXCModule:
             entries = parse_result_attributes(ldap_response)
         except Exception as e:
             context.logger.debug(f"Exception raised while looking for gPLink: {e}")
-            exit(1)
+            return
 
         if not entries:
             context.log.fail("No gPLink entries returned.")
             return
 
+        gplink = entries[0].get("gPLink", "")
+        if not gplink:
+            context.log.debug("No gPLink found for Domain Controllers OU")
+            return
+
         # Extract GUIDS from the output using regex
-        guids = re.findall(r"(?i)cn=\{([0-9a-f\-]{36})\}", entries[0]["gPLink"])
+        guids = re.findall(r"(?i)cn=\{([0-9a-f\-]{36})\}", gplink)
         context.log.debug(f"GUID founds: {guids}")
 
-        smb = connect_smb(connection)
+        smb = self.connect_smb(connection)
 
         for guid in guids:
             # Accessing the GPO in the SYSVOL share to parse GptTmpl.inf
-            path = ntpath.join(connection.targetDomain, "Policies", f"{{{guid}}}", "MACHINE", "Microsoft", "Windows NT", "SecEdit", "GptTmpl.inf",)
+            path = ntpath.join(connection.targetDomain, "Policies", f"{{{guid}}}", "MACHINE", "Microsoft", "Windows NT", "SecEdit", "GptTmpl.inf")
             try:
                 buf = BytesIO()
                 smb.getFile("SYSVOL", path, buf.write)
@@ -122,7 +123,7 @@ class NXCModule:
             for line in GptTmpl.splitlines():
                 if "SeMachineAccountPrivilege" in line:
                     found = True
-                    gpo_name = resolve_gpo(context, connection, guid)
+                    gpo_name = self.resolve_gpo(context, connection, guid)
                     context.log.success(f'(GPO) "{gpo_name}"')
                     context.log.highlight(f"\t{line}")
                     # extract all the sid concerns by the SeMachineAccountPrivilege
@@ -134,49 +135,19 @@ class NXCModule:
                 continue
 
             if sids != []:
-                sessions = {}
                 for sid in sids:
-                    sessions.setdefault(sid, {"Username": ""})
-
-                try:
-                    # Handle RPC connection
-                    string_binding = rf"ncacn_np:{connection.host}[\pipe\lsarpc]"
-                    rpctransport = DCERPCTransportFactory(string_binding)
-                    rpctransport.set_credentials(connection.username, connection.password, connection.domain, connection.lmhash, connection.nthash,)
-                    rpctransport.set_connect_timeout(15)
-                    dce = rpctransport.get_dce_rpc()
-                    if connection.kerberos:
-                        dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
-                    dce.connect()
-                    dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-                    dce.bind(lsat.MSRPC_UUID_LSAT)
-                except Exception as e:
-                    context.log.debug(f"Error connecting to {string_binding}: {e!s}")
-
-                try:
-                    # Getting the LSA policy
-                    policy_handle = lsad.hLsarOpenPolicy2(dce, MAXIMUM_ALLOWED | lsat.POLICY_LOOKUP_NAMES)["PolicyHandle"]
-                except Exception as e:
-                    context.log.debug(f"Unable to get policy handle: {e!s}")
-                    return
-
-                try:
-                    # Sid translation (lookup sid)
-                    resp = lsat.hLsarLookupSids(dce, policy_handle, sessions.keys(), lsat.LSAP_LOOKUP_LEVEL.LsapLookupWksta)
-                except DCERPCException as e:
-                    if str(e).find("STATUS_SOME_NOT_MAPPED") >= 0:
-                        resp = e.get_packet()
-                        context.log.debug(f"Could not resolve some SIDs: {e}")
-                    else:
-                        resp = None
-                        context.log.debug(f"Could not resolve SID(s): {e}")
-                if resp:
-                    for sid, item in zip(sessions.keys(), resp["TranslatedNames"]["Names"], strict=False):
-                        if item["DomainIndex"] >= 0:
-                            context.log.highlight(f'\t\t - "{item["Name"]}" ({sid})')
+                    resp = connection.search(
+                        searchFilter=f"(objectSid={sid})",
+                        attributes=["sAMAccountName"]
+                    )
+                    entries = parse_result_attributes(resp)
+                    if entries:
+                        context.log.highlight(f'\t\t - "{entries[0]["sAMAccountName"]}" ({sid})')
 
             else:
                 context.log.fail("No SID(s) found in SeMachineAccountPrivilege")
+
+        smb.logoff()
 
         return
 

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -141,8 +141,10 @@ class NXCModule:
                         attributes=["sAMAccountName"]
                     )
                     entries = parse_result_attributes(resp)
-                    if entries:
+                    if entries and entries[0].get("sAMAccountName"):
                         context.log.highlight(f'\t\t - "{entries[0]["sAMAccountName"]}" ({sid})')
+                    else:
+                        context.log.debug(f"Could not resolve SID: {sid}")
 
             else:
                 context.log.fail("No SID(s) found in SeMachineAccountPrivilege")

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -6,10 +6,6 @@ from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
 from impacket.smbconnection import SMBConnection
-from impacket.dcerpc.v5 import lsat, lsad
-from impacket.dcerpc.v5.rpcrt import DCERPCException, RPC_C_AUTHN_LEVEL_PKT_PRIVACY, RPC_C_AUTHN_GSS_NEGOTIATE
-from impacket.dcerpc.v5.transport import DCERPCTransportFactory
-from impacket.dcerpc.v5.dtypes import MAXIMUM_ALLOWED
 
 
 class NXCModule:
@@ -29,6 +25,14 @@ class NXCModule:
     description = "Retrieves the MachineAccountQuota domain-level attribute and check SeMachineAccountPrivilege (GPO/SYSVOL)"
     supported_protocols = ["ldap"]
     category = CATEGORY.ENUMERATION
+
+    WELL_KNOWN_SIDS = {
+        "S-1-1-0": "Everyone",
+        "S-1-5-11": "Authenticated Users",
+        "S-1-5-18": "Local System",
+        "S-1-5-32-544": "Administrators",
+        "S-1-5-32-545": "Users",
+    }
 
     def options(self, context, module_options):
         """No options available"""
@@ -139,46 +143,20 @@ class NXCModule:
                 continue
 
             if sids != []:
-                sessions = {}
                 for sid in sids:
-                    sessions.setdefault(sid, {"Username": ""})
+                    if sid in self.WELL_KNOWN_SIDS:
+                        context.log.highlight(f'\t\t - "{self.WELL_KNOWN_SIDS[sid]}" ({sid})')
+                        continue
 
-                try:
-                    # Handle RPC connection
-                    string_binding = rf"ncacn_np:{connection.host}[\pipe\lsarpc]"
-                    rpctransport = DCERPCTransportFactory(string_binding)
-                    rpctransport.set_credentials(connection.username, connection.password, connection.domain, connection.lmhash, connection.nthash,)
-                    rpctransport.set_connect_timeout(15)
-                    dce = rpctransport.get_dce_rpc()
-                    if connection.kerberos:
-                        dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
-                    dce.connect()
-                    dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-                    dce.bind(lsat.MSRPC_UUID_LSAT)
-                except Exception as e:
-                    context.log.debug(f"Error connecting to {string_binding}: {e!s}")
-
-                try:
-                    # Getting the LSA policy
-                    policy_handle = lsad.hLsarOpenPolicy2(dce, MAXIMUM_ALLOWED | lsat.POLICY_LOOKUP_NAMES)["PolicyHandle"]
-                except Exception as e:
-                    context.log.debug(f"Unable to get policy handle: {e!s}")
-                    return
-
-                try:
-                    # Sid translation (lookup sid)
-                    resp = lsat.hLsarLookupSids(dce, policy_handle, sessions.keys(), lsat.LSAP_LOOKUP_LEVEL.LsapLookupWksta)
-                except DCERPCException as e:
-                    if str(e).find("STATUS_SOME_NOT_MAPPED") >= 0:
-                        resp = e.get_packet()
-                        context.log.debug(f"Could not resolve some SIDs: {e}")
+                    resp = connection.search(
+                        searchFilter=f"(objectSid={sid})",
+                        attributes=["sAMAccountName"]
+                    )
+                    entries = parse_result_attributes(resp)
+                    if entries and entries[0].get("sAMAccountName"):
+                        context.log.highlight(f'\t\t - "{entries[0]["sAMAccountName"]}" ({sid})')
                     else:
-                        resp = None
-                        context.log.debug(f"Could not resolve SID(s): {e}")
-                if resp:
-                    for sid, item in zip(sessions.keys(), resp["TranslatedNames"]["Names"], strict=False):
-                        if item["DomainIndex"] >= 0:
-                            context.log.highlight(f'\t\t - "{item["Name"]}" ({sid})')
+                        context.log.debug(f"Could not resolve SID: {sid}")
 
             else:
                 context.log.fail("No SID(s) found in SeMachineAccountPrivilege")

--- a/nxc/modules/maq.py
+++ b/nxc/modules/maq.py
@@ -6,6 +6,10 @@ from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
 from impacket.smbconnection import SMBConnection
+from impacket.dcerpc.v5 import lsat, lsad
+from impacket.dcerpc.v5.rpcrt import DCERPCException, RPC_C_AUTHN_LEVEL_PKT_PRIVACY, RPC_C_AUTHN_GSS_NEGOTIATE
+from impacket.dcerpc.v5.transport import DCERPCTransportFactory
+from impacket.dcerpc.v5.dtypes import MAXIMUM_ALLOWED
 
 
 class NXCModule:
@@ -135,16 +139,46 @@ class NXCModule:
                 continue
 
             if sids != []:
+                sessions = {}
                 for sid in sids:
-                    resp = connection.search(
-                        searchFilter=f"(objectSid={sid})",
-                        attributes=["sAMAccountName"]
-                    )
-                    entries = parse_result_attributes(resp)
-                    if entries and entries[0].get("sAMAccountName"):
-                        context.log.highlight(f'\t\t - "{entries[0]["sAMAccountName"]}" ({sid})')
+                    sessions.setdefault(sid, {"Username": ""})
+
+                try:
+                    # Handle RPC connection
+                    string_binding = rf"ncacn_np:{connection.host}[\pipe\lsarpc]"
+                    rpctransport = DCERPCTransportFactory(string_binding)
+                    rpctransport.set_credentials(connection.username, connection.password, connection.domain, connection.lmhash, connection.nthash,)
+                    rpctransport.set_connect_timeout(15)
+                    dce = rpctransport.get_dce_rpc()
+                    if connection.kerberos:
+                        dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
+                    dce.connect()
+                    dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+                    dce.bind(lsat.MSRPC_UUID_LSAT)
+                except Exception as e:
+                    context.log.debug(f"Error connecting to {string_binding}: {e!s}")
+
+                try:
+                    # Getting the LSA policy
+                    policy_handle = lsad.hLsarOpenPolicy2(dce, MAXIMUM_ALLOWED | lsat.POLICY_LOOKUP_NAMES)["PolicyHandle"]
+                except Exception as e:
+                    context.log.debug(f"Unable to get policy handle: {e!s}")
+                    return
+
+                try:
+                    # Sid translation (lookup sid)
+                    resp = lsat.hLsarLookupSids(dce, policy_handle, sessions.keys(), lsat.LSAP_LOOKUP_LEVEL.LsapLookupWksta)
+                except DCERPCException as e:
+                    if str(e).find("STATUS_SOME_NOT_MAPPED") >= 0:
+                        resp = e.get_packet()
+                        context.log.debug(f"Could not resolve some SIDs: {e}")
                     else:
-                        context.log.debug(f"Could not resolve SID: {sid}")
+                        resp = None
+                        context.log.debug(f"Could not resolve SID(s): {e}")
+                if resp:
+                    for sid, item in zip(sessions.keys(), resp["TranslatedNames"]["Names"], strict=False):
+                        if item["DomainIndex"] >= 0:
+                            context.log.highlight(f'\t\t - "{item["Name"]}" ({sid})')
 
             else:
                 context.log.fail("No SID(s) found in SeMachineAccountPrivilege")


### PR DESCRIPTION
## Description

I recently spent some time working on **SeMachineAccountPrivilege** enumeration, following the discussion and initial work introduced in PR [https://github.com/Pennyw0rth/NetExec/pull/1029](https://github.com/Pennyw0rth/NetExec/pull/1029) by @Blatzy.
Based on that, I’m proposing this PR, which integrates the check directly into the MAQ module and makes it especially useful during internal penetration tests.

The idea is to keep everything dynamic and reliable, by:
- retrieving the gPLink values applied to the Domain Controllers OU
- parsing the corresponding GptTmpl.inf files to locate SeMachineAccountPrivilege
- extracting the associated SIDs and resolving them via LSA LookupSid

This avoids hardcoded assumptions and provides a clearer picture of how the privilege is actually configured on Domain Controllers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

- OS: Debian (Linux)
- Python: 3.11 (running NetExec from source)
- Installed dependencies: standard NetExec dependencies (no extra third-party required)
- Domain Controller: Windows Server 2022
- No special configuration

The feature relies on:
- LDAP access to query the Domain Controllers OU gPLink
- SMB access to SYSVOL to read GPO files (GptTmpl.inf)
- LSA/RPC access (\pipe\lsarpc) to resolve SIDs to names via LookupSid

## Screenshots:

<img width="1780" height="187" alt="image" src="https://github.com/user-attachments/assets/b5d1471b-3c6b-460f-a239-863b77012fa1" />

<img width="1902" height="241" alt="image" src="https://github.com/user-attachments/assets/8465397c-fcdc-46f2-ab01-b167ddf7f911" />

Debug

<img width="1766" height="367" alt="image" src="https://github.com/user-attachments/assets/1198d18a-dc64-4e66-a92b-5385175290d6" />


## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
