### PR TITLE
Refactor add-computer : use impacket CRUD

### DIFF
--- a/nxc/modules/add-computer.py
+++ b/nxc/modules/add-computer.py
@@ -185,7 +185,13 @@ class NXCModule:
                 return None
 
         try:
-            return samr.hSamrCreateUser2InDomain(dce, domain_handle, self.computer_name, samr.USER_WORKSTATION_TRUST_ACCOUNT, samr.USER_FORCE_PASSWORD_CHANGE)["UserHandle"]
+            # Doing this call manually because of weird exception handling in https://github.com/fortra/impacket/blob/084aff60df7e8a5784bee3fb6ac74ed9d1362af8/impacket/dcerpc/v5/samr.py#L2591-L2599
+            request = samr.SamrCreateUser2InDomain()
+            request["DomainHandle"] = domain_handle
+            request["Name"] = self.computer_name
+            request["AccountType"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
+            request["DesiredAccess"] = samr.USER_FORCE_PASSWORD_CHANGE
+            return dce.request(request)
         except samr.DCERPCSessionError as e:
             if "STATUS_USER_EXISTS" in str(e):
                 self.context.log.fail(f"Computer '{self.computer_name}' already exists")


### PR DESCRIPTION
## Description

This PR refactors the add-computer module to support both `SAMR` and `LDAPS` and to use `impacket’s LDAP CRUD` operations instead of `ldap3`.

Previously, the module used a fallback to `LDAPS` when `SAMR` failed. It’s now clearer and more predictable to let the user choose the method via the protocol and options : `nxc smb` uses `SAMR`, and `nxc ldap --port 636` uses `LDAPS`. The module supports both protocols.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):

SMB : 

<img width="1665" height="272" alt="image" src="https://github.com/user-attachments/assets/691ca97d-fa87-4cb7-9390-b24c9e6c97ec" />


LDAPS : 

<img width="1769" height="273" alt="image" src="https://github.com/user-attachments/assets/a8c0f2d0-8e77-4df4-9fe5-38e499f04998" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
