### PR TITLE
Add WinRM upload and download functions

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -139,6 +139,7 @@ class connection:
         self.conn = None
         self.output_file_template = None
         self.output_filename = None
+        self.protocol = args.protocol
 
         # Authentication info
         self.password = ""

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -312,10 +312,9 @@ class winrm(connection):
         try:
             self.logger.display(f'Downloading "{remote_path}" to "{download_path}"')
             self.conn.fetch(remote_path, local_path)
+            self.logger.success(f"File {remote_path} has been saved to {local_path}")
         except Exception as e:
             self.logger.fail(f"Failed to get file {remote_path}, error: {e!s}")
-        else:
-            self.logger.success(f"File {remote_path} has been saved to {local_path}")
 
     def put_file(self, local_path=None, remote_path=None):
         local_path = local_path if local_path else self.args.put_file[0]
@@ -326,10 +325,9 @@ class winrm(connection):
         try:
             self.logger.display(f'Uploading "{local_path}" to "{remote_path}"')
             self.conn.copy(local_path, remote_path)
+            self.logger.success(f"File {local_path} has been uploaded to {remote_path}")
         except Exception as e:
             self.logger.fail(f"Failed to put file {local_path} to {remote_path}, error: {e!s}")
-        else:
-            self.logger.success(f"File {local_path} has been uploaded to {remote_path}")
 
     # Dos attack prevent:
     # if someboby executed "reg save HKLM\sam C:\windows\temp\sam" before, but didn't remove "C:\windows\temp\sam" file,

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -72,7 +72,10 @@ class winrm(connection):
         self.server_os = ntlm_info["os_version"]
         self.logger.extra["hostname"] = self.hostname
 
-        self.db.add_host(self.host, self.port, self.hostname, self.targetDomain, self.server_os)
+        try:
+            self.db.add_host(self.host, self.port, self.hostname, self.targetDomain, self.server_os)
+        except Exception as e:
+            self.logger.debug(f"Error adding host to database: {e!s}")
 
         if self.args.domain:
             self.domain = self.args.domain

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -302,6 +302,35 @@ class winrm(connection):
         if get_output:
             return result
 
+    def get_file(self, remote_path=None, download_path=None):
+        remote_path = self.args.get_file[0] if self.args.get_file else remote_path
+        local_path = self.args.get_file[1] if len(self.args.get_file) > 1 else os.path.basename(remote_path)
+
+        # Do a bit of smart handling for the local file path
+        if local_path.endswith("/"):
+            local_path += os.path.basename(remote_path)
+        try:
+            self.logger.display(f'Downloading "{remote_path}" to "{download_path}"')
+            self.conn.fetch(remote_path, local_path)
+        except Exception as e:
+            self.logger.fail(f"Failed to get file {remote_path}, error: {e!s}")
+        else:
+            self.logger.success(f"File {remote_path} has been saved to {local_path}")
+
+    def put_file(self, local_path=None, remote_path=None):
+        local_path = local_path if local_path else self.args.put_file[0]
+        remote_path = remote_path if remote_path else self.args.put_file[1]
+
+        # Do a bit of smart handling for the remote file path
+        remote_path += os.path.basename(local_path) if remote_path.endswith(("\\", "/")) else ""
+        try:
+            self.logger.display(f'Uploading "{local_path}" to "{remote_path}"')
+            self.conn.copy(local_path, remote_path)
+        except Exception as e:
+            self.logger.fail(f"Failed to put file {local_path} to {remote_path}, error: {e!s}")
+        else:
+            self.logger.success(f"File {local_path} has been uploaded to {remote_path}")
+
     # Dos attack prevent:
     # if someboby executed "reg save HKLM\sam C:\windows\temp\sam" before, but didn't remove "C:\windows\temp\sam" file,
     # when user execute the same command next time, in tty shell, the prompt will ask "File C:\windows\temp\sam already exists. Overwrite (Yes/No)?"

--- a/nxc/protocols/winrm/database.py
+++ b/nxc/protocols/winrm/database.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, select, func, delete
+from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, UniqueConstraint, select, func, delete
 from sqlalchemy.dialects.sqlite import Insert
 from sqlalchemy.orm import declarative_base
 
@@ -28,6 +28,7 @@ class database(BaseDB):
 
         __table_args__ = (
             PrimaryKeyConstraint("id"),
+            UniqueConstraint("ip"),
         )
 
     class User(Base):
@@ -122,7 +123,7 @@ class database(BaseDB):
         # TODO: find a way to abstract this away to a single Upsert call
         q = Insert(self.HostsTable)
         update_columns = {col.name: col for col in q.excluded if col.name not in "id"}
-        q = q.on_conflict_do_update(index_elements=self.HostsTable.primary_key, set_=update_columns)
+        q = q.on_conflict_do_update(index_elements=["ip"], set_=update_columns)
         self.db_execute(q, hosts)
 
     def add_credential(self, credtype, domain, username, password, pillaged_from=None):

--- a/nxc/protocols/winrm/proto_args.py
+++ b/nxc/protocols/winrm/proto_args.py
@@ -19,6 +19,10 @@ def proto_args(parser, parents):
     cgroup.add_argument("--lsa", action="store_true", help="dump LSA secrets from target systems")
     cgroup.add_argument("--dpapi", action="store_true", help="dump user's Credential Manager secrets from target systems")
 
+    files_group = winrm_parser.add_argument_group("File Operations")
+    files_group.add_argument("--put-file", nargs=2, metavar="FILE", help="Put a local file into remote target, ex: whoami.txt \\\\Windows\\\\Temp\\\\whoami.txt")
+    files_group.add_argument("--get-file", nargs=2, metavar="FILE", help="Get a remote file, ex: \\\\Windows\\\\Temp\\\\whoami.txt whoami.txt")
+
     cgroup = winrm_parser.add_argument_group("Command Execution")
     cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")


### PR DESCRIPTION
## Description
Had to work with WinRM a bit so I added some convenience functions among other things.
What is included in here:
- General `connection.protocol` variable so you can immediately check which protocol called a module (some protos don't set that arg by themselves)
- Fixed some issues with the winrm db that caused errors/stacktraces. Now aligns more with the database implementation of SMB.
- `--get-file` and `--put-file` implementation for WinRM with a bit of smart handling for filenames

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
1. Setup WinRM for a host.
2. `nxc winrm <ip> -u <user> -p <password> --get-file remote\path local/path`

vice versa for `--put-file`

## Screenshots (if appropriate):
<img width="1183" height="234" alt="image" src="https://github.com/user-attachments/assets/c8324401-cc79-43af-a3f1-418d6676860e" />

## Checklist:
