### PR TITLE
Fix NFS get_file and put_file auth during path traversal

### DIFF
--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -366,7 +366,7 @@ class nfs(connection):
             curr_fh = mount_fh
             for sub_path in remote_file_path.lstrip("/").split("/"):
                 # Update the UID for the next object and get the handle
-                self.update_auth(mount_fh)
+                self.update_auth(curr_fh)
                 res = self.nfs3.lookup(curr_fh, sub_path, auth=self.auth)
 
                 # Check for a bad path
@@ -448,7 +448,7 @@ class nfs(connection):
             curr_fh = mount_fh
             # If target dir is "" or "/" without filter we would get one item with [""]
             for sub_path in list(filter(None, remote_dir_path.lstrip("/").split("/"))):
-                self.update_auth(mount_fh)
+                self.update_auth(curr_fh)
                 res = self.nfs3.lookup(curr_fh, sub_path, auth=self.auth)
 
                 # If the path does not exist, create it


### PR DESCRIPTION
## Description

`get_file()` and `put_file()` in the NFS protocol module call `update_auth(mount_fh)` in their path traversal loops, always basing credentials on the root/mount handle (uid=0). With `root_squash` enabled, uid=0 is squashed to `nobody`, causing lookups to fail on any directory that isn't world-traversable (e.g., user home directories).

`ls()` already correctly uses `update_auth(curr_fh)`, updating credentials to the current directory's owner at each step of the traversal. This fix applies the same pattern to `get_file()` and `put_file()`.

For example, with `root_squash` and a path like `/home/service/.bash_history` (owned by uid 1337, directory mode 0700):

- **Before**: `update_auth(mount_fh)` sets uid=0 on every iteration → squashed to `nobody` → can't enter `/home/service` → lookup fails
- **After**: `update_auth(curr_fh)` sets uid=1337 when traversing into `/home/service` → not squashed → lookup succeeds

`--ls /home/service` already worked correctly; `--get-file /home/service/.bash_history` did not. Now both behave consistently.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

**Bug reproduction**: Export any NFS share with `root_squash` enabled (the default). Have a non-root user's home directory with mode 0700 containing a file (e.g., `/home/service/.bash_history` owned by uid 1337). Enable `no_subtree_check` so root escape works.

Also works on HTB Slonik if you can test there. Before fix won't read file, but after will.

1. `netexec nfs <target> --ls /home/service` → succeeds, lists files
2. `netexec nfs <target> --get-file /home/service/.bash_history /tmp/out.txt` → fails with "Unknown path"

After the fix, step 2 succeeds.

**Environment**: Tested on Linux with NFS v3, `root_squash` + `no_subtree_check` exports, ext4 filesystem.

## Screenshots (if appropriate):

N/A

## Checklist:

- [x] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)