### PR TITLE
fix(smb): resolve hostname truncation from NetBIOS 15-char limit

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -192,7 +192,13 @@ class smb(connection):
         # self.domain is the attribute we authenticate with
         # self.targetDomain is the attribute which gets displayed as host domain
         if not self.no_ntlm:
-            self.hostname = self.conn.getServerName()
+            dns_hostname = self.conn.getServerDNSHostName()
+            if dns_hostname and "." in dns_hostname:
+                self.hostname = dns_hostname.split(".")[0] or self.conn.getServerName()
+            elif dns_hostname:
+                self.hostname = dns_hostname
+            else:
+                self.hostname = self.conn.getServerName()
             self.targetDomain = self.conn.getServerDNSDomainName()
             if not self.targetDomain:   # Not sure if that can even happen but now we are safe
                 self.targetDomain = self.hostname

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -193,7 +193,7 @@ class smb(connection):
         # self.targetDomain is the attribute which gets displayed as host domain
         if not self.no_ntlm:
             # Try to get hostname with getServerDNSHostName as getServerName is truncated to 15 chars
-            dns_hostname = self.conn.getServerDNSHostName()
+            dns_hostname = self.conn.getServerDNSHostName().upper()
             if dns_hostname and "." in dns_hostname:
                 self.hostname = dns_hostname.split(".")[0]
             elif dns_hostname:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -192,9 +192,10 @@ class smb(connection):
         # self.domain is the attribute we authenticate with
         # self.targetDomain is the attribute which gets displayed as host domain
         if not self.no_ntlm:
+            # Try to get hostname with getServerDNSHostName as getServerName is truncated to 15 chars
             dns_hostname = self.conn.getServerDNSHostName()
             if dns_hostname and "." in dns_hostname:
-                self.hostname = dns_hostname.split(".")[0] or self.conn.getServerName()
+                self.hostname = dns_hostname.split(".")[0]
             elif dns_hostname:
                 self.hostname = dns_hostname
             else:


### PR DESCRIPTION
## Description

Fixes #1059

Currently, hostnames longer than 15 characters are getting truncated in the `--generate-hosts-file` and `--generate-krb5-file` outputs. This happens because `getServerName()` pulls the NetBIOS name, which is hard-capped at 15 characters by the protocol spec (for example, `ACADEMY-AEN-MS01` gets chopped to `ACADEMY-AEN-MS0`).

## How and why we fixed

I swapped out the hostname source in `nxc/protocols/smb.py` (line 195) from `getServerName()` to `getServerDNSHostName()`. This reads the `MsvAvDnsComputerName` AV_PAIR from the NTLM challenge (MS-NLMP sec. 2.2.2.1), giving us the full DNS computer name without the NetBIOS limit.

Because `getServerDNSHostName()` returns the FQDN (like `host.domain.local`), I extract the short hostname using `.split(".")[0]`. This keeps everything compatible with the downstream code that builds FQDNs using `self.hostname + "." + self.domain`.

If the DNS hostname isn't available (like with Samba servers or pre-2003 systems), the code safely falls back to `getServerName()`.

@NeffIsBack suggested this as a fix in issue comments

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Deprecation of feature or functionality
  - [ ] This change requires a documentation update
  - [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
  - [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)
## Setup guide for the review
 Any target with a hostname exceeding 15 characters (e.g. `ACADEMY-AEN-MS01`) will be
 truncated to 15 chars in the output.

## Testing Performed

**Tests run:**
- `nxc smb <target hosts>` — Confirmed all hostnames are displayed correctly.
- `nxc smb <hosts> --generate-hosts-file` — Verified the correct FQDN entries in the output file.
- `nxc smb <dc> --generate-krb5-file` — Verified a valid `krb5.conf` is generated with the correct `kdc` and `admin_server` entries.
- Manually confirmed that `getServerDNSHostName()` returns the full FQDN (`testing.domain.local`) while `getServerName()` returns the NetBIOS name (`testing`).
- Clean pass on syntax checks and the ruff linter.

  ## Checklist:
  - [x] I have ran Ruff against my changes
  - [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary
  - [ ] If reliant on changes of third party dependencies, I have linked the relevant PRs
  - [ ] I have linked relevant sources that describes the added technique
  - [x] I have performed a self-review of my own code (_not_ an AI review)
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation