### PR TITLE
fix(backup_operator): add random suffix to dump filenames

### DIFF
--- a/nxc/modules/backup_operator.py
+++ b/nxc/modules/backup_operator.py
@@ -1,13 +1,11 @@
 import contextlib
-import random
-import string
 from time import sleep
 
 from impacket.examples.secretsdump import SAMHashes, LSASecrets, LocalOperations
 from impacket.smbconnection import SessionError
 from impacket.dcerpc.v5 import transport, rrp
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
-from nxc.helpers.misc import CATEGORY
+from nxc.helpers.misc import CATEGORY, gen_random_string
 
 
 class NXCModule:
@@ -28,7 +26,8 @@ class NXCModule:
 
     def on_login(self, context, connection):
         connection.args.share = "SYSVOL"
-        rand_suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
+        rand_suffix = gen_random_string(8)
+
         # enable remote registry
         context.log.display("Triggering RemoteRegistry to start through named pipe...")
         connection.trigger_winreg()


### PR DESCRIPTION
## Summary

The backup_operator module uses static filenames (`SAM`, `SYSTEM`, `SECURITY`) when saving registry hives to SYSVOL. If the cleanup step fails to delete these files, running the module again is impossible because `hBaseRegSaveKey` refuses to overwrite existing files:

```
nxc smb 10.27.10.7 -u obiwan -p 'wz(}ab4=/&_f' -M backup_operator
SMB         10.27.10.7      445    JEDHA            [*] Windows Server 2022 Build 20348 x64 (name:JEDHA) (domain:rebels.local) (signing:True) (SMBv1:None) (Null Auth:True)
SMB         10.27.10.7      445    JEDHA            [+] rebels.local\obiwan:wz(}ab4=/&_f 
BACKUP_O... 10.27.10.7      445    JEDHA            [*] Triggering RemoteRegistry to start through named pipe...
BACKUP_O... 10.27.10.7      445    JEDHA            [-] Couldn't save HKLM\SAM: RRP SessionError: code: 0xb7 - ERROR_ALREADY_EXISTS - Cannot create a file when that file already exists. on path \\10.27.10.7\SYSVOL\SAM
```

## Fix

Each run now generates an 8-character random suffix appended to the dump filenames (e.g. `SAM_a1b2c3d4`, `SYSTEM_a1b2c3d4`, `SECURITY_a1b2c3d4`). This avoids collisions with leftover files from previous runs. The suffix is consistently used across saving, downloading, and cleanup.

## Test plan
- [ ] Run backup_operator module against a target
- [ ] Verify hive files are saved and downloaded with randomized names
- [ ] Verify cleanup deletes the randomized files
- [ ] If cleanup fails, verify the module can be run again without `ERROR_ALREADY_EXISTS`