### PR TITLE
Added --get-sid flag on mssql protocol

### DIFF
--- a/nxc/protocols/mssql/proto_args.py
+++ b/nxc/protocols/mssql/proto_args.py
@@ -36,4 +36,5 @@ def proto_args(parser, parents):
 
     mapping_enum_group = mssql_parser.add_argument_group("Mapping/Enumeration")
     mapping_enum_group.add_argument("--rid-brute", nargs="?", type=int, const=4000, metavar="MAX_RID", help="enumerate users by bruteforcing RIDs")
+    mapping_enum_group.add_argument("--get-sid", action="store_true", help="Get domain sid")
     return parser

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -259,6 +259,7 @@ netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M aws-cr
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # Need a space at the end for kerb regex
 netexec {DNS} mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # Need a space at the end for kerb regex
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --rid-brute
+netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --get-sid
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --database
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sam
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --lsa


### PR DESCRIPTION
# Added --get-sid flag on mssql protocol

## Description

The `--get-sid` flag has been added to the MSSQL protocol, providing a way to retrieve the domain SID via SQL queries (`DEFAULT_DOMAIN()` and `SUSER_SID()`), matching the existing `--get-sid` functionality already available in the LDAP protocol.

This reuses the same SID resolution logic already present in `rid_brute` (querying `SUSER_SID('DOMAIN\Domain Admins')` and parsing with impacket's `SID` class), but exposes it as a standalone enumeration option.

## Type of change

Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Screenshots (if appropriate):

<img width="1646" height="203" alt="ss" src="https://github.com/user-attachments/assets/2794324b-4165-4b0f-9b52-0cedb1bad1a6" />

## Checklist:

Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are *required* to be added to the e2e tests)
- [x] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)