### PR TITLE
Add LDAP query obfuscation support via ldapx

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -92,9 +92,6 @@ class ldap(connection):
         self.scope = None
         self.configuration_context = ""
         self.obfuscate = args.obfuscate
-        self.obfuscate_filter_chain = args.obfuscate_filter if args.obfuscate else ""
-        self.obfuscate_basedn_chain = args.obfuscate_basedn if args.obfuscate else None
-        self.obfuscate_attrs_chain = args.obfuscate_attrs if args.obfuscate else None
 
         connection.__init__(self, args, db, host)
 
@@ -110,10 +107,7 @@ class ldap(connection):
 
     def create_conn_obj(self):
         if self.obfuscate:
-            if self.obfuscate_filter_chain and "O" in self.obfuscate_filter_chain:
-                self.logger.fail("Filter chain code 'O' (OID) is incompatible with impacket's LDAP parser. Remove it from --obfuscate-filter.")
-                return False
-            self.logger.info(f"LDAP obfuscation enabled: filter={self.obfuscate_filter_chain}, baseDN={self.obfuscate_basedn_chain or 'disabled'}, attrs={self.obfuscate_attrs_chain or 'disabled'}")
+            self.logger.info("LDAP query obfuscation enabled")
 
         try:
             proto = "ldaps" if self.port == 636 else "ldap"
@@ -673,9 +667,16 @@ class ldap(connection):
             baseDN = self.baseDN
 
         if self.obfuscate:
-            searchFilter = self._obfuscate_filter(searchFilter)
-            baseDN = self._obfuscate_basedn(baseDN)
-            attributes = self._obfuscate_attrs(attributes)
+            try:
+                if searchFilter:
+                    searchFilter = ldapx.obfuscate_filter(searchFilter, "CSG")
+                if baseDN:
+                    baseDN = ldapx.obfuscate_basedn(baseDN, "CX")
+                if attributes:
+                    attributes = ldapx.obfuscate_attrlist(attributes, "CR")
+                self.logger.debug(f"Obfuscated baseDN: {baseDN}")
+            except Exception as e:
+                self.logger.debug(f"ldapx obfuscation failed, using original query: {e}")
 
         try:
             if self.ldap_connection:
@@ -704,39 +705,6 @@ class ldap(connection):
                 self.logger.fail(e)
                 return []
         return []
-
-    def _obfuscate_filter(self, search_filter):
-        if not self.obfuscate_filter_chain or not search_filter:
-            return search_filter
-        try:
-            obfuscated = ldapx.obfuscate_filter(search_filter, self.obfuscate_filter_chain)
-            self.logger.debug(f"Obfuscated filter: {obfuscated}")
-            return obfuscated
-        except Exception as e:
-            self.logger.debug(f"ldapx filter obfuscation failed, using original: {e}")
-            return search_filter
-
-    def _obfuscate_basedn(self, base_dn):
-        if not self.obfuscate_basedn_chain or not base_dn:
-            return base_dn
-        try:
-            obfuscated = ldapx.obfuscate_basedn(base_dn, self.obfuscate_basedn_chain)
-            self.logger.debug(f"Obfuscated baseDN: {obfuscated}")
-            return obfuscated
-        except Exception as e:
-            self.logger.debug(f"ldapx baseDN obfuscation failed, using original: {e}")
-            return base_dn
-
-    def _obfuscate_attrs(self, attributes):
-        if not self.obfuscate_attrs_chain or not attributes:
-            return attributes
-        try:
-            obfuscated = ldapx.obfuscate_attrlist(attributes, self.obfuscate_attrs_chain)
-            self.logger.debug(f"Obfuscated attributes: {obfuscated}")
-            return obfuscated
-        except Exception as e:
-            self.logger.debug(f"ldapx attribute obfuscation failed, using original: {e}")
-            return attributes
 
     def users(self):
         """

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -50,6 +50,12 @@ from nxc.parsers.ldap_results import parse_result_attributes
 from nxc.helpers.negotiate_parser import parse_challenge
 from nxc.paths import CONFIG_PATH
 
+try:
+    import ldapx
+    HAS_LDAPX = True
+except ImportError:
+    HAS_LDAPX = False
+
 ldap_error_status = {
     "1": "STATUS_NOT_SUPPORTED",
     "533": "STATUS_ACCOUNT_DISABLED",
@@ -89,6 +95,10 @@ class ldap(connection):
         self.sid_domain = ""
         self.scope = None
         self.configuration_context = ""
+        self.obfuscate = False
+        self.obfuscate_filter_chain = ""
+        self.obfuscate_basedn_chain = None
+        self.obfuscate_attrs_chain = None
 
         connection.__init__(self, args, db, host)
 
@@ -103,6 +113,19 @@ class ldap(connection):
         )
 
     def create_conn_obj(self):
+        if getattr(self.args, "obfuscate", False):
+            if not HAS_LDAPX:
+                self.logger.fail("--obfuscate requires ldapx. Install with: pip install ldapx")
+                return False
+            self.obfuscate = True
+            self.obfuscate_filter_chain = getattr(self.args, "obfuscate_filter", "CSG")
+            self.obfuscate_basedn_chain = getattr(self.args, "obfuscate_basedn", None)
+            self.obfuscate_attrs_chain = getattr(self.args, "obfuscate_attrs", None)
+            if self.obfuscate_filter_chain and "O" in self.obfuscate_filter_chain:
+                self.logger.fail("Filter chain code 'O' (OID) is incompatible with impacket's LDAP parser. Remove it from --obfuscate-filter.")
+                return False
+            self.logger.info(f"LDAP obfuscation enabled: filter={self.obfuscate_filter_chain}, baseDN={self.obfuscate_basedn_chain or 'disabled'}, attrs={self.obfuscate_attrs_chain or 'disabled'}")
+
         try:
             proto = "ldaps" if self.port == 636 else "ldap"
             ldap_url = f"{proto}://{self.host}"
@@ -660,6 +683,11 @@ class ldap(connection):
         elif baseDN is None:
             baseDN = self.baseDN
 
+        if self.obfuscate:
+            searchFilter = self._obfuscate_filter(searchFilter)
+            baseDN = self._obfuscate_basedn(baseDN)
+            attributes = self._obfuscate_attrs(attributes)
+
         try:
             if self.ldap_connection:
                 self.logger.debug(f"Search Filter={searchFilter}")
@@ -687,6 +715,39 @@ class ldap(connection):
                 self.logger.fail(e)
                 return []
         return []
+
+    def _obfuscate_filter(self, search_filter):
+        if not self.obfuscate_filter_chain or not search_filter:
+            return search_filter
+        try:
+            obfuscated = ldapx.obfuscate_filter(search_filter, self.obfuscate_filter_chain)
+            self.logger.debug(f"Obfuscated filter: {obfuscated}")
+            return obfuscated
+        except Exception as e:
+            self.logger.debug(f"ldapx filter obfuscation failed, using original: {e}")
+            return search_filter
+
+    def _obfuscate_basedn(self, base_dn):
+        if not self.obfuscate_basedn_chain or not base_dn:
+            return base_dn
+        try:
+            obfuscated = ldapx.obfuscate_basedn(base_dn, self.obfuscate_basedn_chain)
+            self.logger.debug(f"Obfuscated baseDN: {obfuscated}")
+            return obfuscated
+        except Exception as e:
+            self.logger.debug(f"ldapx baseDN obfuscation failed, using original: {e}")
+            return base_dn
+
+    def _obfuscate_attrs(self, attributes):
+        if not self.obfuscate_attrs_chain or not attributes:
+            return attributes
+        try:
+            obfuscated = ldapx.obfuscate_attrlist(attributes, self.obfuscate_attrs_chain)
+            self.logger.debug(f"Obfuscated attributes: {obfuscated}")
+            return obfuscated
+        except Exception as e:
+            self.logger.debug(f"ldapx attribute obfuscation failed, using original: {e}")
+            return attributes
 
     def users(self):
         """
@@ -1295,12 +1356,7 @@ class ldap(connection):
                     sids = [ace["Ace"]["Sid"].formatCanonical() for ace in dacl["Dacl"]["Data"] if ace["AceType"] == 0x00]
                     self.logger.debug(f"msDS-GroupMSAMembership: {sids}")
                     search_filter = "(|" + "".join([f"(objectSid={sid})" for sid in sids]) + ")"
-                    resp = self.ldap_connection.search(
-                        searchBase=self.baseDN,
-                        searchFilter=search_filter,
-                        attributes=["sAMAccountName"],
-                        sizeLimit=0,
-                    )
+                    resp = self.search(search_filter, ["sAMAccountName"])
                     resp_parsed = parse_result_attributes(resp)
                     if len(resp_parsed) > 1:
                         principal_with_read = [f"{item['sAMAccountName']}" for item in resp_parsed]
@@ -1340,12 +1396,7 @@ class ldap(connection):
             else:
                 # getting the gmsa account
                 search_filter = "(objectClass=msDS-GroupManagedServiceAccount)"
-                gmsa_accounts = self.ldap_connection.search(
-                    searchBase=self.baseDN,
-                    searchFilter=search_filter,
-                    attributes=["sAMAccountName"],
-                    sizeLimit=0,
-                )
+                gmsa_accounts = self.search(search_filter, ["sAMAccountName"])
                 gmsa_accounts_parsed = parse_result_attributes(gmsa_accounts)
                 if gmsa_accounts_parsed:
                     self.logger.debug(f"Total of records returned {len(gmsa_accounts_parsed):d}")
@@ -1363,12 +1414,7 @@ class ldap(connection):
                 gmsa_id, gmsa_pass = self.args.gmsa_decrypt_lsa.split("_")[4].split(":")
                 # getting the gmsa account
                 search_filter = "(objectClass=msDS-GroupManagedServiceAccount)"
-                gmsa_accounts = self.ldap_connection.search(
-                    searchBase=self.baseDN,
-                    searchFilter=search_filter,
-                    attributes=["sAMAccountName"],
-                    sizeLimit=0,
-                )
+                gmsa_accounts = self.search(search_filter, ["sAMAccountName"])
                 gmsa_accounts_parsed = parse_result_attributes(gmsa_accounts)
                 if gmsa_accounts_parsed:
                     self.logger.debug(f"Total of records returned {len(gmsa_accounts):d}")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -50,11 +50,7 @@ from nxc.parsers.ldap_results import parse_result_attributes
 from nxc.helpers.negotiate_parser import parse_challenge
 from nxc.paths import CONFIG_PATH
 
-try:
-    import ldapx
-    HAS_LDAPX = True
-except ImportError:
-    HAS_LDAPX = False
+import ldapx
 
 ldap_error_status = {
     "1": "STATUS_NOT_SUPPORTED",
@@ -95,10 +91,10 @@ class ldap(connection):
         self.sid_domain = ""
         self.scope = None
         self.configuration_context = ""
-        self.obfuscate = False
-        self.obfuscate_filter_chain = ""
-        self.obfuscate_basedn_chain = None
-        self.obfuscate_attrs_chain = None
+        self.obfuscate = args.obfuscate
+        self.obfuscate_filter_chain = args.obfuscate_filter if args.obfuscate else ""
+        self.obfuscate_basedn_chain = args.obfuscate_basedn if args.obfuscate else None
+        self.obfuscate_attrs_chain = args.obfuscate_attrs if args.obfuscate else None
 
         connection.__init__(self, args, db, host)
 
@@ -113,14 +109,7 @@ class ldap(connection):
         )
 
     def create_conn_obj(self):
-        if getattr(self.args, "obfuscate", False):
-            if not HAS_LDAPX:
-                self.logger.fail("--obfuscate requires ldapx. Install with: pip install ldapx")
-                return False
-            self.obfuscate = True
-            self.obfuscate_filter_chain = getattr(self.args, "obfuscate_filter", "CSG")
-            self.obfuscate_basedn_chain = getattr(self.args, "obfuscate_basedn", None)
-            self.obfuscate_attrs_chain = getattr(self.args, "obfuscate_attrs", None)
+        if self.obfuscate:
             if self.obfuscate_filter_chain and "O" in self.obfuscate_filter_chain:
                 self.logger.fail("Filter chain code 'O' (OID) is incompatible with impacket's LDAP parser. Remove it from --obfuscate-filter.")
                 return False

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -45,4 +45,10 @@ def proto_args(parser, parents):
     bgroup.add_argument("--bloodhound", action="store_true", help="Perform a Bloodhound scan")
     bgroup.add_argument("-c", "--collection", default="Default", help="Which information to collect. Supported: Group, LocalAdmin, Session, Trusts, Default, DCOnly, DCOM, RDP, PSRemote, LoggedOn, Container, ObjectProps, ACL, ADCS, All. You can specify more than one by separating them with a comma.")
 
+    ogroup = ldap_parser.add_argument_group("LDAP Obfuscation", "Options for LDAP query obfuscation via ldapx")
+    ogroup.add_argument("--obfuscate", action="store_true", help="Enable LDAP query obfuscation")
+    ogroup.add_argument("--obfuscate-filter", type=str, default="CSG", help="ldapx chain codes for filter obfuscation (default: CSG)")
+    ogroup.add_argument("--obfuscate-basedn", type=str, default=None, help="ldapx chain codes for baseDN obfuscation (disabled by default)")
+    ogroup.add_argument("--obfuscate-attrs", type=str, default=None, help="ldapx chain codes for attribute list obfuscation (disabled by default)")
+
     return parser

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -45,10 +45,6 @@ def proto_args(parser, parents):
     bgroup.add_argument("--bloodhound", action="store_true", help="Perform a Bloodhound scan")
     bgroup.add_argument("-c", "--collection", default="Default", help="Which information to collect. Supported: Group, LocalAdmin, Session, Trusts, Default, DCOnly, DCOM, RDP, PSRemote, LoggedOn, Container, ObjectProps, ACL, ADCS, All. You can specify more than one by separating them with a comma.")
 
-    ogroup = ldap_parser.add_argument_group("LDAP Obfuscation", "Options for LDAP query obfuscation via ldapx")
-    ogroup.add_argument("--obfuscate", action="store_true", help="Enable LDAP query obfuscation")
-    ogroup.add_argument("--obfuscate-filter", type=str, default="CSG", help="ldapx chain codes for filter obfuscation (default: CSG)")
-    ogroup.add_argument("--obfuscate-basedn", type=str, default=None, help="ldapx chain codes for baseDN obfuscation (disabled by default)")
-    ogroup.add_argument("--obfuscate-attrs", type=str, default=None, help="ldapx chain codes for attribute list obfuscation (disabled by default)")
+    ldap_parser.add_argument("--obfuscate", action="store_true", help="Enable LDAP query obfuscation via ldapx")
 
     return parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "dploot>=3.2.2",
     "dsinternals>=1.2.4",
     "jwt>=1.3.1",
+    "ldapx>=0.4.0",
     "lsassy>=3.1.11",
     "masky>=0.2.1",
     "minikerberos>=0.4.1",


### PR DESCRIPTION
## Description

Integrate [ldapx](https://github.com/j0hnZ3RA/ldapx-py) to enable LDAP query obfuscation through the `--obfuscate` flag, covering filters, BaseDNs, and attribute lists transparently via the central `search()` method.

LDAP query obfuscation has shown excellent results against identity protection solutions which rely on pattern matching of well-known LDAP filters to detect enumeration and attacks like Kerberoasting, AS-REP Roasting, delegation abuse, and admin reconnaissance. By applying composable transformations (case randomization, spacing injection, garbage filter insertion, hex encoding, De Morgan rewrites) the queries remain semantically identical but defeat signature-based detection.

**Original:**
```
(&(adminCount=1)(objectClass=user))
```

**Obfuscated (CSG chain):**
```
(&(|(adMiNCount=1)(mYsFWsLZpn:WLdZRcNUMN:=jQmvbtrrvU))(|(objectClass=user)(cMYwPeUXeH~=xHHQtiCaqL)))
```

### Usage

```bash
# Default obfuscation (Case + Spacing + Garbage)
nxc ldap <dc> -u <user> -p <pass> --users --obfuscate

# Custom filter chain
nxc ldap <dc> -u <user> -p <pass> --groups --obfuscate --obfuscate-filter CSGH

# Full obfuscation (filter + baseDN + attributes)
nxc ldap <dc> -u <user> -p <pass> --users --obfuscate --obfuscate-basedn CS --obfuscate-attrs CR
```

### Available chain codes (impacket-compatible)
| Code | Transformation |
|------|---------------|
| C | Case randomization |
| S | Spacing injection |
| G | Garbage filter insertion |
| H | Hex encoding of values |
| D | De Morgan boolean rewrites |
| R | Operand reordering |

> The OID code (`O`) is intentionally blocked as it is incompatible with impacket's LDAP parser.

### Design
- **Zero overhead when disabled**, conditional import, no code path changes without `--obfuscate`
- **Graceful fallback**, if obfuscation fails on any query, the original is used with a debug log
- **Central hook**, all queries flow through `search()`, so every enumeration command benefits automatically
- **ldapx is zero-dependency**, adds no transitive dependencies to NetExec

This PR was created with the assistance of AI (Claude Code / Opus 4.6) for code generation, but all changes were human-reviewed, human-tested against a live Active Directory environment, and human-verified for correctness.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [x] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

**Requirements:**
- Install the `ldapx` dependency: `pip install ldapx` (zero external dependencies)
- Any Active Directory environment for testing

**Testing steps:**
1. Run any LDAP enumeration command **without** `--obfuscate` to establish baseline
2. Run the same command **with** `--obfuscate` and verify identical results
3. Run with `--obfuscate --debug` to observe the obfuscated queries in the log output
4. Try custom chains with `--obfuscate-filter CSGH` or `--obfuscate-basedn CS`
5. Verify that `--obfuscate-filter CO` is rejected with a clear error (OID incompatible with impacket)

All LDAP commands are covered: `--users`, `--groups`, `--computers`, `--dc-list`, `--find-delegation`, `--trusted-for-delegation`, `--kerberoasting`, `--asreproast`, `--admin-count`, `--password-not-required`, `--pass-pol`, `--pso`, `--get-sid`, `--active-users`, `--query`.

## Screenshots (if appropriate):

**executed with the --obfuscate flag**

<img width="1349" height="737" alt="image" src="https://github.com/user-attachments/assets/e68c16bb-3002-476d-8c88-0f2e63f5df86" />



**queries obfuscated**

<img width="1338" height="740" alt="image" src="https://github.com/user-attachments/assets/45dfc93a-94c7-4448-8bea-25e24a9baf13" />



**results remain the same**

<img width="1338" height="723" alt="image" src="https://github.com/user-attachments/assets/dbd24e22-f325-46f7-8ee1-1e8efd0d2972" />




## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)