### PR TITLE
Add WinRM dir command

### DIFF
--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -329,6 +329,11 @@ class winrm(connection):
         except Exception as e:
             self.logger.fail(f"Failed to put file {local_path} to {remote_path}, error: {e!s}")
 
+    def dir(self, directory=None):
+        directory = directory if directory else self.args.dir
+        for line in self.execute(f"dir {directory}", True).splitlines():
+            self.logger.highlight(line.rstrip())
+
     # Dos attack prevent:
     # if someboby executed "reg save HKLM\sam C:\windows\temp\sam" before, but didn't remove "C:\windows\temp\sam" file,
     # when user execute the same command next time, in tty shell, the prompt will ask "File C:\windows\temp\sam already exists. Overwrite (Yes/No)?"

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -331,8 +331,10 @@ class winrm(connection):
 
     def dir(self, directory=None):
         directory = directory if directory else self.args.dir
-        for line in self.execute(f"dir {directory}", True).splitlines():
-            self.logger.highlight(line.rstrip())
+        out = self.execute(f"dir {directory}", True)
+        if out is not None:
+            for line in out.splitlines():
+                self.logger.highlight(line.rstrip())
 
     # Dos attack prevent:
     # if someboby executed "reg save HKLM\sam C:\windows\temp\sam" before, but didn't remove "C:\windows\temp\sam" file,

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -308,7 +308,7 @@ class winrm(connection):
 
         # Do a bit of smart handling for the local file path
         if local_path.endswith("/"):
-            local_path += os.path.basename(remote_path)
+            local_path += ntpath.basename(remote_path)
         try:
             self.logger.display(f'Downloading "{remote_path}" to "{download_path}"')
             self.conn.fetch(remote_path, local_path)

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -303,14 +303,14 @@ class winrm(connection):
             return result
 
     def get_file(self, remote_path=None, download_path=None):
-        remote_path = self.args.get_file[0] if self.args.get_file else remote_path
-        local_path = self.args.get_file[1] if len(self.args.get_file) > 1 else os.path.basename(remote_path)
+        remote_path = remote_path if remote_path else self.args.get_file[0]
+        local_path = download_path if download_path else self.args.get_file[1]
 
         # Do a bit of smart handling for the local file path
         if local_path.endswith("/"):
             local_path += ntpath.basename(remote_path)
         try:
-            self.logger.display(f'Downloading "{remote_path}" to "{download_path}"')
+            self.logger.display(f'Downloading "{remote_path}" to "{local_path}"')
             self.conn.fetch(remote_path, local_path)
             self.logger.success(f"File {remote_path} has been saved to {local_path}")
         except Exception as e:

--- a/nxc/protocols/winrm/proto_args.py
+++ b/nxc/protocols/winrm/proto_args.py
@@ -27,7 +27,7 @@ def proto_args(parser, parents):
     files_group.add_argument("--get-file", nargs=2, metavar="FILE", help="Get a remote file, ex: \\\\Windows\\\\Temp\\\\whoami.txt whoami.txt")
 
     cgroup = winrm_parser.add_argument_group("Command Execution")
-    cgroup.add_argument("--codec", default="utf-8", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
+    cgroup.add_argument("--codec", default="437", help="Set encoding used (codec) from the target's output. If errors are detected, run chcp.com at the target & map the result with https://docs.python.org/3/library/codecs.html#standard-encodings and then execute again with --codec and the corresponding codec")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified command")
     cgroup.add_argument("-X", metavar="PS_COMMAND", dest="ps_execute", help="execute the specified PowerShell command")

--- a/nxc/protocols/winrm/proto_args.py
+++ b/nxc/protocols/winrm/proto_args.py
@@ -19,6 +19,9 @@ def proto_args(parser, parents):
     cgroup.add_argument("--lsa", action="store_true", help="dump LSA secrets from target systems")
     cgroup.add_argument("--dpapi", action="store_true", help="dump user's Credential Manager secrets from target systems")
 
+    mapping_enum_group = winrm_parser.add_argument_group("Mapping/Enumeration")
+    mapping_enum_group.add_argument("--dir", nargs="?", type=str, const="", help="List the content of a path (default path: '%(const)s')")
+
     files_group = winrm_parser.add_argument_group("File Operations")
     files_group.add_argument("--put-file", nargs=2, metavar="FILE", help="Put a local file into remote target, ex: whoami.txt \\\\Windows\\\\Temp\\\\whoami.txt")
     files_group.add_argument("--get-file", nargs=2, metavar="FILE", help="Get a remote file, ex: \\\\Windows\\\\Temp\\\\whoami.txt whoami.txt")


### PR DESCRIPTION
## Description
Adds `--dir` for WinRM, just a bit convenience (and makes it similar to smb).
Also fixes a bug in `--get-file` where the auto completion of the local path was borked because it didn't properly differentiate between linux and Windows paths.
Fyi, also changed the default encoding to pysrp's default, because otherwise it would crash while decoding german characters such as `ä`.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
1. `nxc winrm ... --dir`
2. When doing `nxc winrm ... --get-file '\remote\path\file' ./` this would result in `./\remote\path\file` which should actually be `./file`.
3. Query a german host


## Screenshots (if appropriate):
<img width="1204" height="663" alt="image" src="https://github.com/user-attachments/assets/5dd42a4e-720c-4430-8868-7d49abc76d0c" />
<img width="1182" height="355" alt="image" src="https://github.com/user-attachments/assets/cdd82a04-f29f-48bf-9a57-2d537ba9f016" />
<img width="1299" height="223" alt="image" src="https://github.com/user-attachments/assets/cd2cdea7-3e36-4353-a9aa-b3569552e603" />
