### PR TITLE
feat(smbtakeover): add smbtakeover.py module

### DIFF
--- a/nxc/modules/smbtakeover.py
+++ b/nxc/modules/smbtakeover.py
@@ -65,7 +65,7 @@ class SmbTakeoverWmi:
 
         try:
             self.__dcom = DCOMConnection(
-                target=connection.host,
+                target=connection.remoteName,
                 username=connection.username,
                 password=connection.password,
                 domain=connection.domain,

--- a/nxc/modules/smbtakeover.py
+++ b/nxc/modules/smbtakeover.py
@@ -57,6 +57,7 @@ class SmbTakeoverWmi:
         self.__context_protocol = context.protocol
         self.__is_initialized = False
         self._i_wbem_services = None
+        self.__dcom = None
 
         try:
             self.__dcom = DCOMConnection(
@@ -95,7 +96,7 @@ class SmbTakeoverWmi:
 
         # Don't disconnect on 'nxc wmi' because NetExec disconnects in the end automatically
         # Disconnect only on 'nxc smb' to keep the WMI connection from hanging
-        if hasattr(self, f"_{self.__class__.__name__}__dcom") and self.__dcom and self.__context_protocol != "wmi":
+        if self.__dcom and self.__context_protocol != "wmi":
             try:
                 self.__dcom.disconnect()
             except Exception as e:
@@ -112,21 +113,18 @@ class SmbTakeoverWmi:
         return self._i_wbem_services
 
     def get_service_or_driver(self, name):
-        if name in ("srv2", "srvnet"):
-            table = "Win32_SystemDriver"
-        elif name == "LanmanServer":
-            table = "Win32_Service"
+        svc_name_to_table = {"srv2": "Win32_SystemDriver", "srvnet": "Win32_SystemDriver", "LanmanServer": "Win32_Service"}
 
         try:
-            query = f"SELECT * FROM {table} WHERE Name='{name}'"
+            query = f"SELECT * FROM {svc_name_to_table[name]} WHERE Name='{name}'"
             objects = self.i_wbem_services.ExecQuery(query).Next(0xFFFFFFFF, 1)
             if objects:
                 return objects[0]
         except Exception as e:
             if "code: 0x1 - WBEM_S_FALSE" in str(e):
-                self.logger.debug(f"Object '{name}' not found in {table} (WBEM_S_FALSE)")
+                self.logger.debug(f"Object '{name}' not found in {svc_name_to_table[name]} (WBEM_S_FALSE)")
             else:
-                self.logger.fail(f"Unexpected WMI error checking {table}: {e!s}")
+                self.logger.fail(f"Unexpected WMI error checking {svc_name_to_table[name]}: {e!s}")
         return None
 
     def call_wmi_method(self, obj, method_name, *args):
@@ -178,10 +176,13 @@ class SmbTakeoverWmi:
             self.logger.fail(f"[{service_name}] Not found!")
         return (None, None, None)
 
-    def check(self):
+    def check(self) -> dict:
+        statuses = {}
         for svc_name in ("LanmanServer", "srv2", "srvnet"):
             _, state, start_mode = self.check_service(svc_name)
+            statuses[svc_name] = {"state": state, "start_mode": start_mode}
             self.logger.highlight(f"[{svc_name}] State: {state} | StartMode: {start_mode}")
+        return statuses
 
     def process(self, action: str):
         """
@@ -207,7 +208,21 @@ class SmbTakeoverWmi:
                 if state != target_state:
                     self.start_service(svc_obj, svc_name) if is_start else self.stop_service(svc_obj, svc_name)
 
-        self.check()
+        failed = False
+        statuses = self.check()
+        self.logger.info(statuses)
+        if statuses["LanmanServer"]["start_mode"] != lanman_check:
+            failed = True
+        else:
+            for svc_name in statuses:
+                if statuses[svc_name]["state"] != target_state:
+                    failed = True
+                    break
+
         msg = "rebind" if is_start else "unbind"
-        status = "restored" if is_start else "free"
-        self.logger.success(f"SMB {msg} sequence completed. Port 445/tcp {status}.")
+
+        if failed:
+            self.logger.fail(f"SMB {msg} sequence failed.")
+        else:
+            status = "restored" if is_start else "free"
+            self.logger.success(f"SMB {msg} sequence completed. Port 445/tcp {status}.")

--- a/nxc/modules/smbtakeover.py
+++ b/nxc/modules/smbtakeover.py
@@ -11,7 +11,7 @@ from nxc.helpers.misc import CATEGORY
 
 class NXCModule:
     name = "smbtakeover"
-    description = "Unbinds/Rebinds 445/tcp via SCM interactions strictly over WMI (ncacn_ip_tcp)"
+    description = "Unbinds/Rebinds port 445/tcp via SCM interactions strictly over WMI (ncacn_ip_tcp)"
     supported_protocols = ["smb", "wmi"]
     category = CATEGORY.PRIVILEGE_ESCALATION
 
@@ -19,36 +19,26 @@ class NXCModule:
         self.context = context
         self.module_options = module_options
         self.action = None
-        self.dcom_timeout = 10
 
     def options(self, context, module_options):
         """
-        ACTION          Unbind/Rebind port 445 (choices: check, stop, start)
-                        - check: Enumerates service states
+        ACTION          Unbind/Rebind port 445/tcp (choices: check, stop, start)
+                        - check: Enumerates service states (default)
                         - stop: Unbinds 445/tcp (Stops LanmanServer, srv2, srvnet)
                         - start: Rebinds 445/tcp (Restores services)
-        DCOM-TIMEOUT    Set WMI connection timeout (Default: 10 seconds)
         """
         if "ACTION" not in module_options:
-            context.log.fail("ACTION option not specified! Choices: check, stop, start")
-            exit(1)
-
-        self.action = module_options["ACTION"].lower()
+            self.action = "check"
+        else:
+            self.action = module_options["ACTION"].lower()
 
         if self.action not in ["check", "stop", "start"]:
             context.log.fail("Invalid ACTION. Supported choices are: check, stop, start")
             exit(1)
 
-        if "DCOM-TIMEOUT" in module_options:
-            try:
-                self.dcom_timeout = int(module_options["DCOM-TIMEOUT"])
-            except Exception:
-                context.log.fail("Wrong DCOM timeout value!")
-                exit(1)
-
     def on_admin_login(self, context, connection):
         context.log.display(f"Executing smbtakeover {self.action} via WMI (ncacn_ip_tcp)...")
-        smbtakeover_wmi = SmbTakeoverWmi(context, connection, self.dcom_timeout)
+        smbtakeover_wmi = SmbTakeoverWmi(context, connection)
 
         if smbtakeover_wmi.is_initialized:
             try:
@@ -68,44 +58,31 @@ class NXCModule:
 class SmbTakeoverWmi:
     """Handles SCM interactions indirectly over WMI (ncacn_ip_tcp)"""
 
-    def __init__(self, context, connection, timeout):
+    def __init__(self, context, connection):
         self.logger = context.log
-        self.__currentprotocol = context.protocol
 
-        self.__username = getattr(connection, "username", "")
-        self.__password = getattr(connection, "password", "")
-        self.__domain = getattr(connection, "domain", "")
-        self.__lmhash = getattr(connection, "lmhash", "")
-        self.__nthash = getattr(connection, "nthash", "")
-        self.__doKerberos = getattr(connection, "kerberos", False)
-        self.__kdcHost = getattr(connection, "kdcHost", None)
-        self.__aesKey = getattr(connection, "aesKey", None)
-
-        self.__target = connection.hostname + "." + connection.domain if self.__doKerberos else getattr(connection, "host", "")
-        self.__remoteHost = getattr(connection, "host", "")
-        self.__timeout = timeout
         self.__is_initialized = False
 
         try:
             self.__dcom = DCOMConnection(
-                self.__target,
-                self.__username,
-                self.__password,
-                self.__domain,
-                self.__lmhash,
-                self.__nthash,
-                self.__aesKey,
+                target=connection.host,
+                username=connection.username,
+                password=connection.password,
+                domain=connection.domain,
+                lmhash=connection.lmhash,
+                nthash=connection.nthash,
+                aesKey=connection.aesKey,
                 oxidResolver=True,
-                doKerberos=self.__doKerberos,
-                kdcHost=self.__kdcHost,
-                remoteHost=self.__remoteHost,
+                doKerberos=connection.kerberos,
+                kdcHost=connection.kdcHost,
+                remoteHost=connection.host,
             )
 
             i_interface = self.__dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
             self.__iWbemLevel1Login = wmi.IWbemLevel1Login(i_interface)
             self.__is_initialized = True
         except Exception as e:
-            self.logger.fail(f"WMI connection failed: {e}")
+            self.logger.fail(f"WMI connection failed: {e!s}")
             self.disconnect()
 
     @property
@@ -123,14 +100,24 @@ class SmbTakeoverWmi:
         return i_wbem_services
 
     def get_service_or_driver(self, i_wbem_services, name):
-        for table in ["Win32_Service", "Win32_SystemDriver"]:
-            try:
-                query = f"SELECT * FROM {table} WHERE Name='{name}'"
-                objects = i_wbem_services.ExecQuery(query).Next(0xFFFFFFFF, 1)
-                if len(objects) > 0:
-                    return objects[0]
-            except Exception:
-                pass
+        if name in ["srv2", "srvnet"]:
+            table = "Win32_SystemDriver"
+        elif name == "LanmanServer":
+            table = "Win32_Service"
+        else:
+            self.logger.fail(f"Unknown service or driver name: {name}")
+            return None
+
+        try:
+            query = f"SELECT * FROM {table} WHERE Name='{name}'"
+            objects = i_wbem_services.ExecQuery(query).Next(0xFFFFFFFF, 1)
+            if objects and len(objects) > 0:
+                return objects[0]
+        except Exception as e:
+            if "code: 0x1 - WBEM_S_FALSE" in str(e):
+                self.logger.debug(f"Object '{name}' not found in {table} (WBEM_S_FALSE)")
+            else:
+                self.logger.fail(f"Unexpected WMI error checking {table}: {e!s}")
         return None
 
     def call_wmi_method(self, obj, method_name, *args):
@@ -171,37 +158,45 @@ class SmbTakeoverWmi:
         else:
             self.logger.fail(f"[{service_name}] Failed to start (Ret: {ret})")
 
+    def check_service(self, i_wbem_services, service_name):
+        svc_obj = self.get_service_or_driver(i_wbem_services, service_name)
+        if svc_obj:
+            props = dict(svc_obj.getProperties())
+            state = props.get("State", {}).get("value", "Unknown")
+            start_mode = props.get("StartMode", {}).get("value", "Unknown")
+            return svc_obj, state, start_mode
+        else:
+            self.logger.fail(f"[{service_name}] Service/Driver not found!")
+        return None
+
     def check(self):
         i_wbem_services = self.connect_cimv2()
         services_to_check = ["LanmanServer", "srv2", "srvnet"]
-        self.logger.display("Checking states via WMI (ncacn_ip_tcp)...")
-        for svc_name in services_to_check:
-            svc_obj = self.get_service_or_driver(i_wbem_services, svc_name)
-            if svc_obj:
-                props = dict(svc_obj.getProperties())
-                state = props.get("State", {}).get("value", "Unknown")
-                start_mode = props.get("StartMode", {}).get("value", "Unknown")
-                self.logger.highlight(f"[{svc_name}] State: {state} | StartMode: {start_mode}")
-            else:
-                self.logger.fail(f"[{svc_name}] Service/Driver not found!")
+        for service_name in services_to_check:
+            _, state, start_mode = self.check_service(i_wbem_services, service_name)
+            self.logger.highlight(f"[{service_name}] State: {state} | StartMode: {start_mode}")
         self.__iWbemLevel1Login.RemRelease()
 
     def stop(self):
         i_wbem_services = self.connect_cimv2()
 
-        lanmanserver = self.get_service_or_driver(i_wbem_services, "LanmanServer")
+        lanmanserver, lanmanserver_state, lanmanserver_start_mode = self.check_service(i_wbem_services, "LanmanServer")
         if lanmanserver:
-            self.change_start_mode(lanmanserver, "Disabled", "LanmanServer")
-            self.stop_service(lanmanserver, "LanmanServer")
+            if lanmanserver_start_mode != "Disabled":
+                self.change_start_mode(lanmanserver, "Disabled", "LanmanServer")
 
-        srv2 = self.get_service_or_driver(i_wbem_services, "srv2")
-        if srv2:
+            if lanmanserver_state != "Stopped":
+                self.stop_service(lanmanserver, "LanmanServer")
+
+        srv2, srv2_state, _ = self.check_service(i_wbem_services, "srv2")
+        if srv2 and srv2_state != "Stopped":
             self.stop_service(srv2, "srv2")
 
-        srvnet = self.get_service_or_driver(i_wbem_services, "srvnet")
-        if srvnet:
-            self.change_start_mode(srvnet, "Disabled", "srvnet")
+        srvnet, srvnet_state, _ = self.check_service(i_wbem_services, "srvnet")
+        if srvnet and srvnet_state != "Stopped":
             self.stop_service(srvnet, "srvnet")
+
+        self.check()
 
         self.logger.success("SMB unbind sequence completed via WMI. Port 445 is free.")
         self.__iWbemLevel1Login.RemRelease()
@@ -209,19 +204,23 @@ class SmbTakeoverWmi:
     def start(self):
         i_wbem_services = self.connect_cimv2()
 
-        srvnet = self.get_service_or_driver(i_wbem_services, "srvnet")
-        if srvnet:
-            self.change_start_mode(srvnet, "Manual", "srvnet")
+        srvnet, srvnet_state, _ = self.check_service(i_wbem_services, "srvnet")
+        if srvnet and srvnet_state != "Running":
             self.start_service(srvnet, "srvnet")
 
-        srv2 = self.get_service_or_driver(i_wbem_services, "srv2")
-        if srv2:
+        srv2, srv2_state, _ = self.check_service(i_wbem_services, "srv2")
+        if srv2 and srv2_state != "Running":
             self.start_service(srv2, "srv2")
 
-        lanmanserver = self.get_service_or_driver(i_wbem_services, "LanmanServer")
+        lanmanserver, lanmanserver_state, lanmanserver_start_mode = self.check_service(i_wbem_services, "LanmanServer")
         if lanmanserver:
-            self.change_start_mode(lanmanserver, "Automatic", "LanmanServer")
-            self.start_service(lanmanserver, "LanmanServer")
+            if lanmanserver_start_mode != "Auto":
+                self.change_start_mode(lanmanserver, "Automatic", "LanmanServer")
+
+            if lanmanserver_state != "Running":
+                self.start_service(lanmanserver, "LanmanServer")
+
+        self.check()
 
         self.logger.success("SMB rebind sequence completed via WMI. Port 445 restored.")
         self.__iWbemLevel1Login.RemRelease()

--- a/nxc/modules/smbtakeover.py
+++ b/nxc/modules/smbtakeover.py
@@ -1,4 +1,3 @@
-import contextlib
 from sys import exit
 
 from impacket.dcerpc.v5.dcom import wmi
@@ -18,7 +17,7 @@ class NXCModule:
     def __init__(self, context=None, module_options=None):
         self.context = context
         self.module_options = module_options
-        self.action = None
+        self.action = "check"
 
     def options(self, context, module_options):
         """
@@ -27,31 +26,26 @@ class NXCModule:
                         - stop: Unbinds 445/tcp (Stops LanmanServer, srv2, srvnet)
                         - start: Rebinds 445/tcp (Restores services)
         """
-        if "ACTION" not in module_options:
-            self.action = "check"
-        else:
+        if "ACTION" in module_options:
             self.action = module_options["ACTION"].lower()
 
-        if self.action not in ["check", "stop", "start"]:
+        if self.action not in ("check", "stop", "start"):
             context.log.fail("Invalid ACTION. Supported choices are: check, stop, start")
             exit(1)
 
     def on_admin_login(self, context, connection):
-        context.log.display(f"Executing smbtakeover {self.action} via WMI (ncacn_ip_tcp)...")
+        context.log.display(f"Executing smbtakeover '{self.action}' via WMI (ncacn_ip_tcp)...")
         smbtakeover_wmi = SmbTakeoverWmi(context, connection)
 
         if smbtakeover_wmi.is_initialized:
             try:
                 if self.action == "check":
                     smbtakeover_wmi.check()
-                elif self.action == "stop":
-                    smbtakeover_wmi.stop()
-                elif self.action == "start":
-                    smbtakeover_wmi.start()
+                else:
+                    smbtakeover_wmi.process(action=self.action)
             except Exception as e:
                 context.log.fail(f"Execution error: {e!s}")
-
-            if context.protocol != "wmi":
+            finally:
                 smbtakeover_wmi.disconnect()
 
 
@@ -60,8 +54,9 @@ class SmbTakeoverWmi:
 
     def __init__(self, context, connection):
         self.logger = context.log
-
+        self.__context_protocol = context.protocol
         self.__is_initialized = False
+        self._i_wbem_services = None
 
         try:
             self.__dcom = DCOMConnection(
@@ -90,28 +85,42 @@ class SmbTakeoverWmi:
         return self.__is_initialized
 
     def disconnect(self):
-        with contextlib.suppress(Exception):
-            if hasattr(self, f"_{self.__class__.__name__}__dcom"):
+        if self._i_wbem_services:
+            try:
+                self._i_wbem_services.RemRelease()
+            except Exception as e:
+                self.logger.debug(f"IWbemServices RemRelease error: {e!s}")
+            finally:
+                self._i_wbem_services = None
+
+        # Don't disconnect on 'nxc wmi' because NetExec disconnects in the end automatically
+        # Disconnect only on 'nxc smb' to keep the WMI connection from hanging
+        if hasattr(self, f"_{self.__class__.__name__}__dcom") and self.__dcom and self.__context_protocol != "wmi":
+            try:
                 self.__dcom.disconnect()
+            except Exception as e:
+                self.logger.debug(f"DCOM disconnect error: {e!s}")
+            finally:
+                self.__dcom = None
 
-    def connect_cimv2(self):
-        i_wbem_services = self.__iWbemLevel1Login.NTLMLogin("//./root/cimv2", NULL, NULL)
-        i_wbem_services.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-        return i_wbem_services
+    @property
+    def i_wbem_services(self):
+        if self._i_wbem_services is None:
+            self._i_wbem_services = self.__iWbemLevel1Login.NTLMLogin("//./root/cimv2", NULL, NULL)
+            self._i_wbem_services.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+            self.__iWbemLevel1Login.RemRelease()
+        return self._i_wbem_services
 
-    def get_service_or_driver(self, i_wbem_services, name):
-        if name in ["srv2", "srvnet"]:
+    def get_service_or_driver(self, name):
+        if name in ("srv2", "srvnet"):
             table = "Win32_SystemDriver"
         elif name == "LanmanServer":
             table = "Win32_Service"
-        else:
-            self.logger.fail(f"Unknown service or driver name: {name}")
-            return None
 
         try:
             query = f"SELECT * FROM {table} WHERE Name='{name}'"
-            objects = i_wbem_services.ExecQuery(query).Next(0xFFFFFFFF, 1)
-            if objects and len(objects) > 0:
+            objects = self.i_wbem_services.ExecQuery(query).Next(0xFFFFFFFF, 1)
+            if objects:
                 return objects[0]
         except Exception as e:
             if "code: 0x1 - WBEM_S_FALSE" in str(e):
@@ -138,7 +147,7 @@ class SmbTakeoverWmi:
         if ret == 0:
             self.logger.success(f"[{service_name}] StartMode changed to {mode}")
         else:
-            self.logger.fail(f"[{service_name}] Failed to set StartMode to {mode} (Ret: {ret})")
+            self.logger.fail(f"[{service_name}] Failed to set StartMode (Ret: {ret})")
 
     def stop_service(self, service_obj, service_name):
         ret = self.call_wmi_method(service_obj, "StopService")
@@ -158,69 +167,47 @@ class SmbTakeoverWmi:
         else:
             self.logger.fail(f"[{service_name}] Failed to start (Ret: {ret})")
 
-    def check_service(self, i_wbem_services, service_name):
-        svc_obj = self.get_service_or_driver(i_wbem_services, service_name)
+    def check_service(self, service_name):
+        svc_obj = self.get_service_or_driver(service_name)
         if svc_obj:
             props = dict(svc_obj.getProperties())
             state = props.get("State", {}).get("value", "Unknown")
             start_mode = props.get("StartMode", {}).get("value", "Unknown")
-            return svc_obj, state, start_mode
+            return (svc_obj, state, start_mode)
         else:
-            self.logger.fail(f"[{service_name}] Service/Driver not found!")
-        return None
+            self.logger.fail(f"[{service_name}] Not found!")
+        return (None, None, None)
 
     def check(self):
-        i_wbem_services = self.connect_cimv2()
-        services_to_check = ["LanmanServer", "srv2", "srvnet"]
-        for service_name in services_to_check:
-            _, state, start_mode = self.check_service(i_wbem_services, service_name)
-            self.logger.highlight(f"[{service_name}] State: {state} | StartMode: {start_mode}")
-        self.__iWbemLevel1Login.RemRelease()
+        for svc_name in ("LanmanServer", "srv2", "srvnet"):
+            _, state, start_mode = self.check_service(svc_name)
+            self.logger.highlight(f"[{svc_name}] State: {state} | StartMode: {start_mode}")
 
-    def stop(self):
-        i_wbem_services = self.connect_cimv2()
+    def process(self, action: str):
+        """
+        Unified SMB control logic via WMI.
+        'stop'  sequence: LanmanServer -> srv2 -> srvnet
+        'start' sequence: srvnet -> srv2 -> LanmanServer
+        """
+        is_start = action == "start"
+        services = ["LanmanServer", "srv2", "srvnet"]
+        if is_start:
+            services.reverse()
 
-        lanmanserver, lanmanserver_state, lanmanserver_start_mode = self.check_service(i_wbem_services, "LanmanServer")
-        if lanmanserver:
-            if lanmanserver_start_mode != "Disabled":
-                self.change_start_mode(lanmanserver, "Disabled", "LanmanServer")
+        target_state = "Running" if is_start else "Stopped"
+        lanman_mode = "Automatic" if is_start else "Disabled"
+        lanman_check = "Auto" if is_start else "Disabled"
 
-            if lanmanserver_state != "Stopped":
-                self.stop_service(lanmanserver, "LanmanServer")
+        for svc_name in services:
+            svc_obj, state, start_mode = self.check_service(svc_name)
+            if svc_obj:
+                if svc_name == "LanmanServer" and start_mode != lanman_check:
+                    self.change_start_mode(svc_obj, lanman_mode, svc_name)
 
-        srv2, srv2_state, _ = self.check_service(i_wbem_services, "srv2")
-        if srv2 and srv2_state != "Stopped":
-            self.stop_service(srv2, "srv2")
-
-        srvnet, srvnet_state, _ = self.check_service(i_wbem_services, "srvnet")
-        if srvnet and srvnet_state != "Stopped":
-            self.stop_service(srvnet, "srvnet")
-
-        self.check()
-
-        self.logger.success("SMB unbind sequence completed via WMI. Port 445 is free.")
-        self.__iWbemLevel1Login.RemRelease()
-
-    def start(self):
-        i_wbem_services = self.connect_cimv2()
-
-        srvnet, srvnet_state, _ = self.check_service(i_wbem_services, "srvnet")
-        if srvnet and srvnet_state != "Running":
-            self.start_service(srvnet, "srvnet")
-
-        srv2, srv2_state, _ = self.check_service(i_wbem_services, "srv2")
-        if srv2 and srv2_state != "Running":
-            self.start_service(srv2, "srv2")
-
-        lanmanserver, lanmanserver_state, lanmanserver_start_mode = self.check_service(i_wbem_services, "LanmanServer")
-        if lanmanserver:
-            if lanmanserver_start_mode != "Auto":
-                self.change_start_mode(lanmanserver, "Automatic", "LanmanServer")
-
-            if lanmanserver_state != "Running":
-                self.start_service(lanmanserver, "LanmanServer")
+                if state != target_state:
+                    self.start_service(svc_obj, svc_name) if is_start else self.stop_service(svc_obj, svc_name)
 
         self.check()
-
-        self.logger.success("SMB rebind sequence completed via WMI. Port 445 restored.")
-        self.__iWbemLevel1Login.RemRelease()
+        msg = "rebind" if is_start else "unbind"
+        status = "restored" if is_start else "free"
+        self.logger.success(f"SMB {msg} sequence completed. Port 445/tcp {status}.")

--- a/nxc/modules/smbtakeover.py
+++ b/nxc/modules/smbtakeover.py
@@ -210,7 +210,7 @@ class SmbTakeoverWmi:
 
         failed = False
         statuses = self.check()
-        self.logger.info(statuses)
+
         if statuses["LanmanServer"]["start_mode"] != lanman_check:
             failed = True
         else:

--- a/nxc/modules/smbtakeover.py
+++ b/nxc/modules/smbtakeover.py
@@ -1,0 +1,227 @@
+import contextlib
+from sys import exit
+
+from impacket.dcerpc.v5.dcom import wmi
+from impacket.dcerpc.v5.dcomrt import DCOMConnection
+from impacket.dcerpc.v5.dtypes import NULL
+from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
+
+from nxc.helpers.misc import CATEGORY
+
+
+class NXCModule:
+    name = "smbtakeover"
+    description = "Unbinds/Rebinds 445/tcp via SCM interactions strictly over WMI (ncacn_ip_tcp)"
+    supported_protocols = ["smb", "wmi"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
+
+    def __init__(self, context=None, module_options=None):
+        self.context = context
+        self.module_options = module_options
+        self.action = None
+        self.dcom_timeout = 10
+
+    def options(self, context, module_options):
+        """
+        ACTION          Unbind/Rebind port 445 (choices: check, stop, start)
+                        - check: Enumerates service states
+                        - stop: Unbinds 445/tcp (Stops LanmanServer, srv2, srvnet)
+                        - start: Rebinds 445/tcp (Restores services)
+        DCOM-TIMEOUT    Set WMI connection timeout (Default: 10 seconds)
+        """
+        if "ACTION" not in module_options:
+            context.log.fail("ACTION option not specified! Choices: check, stop, start")
+            exit(1)
+
+        self.action = module_options["ACTION"].lower()
+
+        if self.action not in ["check", "stop", "start"]:
+            context.log.fail("Invalid ACTION. Supported choices are: check, stop, start")
+            exit(1)
+
+        if "DCOM-TIMEOUT" in module_options:
+            try:
+                self.dcom_timeout = int(module_options["DCOM-TIMEOUT"])
+            except Exception:
+                context.log.fail("Wrong DCOM timeout value!")
+                exit(1)
+
+    def on_admin_login(self, context, connection):
+        context.log.display(f"Executing smbtakeover {self.action} via WMI (ncacn_ip_tcp)...")
+        smbtakeover_wmi = SmbTakeoverWmi(context, connection, self.dcom_timeout)
+
+        if smbtakeover_wmi.is_initialized:
+            try:
+                if self.action == "check":
+                    smbtakeover_wmi.check()
+                elif self.action == "stop":
+                    smbtakeover_wmi.stop()
+                elif self.action == "start":
+                    smbtakeover_wmi.start()
+            except Exception as e:
+                context.log.fail(f"Execution error: {e!s}")
+
+            if context.protocol != "wmi":
+                smbtakeover_wmi.disconnect()
+
+
+class SmbTakeoverWmi:
+    """Handles SCM interactions indirectly over WMI (ncacn_ip_tcp)"""
+
+    def __init__(self, context, connection, timeout):
+        self.logger = context.log
+        self.__currentprotocol = context.protocol
+
+        self.__username = getattr(connection, "username", "")
+        self.__password = getattr(connection, "password", "")
+        self.__domain = getattr(connection, "domain", "")
+        self.__lmhash = getattr(connection, "lmhash", "")
+        self.__nthash = getattr(connection, "nthash", "")
+        self.__doKerberos = getattr(connection, "kerberos", False)
+        self.__kdcHost = getattr(connection, "kdcHost", None)
+        self.__aesKey = getattr(connection, "aesKey", None)
+
+        self.__target = connection.hostname + "." + connection.domain if self.__doKerberos else getattr(connection, "host", "")
+        self.__remoteHost = getattr(connection, "host", "")
+        self.__timeout = timeout
+        self.__is_initialized = False
+
+        try:
+            self.__dcom = DCOMConnection(
+                self.__target,
+                self.__username,
+                self.__password,
+                self.__domain,
+                self.__lmhash,
+                self.__nthash,
+                self.__aesKey,
+                oxidResolver=True,
+                doKerberos=self.__doKerberos,
+                kdcHost=self.__kdcHost,
+                remoteHost=self.__remoteHost,
+            )
+
+            i_interface = self.__dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
+            self.__iWbemLevel1Login = wmi.IWbemLevel1Login(i_interface)
+            self.__is_initialized = True
+        except Exception as e:
+            self.logger.fail(f"WMI connection failed: {e}")
+            self.disconnect()
+
+    @property
+    def is_initialized(self):
+        return self.__is_initialized
+
+    def disconnect(self):
+        with contextlib.suppress(Exception):
+            if hasattr(self, f"_{self.__class__.__name__}__dcom"):
+                self.__dcom.disconnect()
+
+    def connect_cimv2(self):
+        i_wbem_services = self.__iWbemLevel1Login.NTLMLogin("//./root/cimv2", NULL, NULL)
+        i_wbem_services.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+        return i_wbem_services
+
+    def get_service_or_driver(self, i_wbem_services, name):
+        for table in ["Win32_Service", "Win32_SystemDriver"]:
+            try:
+                query = f"SELECT * FROM {table} WHERE Name='{name}'"
+                objects = i_wbem_services.ExecQuery(query).Next(0xFFFFFFFF, 1)
+                if len(objects) > 0:
+                    return objects[0]
+            except Exception:
+                pass
+        return None
+
+    def call_wmi_method(self, obj, method_name, *args):
+        try:
+            out = getattr(obj, method_name)(*args)
+            if isinstance(out, int):
+                return out
+            if out is None:
+                return None
+            props = dict(out.getProperties())
+            return props.get("ReturnValue", {}).get("value", None)
+        except Exception as e:
+            self.logger.fail(f"Error executing {method_name}: {e!s}")
+            return None
+
+    def change_start_mode(self, service_obj, mode, service_name):
+        ret = self.call_wmi_method(service_obj, "ChangeStartMode", mode)
+        if ret == 0:
+            self.logger.success(f"[{service_name}] StartMode changed to {mode}")
+        else:
+            self.logger.fail(f"[{service_name}] Failed to set StartMode to {mode} (Ret: {ret})")
+
+    def stop_service(self, service_obj, service_name):
+        ret = self.call_wmi_method(service_obj, "StopService")
+        if ret == 0:
+            self.logger.success(f"[{service_name}] Stopped successfully")
+        elif ret == 5:
+            self.logger.info(f"[{service_name}] Already stopped")
+        else:
+            self.logger.fail(f"[{service_name}] Failed to stop (Ret: {ret})")
+
+    def start_service(self, service_obj, service_name):
+        ret = self.call_wmi_method(service_obj, "StartService")
+        if ret == 0:
+            self.logger.success(f"[{service_name}] Started successfully")
+        elif ret == 10:
+            self.logger.info(f"[{service_name}] Already running")
+        else:
+            self.logger.fail(f"[{service_name}] Failed to start (Ret: {ret})")
+
+    def check(self):
+        i_wbem_services = self.connect_cimv2()
+        services_to_check = ["LanmanServer", "srv2", "srvnet"]
+        self.logger.display("Checking states via WMI (ncacn_ip_tcp)...")
+        for svc_name in services_to_check:
+            svc_obj = self.get_service_or_driver(i_wbem_services, svc_name)
+            if svc_obj:
+                props = dict(svc_obj.getProperties())
+                state = props.get("State", {}).get("value", "Unknown")
+                start_mode = props.get("StartMode", {}).get("value", "Unknown")
+                self.logger.highlight(f"[{svc_name}] State: {state} | StartMode: {start_mode}")
+            else:
+                self.logger.fail(f"[{svc_name}] Service/Driver not found!")
+        self.__iWbemLevel1Login.RemRelease()
+
+    def stop(self):
+        i_wbem_services = self.connect_cimv2()
+
+        lanmanserver = self.get_service_or_driver(i_wbem_services, "LanmanServer")
+        if lanmanserver:
+            self.change_start_mode(lanmanserver, "Disabled", "LanmanServer")
+            self.stop_service(lanmanserver, "LanmanServer")
+
+        srv2 = self.get_service_or_driver(i_wbem_services, "srv2")
+        if srv2:
+            self.stop_service(srv2, "srv2")
+
+        srvnet = self.get_service_or_driver(i_wbem_services, "srvnet")
+        if srvnet:
+            self.change_start_mode(srvnet, "Disabled", "srvnet")
+            self.stop_service(srvnet, "srvnet")
+
+        self.logger.success("SMB unbind sequence completed via WMI. Port 445 is free.")
+        self.__iWbemLevel1Login.RemRelease()
+
+    def start(self):
+        i_wbem_services = self.connect_cimv2()
+
+        srvnet = self.get_service_or_driver(i_wbem_services, "srvnet")
+        if srvnet:
+            self.change_start_mode(srvnet, "Manual", "srvnet")
+            self.start_service(srvnet, "srvnet")
+
+        srv2 = self.get_service_or_driver(i_wbem_services, "srv2")
+        if srv2:
+            self.start_service(srv2, "srv2")
+
+        lanmanserver = self.get_service_or_driver(i_wbem_services, "LanmanServer")
+        if lanmanserver:
+            self.change_start_mode(lanmanserver, "Automatic", "LanmanServer")
+            self.start_service(lanmanserver, "LanmanServer")
+
+        self.logger.success("SMB rebind sequence completed via WMI. Port 445 restored.")
+        self.__iWbemLevel1Login.RemRelease()


### PR DESCRIPTION
## Description
Added `smbtakeover.py` module to unbind/rebind SMB port `445/tcp`. Useful when conducting NTLM relay attacks.

Usually Windows hosts already use port `445/tcp` for SMB. And to conduct an NTLM relay attack you'd need port `445` to be available to bind to it. There are ways to do it via loading a driver, loading a module into LSASS, rebooting the target machine - which are all bad for OPSEC.

This module solves this problem in an OPSEC safe way.

Original research - https://specterops.io/blog/2024/08/01/relay-your-heart-away-an-opsec-conscious-approach-to-445-takeover/
Original code - https://github.com/zyn3rgy/smbtakeover

Used Gemini Pro to generate the NXCModule class. Validated after it.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [X] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [X] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
NOTE: User running the module has to have `Administrator` level access on the machine (to start/stop the services).
NOTE: WMI ports need to be accessible (check firewall).

I used `Kaiju` chain from Vulnlab to validate the module.

## Screenshots (if appropriate):
<img width="1265" height="1195" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/1e42e633-a1cf-4bab-81ed-d537cd052de2" />

Unbinding and then rebinding works ok.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [X] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [X] I have performed a self-review of my own code (_not_ an AI review)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
