### PR TITLE
DPAPI.py usage with PVK is broken

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -2093,16 +2093,8 @@ class smb(connection):
     @requires_admin
     def dpapi(self):
         dump_system = "nosystem" not in self.args.dpapi
-
-        if self.args.pvk is not None:
-            try:
-                self.pvkbytes = open(self.args.pvk, "rb").read()  # noqa: SIM115
-                self.logger.success(f"Loading domain backupkey from {self.args.pvk}")
-            except Exception as e:
-                self.logger.fail(str(e))
-
-        if self.pvkbytes is None:
-            self.pvkbytes = get_domain_backup_key(self)
+        
+        self.pvkbytes = get_domain_backup_key(self)
 
         target = Target.create(
             domain=self.domain,

--- a/nxc/protocols/smb/dpapi.py
+++ b/nxc/protocols/smb/dpapi.py
@@ -6,6 +6,15 @@ from dploot.triage.masterkeys import MasterkeysTriage, parse_masterkey_file
 
 def get_domain_backup_key(context):
     pvkbytes = None
+    if getattr(context.args, "pvk", None):
+        context.logger.display(f"Using provided PVK file: {context.args.pvk}")
+        try:
+            with open(context.args.pvk, "rb") as f:
+                context.logger.success("Loading domain backupkey from file...")
+                return f.read()
+        except Exception as e:
+            context.logger.fail(f"Failed to read PVK file ({context.args.pvk}): {e}")
+            return False
     try:
         results = context.db.get_domain_backupkey(context.domain)
     except Exception:


### PR DESCRIPTION
## Description
DPAPI.py's "get_domain_backup_key" ignores PVK file input as argument. All DPAPI modules (mobaxterm , putty , etc) are using that function which basically tries to export the domain backup key instead of using the provided PVK.


## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
when running "nxc smb target -u user -p pass  --pvk caps_dpapi_backupkey.pvk -M mobaxterm -M putty"
you expect the modules to use the provided PVK. Instead - the "get_domain_backup_key" function tries to export the domain backup key from the DC. I modified the function to first check for PVK argument before trying to export the domain backup key.

## Screenshots (if appropriate):
Screenshots are always nice to have and can give a visual representation of the change.
If appropriate, include before and after screenshot(s) to show which results are to be expected.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
