### PR TITLE
Don't display the index error when guest auth is active

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -1386,7 +1386,7 @@ class smb(connection):
             self.logger.debug(f"domain: {self.domain}")
             user_id = self.db.get_user(self.domain.upper(), self.username)[0][0]
         except IndexError as e:
-            if self.kerberos or self.username == "":
+            if self.kerberos or self.username == "" or self.is_guest:
                 pass
             else:
                 self.logger.fail(f"IndexError: {e!s}")


### PR DESCRIPTION
## Description
Fixes #1143 when users list shares with a guest session and we therefore don't have a valid user to query the nxcdb.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Run `nxc smb <ip> -u invalid_user -p test --shares`

## Screenshots (if appropriate):
Before:
<img width="1377" height="242" alt="image" src="https://github.com/user-attachments/assets/d4b45dc8-4405-4727-a540-f02ca45550fc" />

After:
<img width="1376" height="220" alt="image" src="https://github.com/user-attachments/assets/75b05b0f-75f8-43a3-b467-615919aff938" />

# Checklist