### PR TITLE
fix: ftp put_file reports failure on 0-byte uploads

### DIFF
--- a/nxc/protocols/ftp.py
+++ b/nxc/protocols/ftp.py
@@ -165,7 +165,7 @@ class ftp(connection):
             self.logger.fail(f"Failed to upload file. {local_file} does not exist locally.")
             return False
         # Check if the file was uploaded
-        if self.conn.size(remote_file) > 0:
+        if self.conn.size(remote_file) is not None:
             self.logger.success(f"Uploaded: {local_file} to {remote_file}")
         else:
             self.logger.fail(f"Failed to upload: {local_file} to {remote_file}")

--- a/nxc/protocols/ftp.py
+++ b/nxc/protocols/ftp.py
@@ -154,7 +154,7 @@ class ftp(connection):
             self.logger.fail(f"Failed to upload file. {local_file} does not exist locally.")
             return False
         # Check if the file was uploaded
-        if self.conn.size(remote_file) > 0:
+        if self.conn.size(remote_file) is not None:
             self.logger.success(f"Uploaded: {local_file} to {remote_file}")
         else:
             self.logger.fail(f"Failed to upload: {local_file} to {remote_file}")

--- a/nxc/protocols/ftp.py
+++ b/nxc/protocols/ftp.py
@@ -23,17 +23,6 @@ class ftp(connection):
             }
         )
 
-    def proto_flow(self):
-        self.proto_logger()
-        if self.create_conn_obj() and self.login():
-            if hasattr(self.args, "module") and self.args.module:
-                self.load_modules()
-                self.logger.debug("Calling modules")
-                self.call_modules()
-            else:
-                self.logger.debug("Calling command arguments")
-                self.call_cmd_args()
-
     def enum_host_info(self):
         welcome = self.conn.getwelcome()
         self.logger.debug(f"Welcome result: {welcome}")
@@ -165,7 +154,7 @@ class ftp(connection):
             self.logger.fail(f"Failed to upload file. {local_file} does not exist locally.")
             return False
         # Check if the file was uploaded
-        if self.conn.size(remote_file) is not None:
+        if self.conn.size(remote_file) > 0:
             self.logger.success(f"Uploaded: {local_file} to {remote_file}")
         else:
             self.logger.fail(f"Failed to upload: {local_file} to {remote_file}")

--- a/test.aspx
+++ b/test.aspx
@@ -1,1 +1,0 @@
-MainThis

--- a/test.aspx
+++ b/test.aspx
@@ -1,0 +1,1 @@
+MainThis


### PR DESCRIPTION
## Description
Was busy looking at the wiki and saw the failed upload in the example and tried it myself. Upload works, but the test files are blank and the check doesn't check if the file exists, it checks the file size and if its 0 bytes, it regards it as a failed to upload. Super small bug.

I also realise now, that there is nothing prompting or protecting files being overwritten, for this protocol and others. nfs does have this so unsure if its relevant or not to add it here. But this is the simple bug fix for now. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Tested on default NetExec on generic FTP server, with a super minimal change:
```diff
-        if self.conn.size(remote_file) > 0:
+        if self.conn.size(remote_file) is not None:
```
The only lacking portion is this was not testing against some FTP services, but then again, the assumption is they follow the RFC for status codes. So this should be fine, and also doesn't touch that part of the logic anyway. 

## Screenshots:
Current nxc version:
<img width="2809" height="699" alt="image" src="https://github.com/user-attachments/assets/f8f7069d-d42e-4ca3-b39e-0f9abeccb1d4" />
<img width="1651" height="81" alt="image" src="https://github.com/user-attachments/assets/43950b33-c849-4e07-b96a-a8823ce3feca" />

Fix by replacing ` is not None:`  instead of ` > 0:`
<img width="2807" height="701" alt="image" src="https://github.com/user-attachments/assets/b5b2871d-c581-4253-b252-ae9812fbdd1f" />

## Checklist:
- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
