### PR TITLE
Fix AttributeError on NetBIOSTimeout in kerberos_login

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -489,7 +489,8 @@ class smb(connection):
                 self.inc_failed_login(username)
                 return False
         except (ConnectionResetError, NetBIOSTimeout, NetBIOSError) as e:
-            self.logger.fail(f"Connection Error: {e}")
+            desc = e.getErrorString() if hasattr(e, "getErrorString") else str(e)
+            self.logger.fail(f"{domain}\\{self.username}:{process_secret(self.password)} {desc}")
             return False
         except BrokenPipeError:
             self.logger.fail("Broken Pipe Error while attempting to login")
@@ -553,7 +554,8 @@ class smb(connection):
                 self.inc_failed_login(self.username)
                 return False
         except (ConnectionResetError, NetBIOSTimeout, NetBIOSError) as e:
-            self.logger.fail(f"Connection Error: {e}")
+            desc = e.getErrorString() if hasattr(e, "getErrorString") else str(e)
+            self.logger.fail(f"{domain}\\{self.username}:{process_secret(self.password)} {desc}")
             return False
         except BrokenPipeError:
             self.logger.fail("Broken Pipe Error while attempting to login")


### PR DESCRIPTION
## Description

During Kerberos auth (including `S4U2self/S4U2proxy`), a `NetBIOSTimeout` was caught by `except (SessionError, Exception)`. The handler called `e.getErrorString()`, which only exists on `SessionError`, causing :
```
AttributeError: 'NetBIOSTimeout' object has no attribute 'getErrorString'
```

Fix : Catch connection-related exceptions (`ConnectionResetError`, `NetBIOSTimeout`, `NetBIOSError`, `OSError`) in a dedicated block that logs them with `self.logger.fail(f"Connection Error: {e}")`.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)


## Screenshots (if appropriate):

Before : 

<img width="1899" height="962" alt="1" src="https://github.com/user-attachments/assets/d252afe3-2e6f-475e-8604-2c668c7a9315" />

After : 

<img width="1415" height="158" alt="2" src="https://github.com/user-attachments/assets/bcb57c39-f715-449f-b0a7-da830adca76c" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
