### PR TITLE
enum_av module: add AVG / Avast indicator

### DIFF
--- a/nxc/modules/enum_av.py
+++ b/nxc/modules/enum_av.py
@@ -485,6 +485,19 @@ conf = {
             "pipes": [
                 {"name": "FS_CCFIPC_*", "processes": ["fsatpn.exe", "fsatpl.exe", "fshoster32.exe", "fsulprothoster.exe", "fsulprothoster.exe", "fshoster64.exe", "FsPisces.exe", "fsdevcon.exe"]}
             ]
+        },
+        {
+            "name": "Avast / AVG",
+            "services": [
+                {"name": "AvastWscReporter", "description": "Avast WSC Reporter Service"},
+                {"name": "aswbIDSAgent", "description": "Avast IDS Agent Service"},
+                {"name": "AVGWscReporter", "description": "AVG WSC Reporter Service"},
+                {"name": "avgbIDSAgent", "description": "AVG IDS Agent Service"}
+            ],
+            "pipes": [
+                {"name": "aswCallbackPipe*", "processes": ["AvastSvc.exe", "aswEngSrv.exe"]},
+                {"name": "avgCallbackPipe*", "processes": ["AVGSvc.exe", "aswEngSrv.exe"]}
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Description

Added Avast / AVG indicators for the `enum_av.py` module. ( If you guys like this PR, I plan to add more EDR / AV detection to enum_av.py, let me know if you're interested ) 

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Tested `enum_av.py` module against a Windows 11 (Build 26100) machine with both Avast Free Antivirus and AVG Free Antivirus (tested separately).

### Testing methodology

1. Installed the antivirus on a Windows 11 VM (VirtualBox, host-only network)
2. Enumerated all real service names via `impacket-services` (services.py)
3. Tested each service name individually against `LsarLookupNames` to confirm detection
4. Enumerated all named pipes on `IPC$` to find pipes
5. Confirmed running processes on Windows using `Get-Process`
6. Verified false positives by uninstalling and running the module


## Screenshots (if appropriate):

<img width="1859" height="129" alt="nxc_Enum_AV" src="https://github.com/user-attachments/assets/eb06453e-143b-4ed3-abd2-7fcf11ae2586" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
