### PR TITLE
Fix certipy-find support for NT hash and AES key auth

### DIFF
--- a/nxc/modules/certipy-find.py
+++ b/nxc/modules/certipy-find.py
@@ -75,7 +75,7 @@ class NXCModule:
             username=connection.username,
             password=connection.password,
             remote_name=connection.remoteName,
-            hashes=connection.hash,
+            hashes=f"{connection.lmhash}:{connection.nthash}",
             lmhash=connection.lmhash,
             nthash=connection.nthash,
             do_kerberos=connection.kerberos,


### PR DESCRIPTION
## Description

The certipy-find module did not pass the right authentication parameters to Certipy : with an `NT hash (-H)` or an `AES key (--aesKey)`, authentication failed (`“NTLM needs password”` or `“No credentials provided for TGT request”`). This is fixed by passing the missing arguments to Certipy’s Target : `hashes`, `aes`, and `dc_ip`.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):

Before : 

<img width="1907" height="979" alt="1" src="https://github.com/user-attachments/assets/a720ec34-2396-4f0a-90fd-c5bfc3aff6e2" />

<img width="1909" height="944" alt="2" src="https://github.com/user-attachments/assets/c71eea25-ad95-4fb9-bb36-6662c4d70eb7" />

After : 

<img width="1462" height="966" alt="3" src="https://github.com/user-attachments/assets/a64fbbb7-7639-47c8-974d-1cb2bd95fd68" />

<img width="1456" height="973" alt="4" src="https://github.com/user-attachments/assets/335049ec-999b-45e4-b34e-8f6982bab758" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
