### PR TITLE
Prevent doing database stuff if we don't have a valid connection

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -456,21 +456,22 @@ class smb(connection):
             if "Unix" not in self.server_os:
                 self.check_if_admin()
 
-            if not self.is_guest and self.username:
+            # Only do database/bloodhound stuff if we don't have guest/null auth
+            valid_auth = not self.is_guest and self.username
+            if valid_auth:
                 self.logger.debug(f"Adding credential: {domain}/{self.username}:{self.password}")
                 self.db.add_credential("plaintext", domain, self.username, self.password)
                 user_id = self.db.get_credential("plaintext", domain, self.username, self.password)
                 host_id = self.db.get_hosts(self.host)[0].id
                 self.db.add_loggedin_relation(user_id, host_id)
-
-            self.logger.success(f"{domain}\\{self.username}:{process_secret(self.password)} {self.mark_guest()}{self.mark_pwned()}")
-
-            if not self.args.local_auth and self.username != "":
-                add_user_bh(self.username, self.domain, self.logger, self.config)
-            if self.admin_privs:
+            if self.admin_privs and valid_auth:
                 self.logger.debug(f"Adding admin user: {self.domain}/{self.username}:{self.password}@{self.host}")
                 self.db.add_admin_user("plaintext", domain, self.username, self.password, self.host, user_id=user_id)
                 add_user_bh(f"{self.hostname}$", domain, self.logger, self.config)
+            if not self.args.local_auth and valid_auth:
+                add_user_bh(self.username, self.domain, self.logger, self.config)
+
+            self.logger.success(f"{domain}\\{self.username}:{process_secret(self.password)} {self.mark_guest()}{self.mark_pwned()}")
 
             # check https://github.com/byt3bl33d3r/CrackMapExec/issues/321
             if self.args.continue_on_success and self.signing:
@@ -523,19 +524,20 @@ class smb(connection):
             if "Unix" not in self.server_os:
                 self.check_if_admin()
 
-            if not self.is_guest and (self.username and self.hash):
+            # Only do database/bloodhound stuff if we don't have guest
+            valid_auth = not self.is_guest and self.username and self.hash
+            if valid_auth:
                 self.db.add_credential("hash", domain, self.username, self.hash)
                 user_id = self.db.get_credential("hash", domain, self.username, self.hash)
                 host_id = self.db.get_hosts(self.host)[0].id
                 self.db.add_loggedin_relation(user_id, host_id)
-
-            self.logger.success(f"{domain}\\{self.username}:{process_secret(self.hash)} {self.mark_guest()}{self.mark_pwned()}")
-
-            if not self.args.local_auth and self.username != "":
-                add_user_bh(self.username, self.domain, self.logger, self.config)
-            if self.admin_privs:
+            if self.admin_privs and valid_auth:
                 self.db.add_admin_user("hash", domain, self.username, nthash, self.host, user_id=user_id)
                 add_user_bh(f"{self.hostname}$", domain, self.logger, self.config)
+            if not self.args.local_auth and valid_auth:
+                add_user_bh(self.username, self.domain, self.logger, self.config)
+
+            self.logger.success(f"{domain}\\{self.username}:{process_secret(self.hash)} {self.mark_guest()}{self.mark_pwned()}")
 
             # check https://github.com/byt3bl33d3r/CrackMapExec/issues/321
             if self.args.continue_on_success and self.signing:


### PR DESCRIPTION
## Description
With the changes introduced in https://github.com/Pennyw0rth/NetExec/pull/1133 we (rightfully) don't add users to the database if the auth is a guest or null auth. However, when relaying ntlmrelay marks this connection as guest auth while we still (potentially) are admin. This results in the step of "adding user to db" is skipped, but afterwards trying to add the admin relationship to a user that doesn't exist. 

This PR solves this problem by deciding if the auth is legitimate (not guest/null auth for plaintext and not guest auth for hashes) and then doing all database/bloodhound stuff.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
1. Setup a relay where the connection has administrative privileges.
2. Just run `proxychains nxc smb -u user -p password -d domain`

## Screenshots (if appropriate):
Before:
<img width="1592" height="1059" alt="image" src="https://github.com/user-attachments/assets/8c1a1996-6f23-4e9f-90ba-4be7d12c58c6" />

After:
<img width="1419" height="84" alt="image" src="https://github.com/user-attachments/assets/4f17d190-9a48-4843-82a5-0c5bb80d41bb" />

## Checklist:

