### PR TITLE
Refactor is_host_dc call based on file generation flags

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -299,7 +299,7 @@ class smb(connection):
         self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.targetDomain}) ({signing}) ({smbv1}){ntlm}{null_auth}{guest}")
 
         if self.args.generate_hosts_file or self.args.generate_krb5_file:
-            if self.isdc == None:
+            if self.isdc is None:
                 self.is_host_dc()
             if self.args.generate_hosts_file:
                 with open(self.args.generate_hosts_file, "a+") as host_file:


### PR DESCRIPTION
Conditionally call is_host_dc based on arguments for generating files.

## Description

This pull request introduces a small but important change to the logic for determining whether to call the `is_host_dc()` method in the `enum_host_info` function in `nxc/protocols/smb.py`. The update ensures that `is_host_dc()` is only called under specific conditions related to the generation of hosts or krb5 files.

Key logic update:

* The call to `is_host_dc()` is now conditioned to only run if either `generate_hosts_file` or `generate_krb5_file` arguments are set, or if neither is set, ensuring more precise control over when domain controller detection occurs. [[1]](diffhunk://#diff-03a263aab56e8880814c8a586230088900d62ab9c53b93744492f6fcd1bf7630R170) [[2]](diffhunk://#diff-03a263aab56e8880814c8a586230088900d62ab9c53b93744492f6fcd1bf7630R202-R203)

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

## Screenshots (if appropriate):

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
