### PR TITLE
[Module Enhancement] Entra ID module update

### DIFF
--- a/nxc/modules/entra-id.py
+++ b/nxc/modules/entra-id.py
@@ -129,8 +129,8 @@ class NXCModule:
         self.context.log.info(f"Found the ADFS object: {adfs_parsed}")
 
         if adfs_parsed:
-            self.context.log.success("Domain federated with Entra ID via ADFS:")
-            # As far as I know the is no reliable way to get info about the ADCS via ldap in newer adfs version
+            self.context.log.success("ADFS:")
+            # Afaik there is no reliable way to get info about the ADCS via ldap
 
             # Searching accounts with adfs in name or description
             adfs1_parsed = parse_result_attributes(self.connection.search(


### PR DESCRIPTION
## Description

This PR updates the entra-id module to detect other possible way to pivot from OnPrem domain to Entra ID.
* Microsoft Entra Connect - Same logic as before
* Desktop/Seamless SSO - detect AZUREADSSOACC$ account
* Cloud Sync - Search for the default GMSA account
* ADFS - search for the ADFS object and related account and spn


## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
All installers for AAD connect and cloud sync can be found in the Entra Connect page of https://entra.microsoft.com 

## Screenshots (if appropriate):

<img width="1523" height="400" alt="image" src="https://github.com/user-attachments/assets/103c5da5-e212-4c26-bb04-0ae414e22467" />

This also fix the unhandled error when a the AAD connect fqdn can't be resolved.

<img width="1580" height="799" alt="image" src="https://github.com/user-attachments/assets/fc8614c2-d0ba-41c4-8346-72965a360f6a" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
