### PR TITLE
Fix DPAPI credential lookup: add lowercase username for dploot compatibility 

### DIFF
--- a/nxc/protocols/smb/dpapi.py
+++ b/nxc/protocols/smb/dpapi.py
@@ -58,11 +58,10 @@ def collect_masterkeys_from_target(context, target, dploot_connection, user=True
     if user:
         plaintexts = {username: password for _, _, username, password, _, _ in context.db.get_credentials(cred_type="plaintext")}
         nthashes = {username: nt.split(":")[1] if ":" in nt else nt for _, _, username, nt, _, _ in context.db.get_credentials(cred_type="hash")}
+        # dploot matches user.lower()
         if context.password != "":
-            plaintexts[context.username] = context.password
-            plaintexts[context.username.lower()] = context.password  # dploot matches user.lower()
+            plaintexts[context.username.lower()] = context.password
         if context.nthash != "":
-            nthashes[context.username] = context.nthash
             nthashes[context.username.lower()] = context.nthash
 
     # Collect User and Machine masterkeys


### PR DESCRIPTION
## Description

Fixes DPAPI master key decryption when the username contains uppercase letters (e.g. `Administrator`).

dploot looks up credentials using `user.lower()` (e.g. `"administrator"`), but credentials were only stored under `context.username` (e.g. `"Administrator"`). Because Python dict lookups are case-sensitive, the credential lookup failed and master keys were not decrypted.

This change adds the lowercase username as an additional key in both `plaintexts` and `nthashes` so dploot can find the credentials regardless of casing.

No new dependencies.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review
Please provide guidance on what setup is needed to test the introduced changes, such as your locally running machine Python version & OS, as well as the target(s) you tested against, including software versions.
In particular:
- **Bug Fix**: Run the DPAPI module against a Windows target using a username with uppercase letters (e.g. `Administrator`, `DOMAIN\User`). Before the fix, master keys for that user were not decrypted because the credential lookup failed. After the fix, credentials are found and master keys decrypt successfully.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)