### PR TITLE
Add users with empty password to db

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -456,7 +456,7 @@ class smb(connection):
             if "Unix" not in self.server_os:
                 self.check_if_admin()
 
-            if not self.is_guest and (self.username and self.password):
+            if not self.is_guest and self.username:
                 self.logger.debug(f"Adding credential: {domain}/{self.username}:{self.password}")
                 self.db.add_credential("plaintext", domain, self.username, self.password)
                 user_id = self.db.get_credential("plaintext", domain, self.username, self.password)


### PR DESCRIPTION
## Description
The changes in PR https://github.com/Pennyw0rth/NetExec/pull/1133 were a little bit too restrictive. We excluded users from the db that had empty passwords, but that can be the case. We will only don't add to the db when we either have the guest session or null auth (missing username).

Fixes #1143

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Run `nxc smb -u username -p '' --shares` where the user has an empty pw.

## Screenshots (if appropriate):
Before&After:
<img width="1536" height="892" alt="image" src="https://github.com/user-attachments/assets/376a31eb-7af4-4f5d-92ee-87f35dbd80bf" />
