### PR TITLE
Allow proto flags in combination with modules

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -254,13 +254,12 @@ class connection:
 
             self.print_host_info()
             if self.login() or (self.username == "" and self.password == ""):
-                if hasattr(self.args, "module") and self.args.module:
+                self.logger.debug("Calling command arguments")
+                self.call_cmd_args()
+                if self.args.module:
                     self.load_modules()
                     self.logger.debug("Calling modules")
                     self.call_modules()
-                else:
-                    self.logger.debug("Calling command arguments")
-                    self.call_cmd_args()
             self.disconnect()
 
     def call_cmd_args(self):


### PR DESCRIPTION
## Description
I don't really see a reason (anymore) to forbid the combination of flags (e.g. `--dpapi`) and modules (e.g. `-M lsassy`). As other PRs (#1067) needs this as well I just removed that restriction.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
`nxc smb ... --dpapi -M lsassy`

## Screenshots (if appropriate):
<img width="1591" height="280" alt="image" src="https://github.com/user-attachments/assets/88bc44e7-3718-4818-bd24-33d435422dc3" />

## Checklist:
