### PR TITLE
Fix inconsistent LDAP attribute name in module get-userPassword.py

### DIFF
--- a/nxc/modules/get-userPassword.py
+++ b/nxc/modules/get-userPassword.py
@@ -41,6 +41,6 @@ class NXCModule:
             resp_parsed = parse_result_attributes(resp)
             context.log.success("Found following users: ")
             for user in resp_parsed:
-                context.log.highlight(f"User: {user['sAMAccountName']} unixUserPassword: {user['userPassword']}")
+                context.log.highlight(f"User: {user['sAMAccountName']} userPassword: {user['userPassword']}")
         else:
-            context.log.fail("No unixUserPassword Found")
+            context.log.fail("No userPassword Found")


### PR DESCRIPTION
This PR fixes an inconsistency in get-userPassword.py.

The LDAP query requests the attribute `userPassword`, but the output
refers to `unixUserPassword`, which can be misleading. The output
has been aligned with the actual queried attribute.