### PR TITLE
Set a timeout on empire exec HTTP calls

### DIFF
--- a/nxc/modules/empire_exec.py
+++ b/nxc/modules/empire_exec.py
@@ -52,6 +52,7 @@ class NXCModule:
                 f"{base_url}/token",
                 data=empire_creds,
                 verify=False,
+                timeout=10.0,
             )
         except ConnectionError as e:
             context.log.fail(f"Unable to login to Empire's RESTful API: {e}")
@@ -90,6 +91,7 @@ class NXCModule:
                 json=data,
                 headers=headers,
                 verify=False,
+                timeout=10.0,
             )
         except ConnectionError:
             context.log.fail("Unable to request stager from Empire's RESTful API")


### PR DESCRIPTION
Set a network timeout in modules/empire_exec.py to prevent indefinite worker hangs.

Network calls without a timeout can hang a worker indefinitely.

Ran: `/Users/tejasattarde/Downloads/gh-patchbot/.venv/bin/python3.14 -m py_compile nxc/modules/empire_exec.py`.

`modules/empire_exec.py` line 51.