### PR TITLE
FIx Reuse delegated ST across Kerberos RPC connections

### DIFF
--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -13,7 +13,7 @@ class TSCH_EXEC:
     def __init__(self, target, share_name, username, password, domain, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None,
                  # These options are used by the schtask_as module, except the run_task_as
                  # that defaults to NT AUTHORITY\System user (SID S-1-5-18) if not specified
-                 run_task_as="S-1-5-18", run_cmd=None, output_filename=None, task_name=None, output_file_location=None):
+                 run_task_as="S-1-5-18", run_cmd=None, output_filename=None, task_name=None, output_file_location=None, st=None):
         self.__target = target
         self.__username = username
         self.__password = password
@@ -30,6 +30,7 @@ class TSCH_EXEC:
         self.__tries = tries
         self.__output_filename = None
         self.__share = share
+        self.__st = st
         self.logger = logger
 
         # Optional args for finetuning the task execution, e.g. used in nxc/modules/schtask_as.py
@@ -62,6 +63,7 @@ class TSCH_EXEC:
                 self.__lmhash,
                 self.__nthash,
                 self.__aesKey,
+                TGS=self.__st,
             )
             self.__rpctransport.set_kerberos(self.__doKerberos, self.__kdcHost)
 

--- a/nxc/protocols/smb/mmcexec.py
+++ b/nxc/protocols/smb/mmcexec.py
@@ -59,7 +59,7 @@ from impacket.dcerpc.v5.dtypes import NULL
 
 
 class MMCEXEC:
-    def __init__(self, target, share_name, username, password, domain, smbconnection, doKerberos=False, aesKey=None, kdcHost=None, remoteHost=None, hashes=None, share=None, logger=None, timeout=None, tries=None):
+    def __init__(self, target, share_name, username, password, domain, smbconnection, doKerberos=False, aesKey=None, kdcHost=None, remoteHost=None, hashes=None, share=None, logger=None, timeout=None, tries=None, st=None):
         self.__target = target
         self.__username = username
         self.__password = password
@@ -101,6 +101,7 @@ class MMCEXEC:
             doKerberos=self.__doKerberos,
             kdcHost=self.__kdcHost,
             remoteHost=self.__remoteHost,
+            TGS=st,
         )
         try:
             iInterface = self.__dcom.CoCreateInstanceEx(string_to_bin("49B2791A-B1AE-4C90-9B8E-E860BA07F889"), IID_IDispatch)

--- a/nxc/protocols/smb/passpol.py
+++ b/nxc/protocols/smb/passpol.py
@@ -26,6 +26,7 @@ class PassPolDump:
         self.doKerberos = connection.kerberos
         self.host = connection.host
         self.kdcHost = connection.kdcHost
+        self.delegated_st = connection.delegated_st
         self.protocols = PassPolDump.KNOWN_PROTOCOLS.keys()
         self.pass_pol = {}
 
@@ -57,6 +58,7 @@ class PassPolDump:
                 self.lmhash,
                 self.nthash,
                 self.aesKey,
+                TGS=self.delegated_st,
                 doKerberos=self.doKerberos,
                 kdcHost=self.kdcHost,
                 remote_host=self.host,

--- a/nxc/protocols/smb/samrfunc.py
+++ b/nxc/protocols/smb/samrfunc.py
@@ -35,8 +35,9 @@ class SamrFunc:
         if self.password is None:
             self.password = ""
 
-        self.samr_query = SAMRQuery(username=self.username, password=self.password, domain=self.domain, remote_name=self.remote_name, remote_host=self.host, lmhash=self.lmhash, nthash=self.nthash, kerberos=self.doKerberos, kdcHost=self.kdcHost, aesKey=self.aesKey, logger=self.logger)
-        self.lsa_query = LSAQuery(username=self.username, password=self.password, domain=self.domain, remote_name=self.remote_name, remote_host=self.host, lmhash=self.lmhash, nthash=self.nthash, kdcHost=self.kdcHost, kerberos=self.doKerberos, aesKey=self.aesKey, logger=self.logger)
+        self.delegated_st = connection.delegated_st
+        self.samr_query = SAMRQuery(username=self.username, password=self.password, domain=self.domain, remote_name=self.remote_name, remote_host=self.host, lmhash=self.lmhash, nthash=self.nthash, kerberos=self.doKerberos, kdcHost=self.kdcHost, aesKey=self.aesKey, logger=self.logger, st=self.delegated_st)
+        self.lsa_query = LSAQuery(username=self.username, password=self.password, domain=self.domain, remote_name=self.remote_name, remote_host=self.host, lmhash=self.lmhash, nthash=self.nthash, kdcHost=self.kdcHost, kerberos=self.doKerberos, aesKey=self.aesKey, logger=self.logger, st=self.delegated_st)
 
     def get_builtin_groups(self, group):
         domains = self.samr_query.get_domains()
@@ -85,7 +86,7 @@ class SamrFunc:
 
 
 class SAMRQuery:
-    def __init__(self, username="", password="", domain="", port=445, remote_name="", remote_host="", lmhash="", nthash="", kerberos=None, kdcHost="", aesKey="", logger=None):
+    def __init__(self, username="", password="", domain="", port=445, remote_name="", remote_host="", lmhash="", nthash="", kerberos=None, kdcHost="", aesKey="", logger=None, st=None):
         self.__username = username
         self.__password = password
         self.__domain = domain
@@ -97,6 +98,7 @@ class SAMRQuery:
         self.__remote_host = remote_host
         self.__kerberos = kerberos
         self.__kdcHost = kdcHost
+        self.__st = st
         self.logger = logger
         self.dce = self.get_dce()
         self.server_handle = self.get_server_handle()
@@ -115,6 +117,7 @@ class SAMRQuery:
             self.__lmhash,
             self.__nthash,
             self.__aesKey,
+            TGS=self.__st,
             doKerberos=self.__kerberos,
             kdcHost=self.__kdcHost,
         )
@@ -178,7 +181,7 @@ class SAMRQuery:
 
 
 class LSAQuery:
-    def __init__(self, username="", password="", domain="", port=445, remote_name="", remote_host="", lmhash="", nthash="", kdcHost="", aesKey="", kerberos=None, logger=None):
+    def __init__(self, username="", password="", domain="", port=445, remote_name="", remote_host="", lmhash="", nthash="", kdcHost="", aesKey="", kerberos=None, logger=None, st=None):
         self.__username = username
         self.__password = password
         self.__domain = domain
@@ -190,6 +193,7 @@ class LSAQuery:
         self.__remote_host = remote_host
         self.__kdcHost = kdcHost
         self.__kerberos = kerberos
+        self.__st = st
         self.dce = self.get_dce()
         self.policy_handle = self.get_policy_handle()
         self.logger = logger
@@ -210,6 +214,7 @@ class LSAQuery:
                 self.__lmhash,
                 self.__nthash,
                 self.__aesKey,
+                TGS=self.__st,
             )
         return rpc_transport
 

--- a/nxc/protocols/smb/samruser.py
+++ b/nxc/protocols/smb/samruser.py
@@ -27,6 +27,7 @@ class UserSamrDump:
         self.doKerberos = connection.kerberos
         self.host = connection.host
         self.kdcHost = connection.kdcHost
+        self.delegated_st = connection.delegated_st
         self.protocols = UserSamrDump.KNOWN_PROTOCOLS.keys()
         self.users = []
         self.rpc_transport = None
@@ -51,7 +52,7 @@ class UserSamrDump:
                 self.logger.debug(f"Invalid Protocol: {protocol}")
 
             self.logger.debug(f"Trying protocol {protocol}")
-            self.rpc_transport = transport.SMBTransport(self.addr, port, r"\samr", self.username, self.password, self.domain, self.lmhash, self.nthash, self.aesKey, doKerberos=self.doKerberos, kdcHost=self.kdcHost, remote_host=self.host)
+            self.rpc_transport = transport.SMBTransport(self.addr, port, r"\samr", self.username, self.password, self.domain, self.lmhash, self.nthash, self.aesKey, TGS=self.delegated_st, doKerberos=self.doKerberos, kdcHost=self.kdcHost, remote_host=self.host)
             try:
                 self.fetch_users(requested_users, dump_path)
                 break

--- a/nxc/protocols/smb/smbexec.py
+++ b/nxc/protocols/smb/smbexec.py
@@ -8,7 +8,7 @@ from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
 
 
 class SMBEXEC:
-    def __init__(self, host, share_name, smbconnection, username="", password="", domain="", doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, share=None, port=445, logger=None, tries=None):
+    def __init__(self, host, share_name, smbconnection, username="", password="", domain="", doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, share=None, port=445, logger=None, tries=None, st=None):
         self.__host = host
         self.__share_name = share_name
         self.__port = port
@@ -61,6 +61,7 @@ class SMBEXEC:
                 self.__lmhash,
                 self.__nthash,
                 self.__aesKey,
+                TGS=st,
             )
             self.__rpctransport.set_kerberos(self.__doKerberos, self.__kdcHost)
 

--- a/nxc/protocols/smb/wmiexec.py
+++ b/nxc/protocols/smb/wmiexec.py
@@ -10,7 +10,7 @@ from impacket.dcerpc.v5.dtypes import NULL
 
 
 class WMIEXEC:
-    def __init__(self, target, share_name, username, password, domain, smbconnection, doKerberos=False, aesKey=None, kdcHost=None, remoteHost=None, hashes=None, share=None, logger=None, timeout=None, tries=None):
+    def __init__(self, target, share_name, username, password, domain, smbconnection, doKerberos=False, aesKey=None, kdcHost=None, remoteHost=None, hashes=None, share=None, logger=None, timeout=None, tries=None, st=None):
         self.__target = target
         self.__username = username
         self.__password = password
@@ -55,6 +55,7 @@ class WMIEXEC:
             doKerberos=self.__doKerberos,
             kdcHost=self.__kdcHost,
             remoteHost=self.__remoteHost,
+            TGS=st,
         )
         iInterface = self.__dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
         flag, self.__stringBinding = dcom_FirewallChecker(iInterface, self.__remoteHost, self.__timeout)


### PR DESCRIPTION
## Description

After @mpgn  review on PR [#1078](https://github.com/Pennyw0rth/NetExec/pull/1078)) I noticed that when using `--delegate` (with or without `--use-kcache`), the Service Ticket (ST) obtained via S4U2Proxy was only used for the initial SMB connection. Subsequent operations that open new connections (e.g. `--users`, `-x`, `--pass-pol`) were creating new SMB/RPC transports without that delegated ST. They then tried to authenticate as the delegated user with the original credentials (e.g. machine account password), which fails with `KDC_ERR_PREAUTH_FAILED` or `STATUS_MORE_PROCESSING_REQUIRED` because the delegated user has no usable password in that context.

This PR fixes that by storing the delegated ST after S4U2Proxy in `smb.py` (`self.delegated_st`) and passing it into every code path that builds a new Kerberos-authenticated connection : SAMR (users, passpol, samrfunc), exec methods (atexec, smbexec, wmiexec, mmcexec), and any transport that accepts a `ST`.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)


## Screenshots (if appropriate):

Before : 

<img width="1909" height="251" alt="2" src="https://github.com/user-attachments/assets/6766f284-8661-47db-bdc8-2e2add86732f" />

<img width="1893" height="868" alt="3" src="https://github.com/user-attachments/assets/3871c47d-1ed4-495b-888c-01d4a6746766" />


After : 

<img width="1881" height="727" alt="4" src="https://github.com/user-attachments/assets/ed9363f6-ead8-48bb-a773-897b7792ae8a" />


<img width="1871" height="135" alt="5" src="https://github.com/user-attachments/assets/f6ca9c0f-1d1a-4b6a-b734-4800f41c5c8f" />



## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
