### PR TITLE
db: do not add credential to db if guest or null auth

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -455,8 +455,7 @@ class smb(connection):
                 host_id = self.db.get_hosts(self.host)[0].id
                 self.db.add_loggedin_relation(user_id, host_id)
 
-            out = f"{domain}\\{self.username}:{process_secret(self.password)} {self.mark_guest()}{self.mark_pwned()}"
-            self.logger.success(out)
+            self.logger.success(f"{domain}\\{self.username}:{process_secret(self.password)} {self.mark_guest()}{self.mark_pwned()}")
 
             if not self.args.local_auth and self.username != "":
                 add_user_bh(self.username, self.domain, self.logger, self.config)
@@ -521,8 +520,7 @@ class smb(connection):
                 host_id = self.db.get_hosts(self.host)[0].id
                 self.db.add_loggedin_relation(user_id, host_id)
 
-            out = f"{domain}\\{self.username}:{process_secret(self.hash)} {self.mark_guest()}{self.mark_pwned()}"
-            self.logger.success(out)
+            self.logger.success(f"{domain}\\{self.username}:{process_secret(self.hash)} {self.mark_guest()}{self.mark_pwned()}")
 
             if not self.args.local_auth and self.username != "":
                 add_user_bh(self.username, self.domain, self.logger, self.config)


### PR DESCRIPTION
## Description
Greetings,

This PR add a condition before adding a credential in the DB for the SMB protocol. Right now, when guest access is enabled, it will be added to the DB and same case for an empty username/password/hash combo.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
```sh
poetry run NetExec smb "$TARGET" -u 'dontexist' -p '' # Credential should NOT be added
poetry run NetExec smb "$TARGET" -u '' -p '' # Credential should NOT be added
poetry run NetExec smb "$TARGET" -u '$USERNAME' -p '$PASSWORD' # Credential should be added
```

## Screenshots (if appropriate):
<img width="972" height="555" alt="image" src="https://github.com/user-attachments/assets/688c32b2-fb7b-4829-9936-95c73ef49dd1" />

<img width="787" height="309" alt="image" src="https://github.com/user-attachments/assets/d4bf30b3-fc8f-4928-8a43-874130a68fd2" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
