### PR TITLE
Fix nfs for nfs4 only servers

### DIFF
--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -84,7 +84,7 @@ class nfs(connection):
             "gid": 0,
             "aux_gid": [],
         }
-        self.root_escape = False
+        self.root_escape = None
         # If root escape is possible, the escape_share and escape_fh will be populated
         self.escape_share = None
         self.escape_fh = b""
@@ -137,7 +137,10 @@ class nfs(connection):
         self.nfs3 = NFSv3(self.host, nfs_port, self.args.nfs_timeout, self.auth)
         self.nfs3.connect()
         # Check if root escape is possible
-        self.root_escape = self.try_root_escape()
+        if NFS_V3 in self.nfs_versions:
+            self.root_escape = self.try_root_escape()
+        else:
+            self.logger.debug("NFSv3 not supported, skipping root escape check")
         self.nfs3.disconnect()
 
     def print_host_info(self):


### PR DESCRIPTION
## Description
As reported in #1073 the nfs proto crashes when NFSv3 is not supported. This is due to netexec relying on an NFS3 library and therefore is not able to handle NFS4 servers. This PR just adds a check and does not try the root escape when NFS3 is not supported.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Setup an NFS4 only server (install nfs and configure `vers3=n` in `/etc/nfs.conf`). Then connect to the nfs server.

## Screenshots (if appropriate):
Before&After:
<img width="1544" height="1099" alt="image" src="https://github.com/user-attachments/assets/4c8b5ca4-5b66-4835-acbe-6c51eeb09b1f" />

