### PR TITLE
Fix spider_plus module when hitting symlink

### DIFF
--- a/nxc/modules/spider_plus.py
+++ b/nxc/modules/spider_plus.py
@@ -125,6 +125,8 @@ class SMBSpiderPlus:
                 self.logger.debug(f'Cannot list files in folder "{subfolder}".')
             elif "STATUS_OBJECT_PATH_NOT_FOUND" in str(e):
                 self.logger.debug(f"The folder {subfolder} does not exist.")
+            elif "STATUS_STOPPED_ON_SYMLINK" in str(e):
+                self.logger.debug(f"The folder {subfolder} is a symlink that cannot be followed. Skipping.")
             elif self.reconnect():
                 filelist = self.list_path(share, subfolder)
         except NetBIOSTimeout as e:


### PR DESCRIPTION
## Description
As reported in #1127 when hitting a symlink the `spider_plus` module tries to reconnect and retry. This doesn't solve the problem of not being able to "list" the symlink causing an endless loop. This fixes it by just not reconnecting, but skipping the probably not retrievable symlink.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Scan C$ for example with the `spider_plus` module. A good filter to exclude a ton of garbage is:
```sh
poetry run nxc smb 192.168.56.22 -u jon.snow -p iknownothing -M spider_plus -o EXCLUDE_FILTER='print$,ipc$,ADMIN$,public,ProgramData,Program Files (x86),Program Files,Windows' --debug
```

## Screenshots (if appropriate):
Before:
<img width="1542" height="1052" alt="image" src="https://github.com/user-attachments/assets/f68bb1a8-5c8b-454e-917c-f092d0210d3b" />

After:
<img width="1583" height="550" alt="image" src="https://github.com/user-attachments/assets/db528be6-5e41-4700-8d97-cf2c0cae29b3" />
