### PR TITLE
Properly handle shell metacharacters in command output for wmi

### DIFF
--- a/nxc/protocols/wmi/wmiexec.py
+++ b/nxc/protocols/wmi/wmiexec.py
@@ -67,7 +67,7 @@ class WMIEXEC:
         self.__registry_Path = f"Software\\Classes\\{gen_random_string(8)}"
 
         # 1. Run the command and write output to file
-        self.execute_remote(f'{self.__shell} {command} 1> "{result_output}" 2>&1')
+        self.execute_remote(f'{self.__shell} ({command}) 1> "{result_output}" 2>&1')
         self.logger.info(f"Waiting {self.__exec_timeout}s for command to complete.")
         time.sleep(self.__exec_timeout)
 
@@ -109,7 +109,7 @@ class WMIEXEC:
 
         # 1. Run the command and write output to file
         if not command.lower().startswith("powershell"):
-            command = f"powershell -Command {command}"
+            command = f'powershell -Command "& {{{command}}}"'
         self.execute_remote(f'{command} > "{result_output}" 2>&1')
         self.logger.info(f"Waiting {self.__exec_timeout}s for command to complete.")
         time.sleep(self.__exec_timeout)


### PR DESCRIPTION
## Description

Fixes: #1093

This pull request makes small changes to how commands are executed remotely in the `wmiexec.py` protocol handler. The updates improve command execution reliability by ensuring proper command grouping and PowerShell command invocation.

Improvements to remote command execution:

* Wrapped shell commands in parentheses in the `execute_WithOutput` method to ensure the entire command is executed as a group and redirection applies as intended.
* Modified PowerShell command formatting in the `execute_WithOutput_psh` method to wrap the command in `& { ... }`, ensuring correct execution context and handling of multi-line or complex commands.

I think it is possible that this could still have issues with certain metachars. Like anything else taking in arbitrary input, it would be best to do some encoding. But if we care more about AV, I think this is a good solution. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):
**CMD**
Before:
<img width="1912" height="484" alt="image" src="https://github.com/user-attachments/assets/eb9992b9-3ac7-4a18-996d-8a43654231d5" />


After:
<img width="1897" height="509" alt="image" src="https://github.com/user-attachments/assets/32740316-ebdc-40ed-a413-c503f5258a4b" />

**PowerShell**
Before:
<img width="1912" height="557" alt="image" src="https://github.com/user-attachments/assets/e66a654c-e6a8-488b-86e0-8dd26d4bf98f" />

After:
<img width="1912" height="559" alt="image" src="https://github.com/user-attachments/assets/b6cc044a-50cd-40f9-b0ee-09a0a68dac8c" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
