### PR TITLE
Fix custom LDAP port specification and improve scheme handling

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -32,6 +32,26 @@ from impacket.krb5.kerberosv5 import getKerberosTGS, SessionKeyDecryptionError
 from impacket.krb5.ccache import CCache
 from impacket.krb5.types import Principal, KerberosException
 from impacket.ldap import ldap as ldap_impacket
+from urllib.parse import urlparse
+
+# Monkey patch LDAPConnection to support custom ports in the URL
+_original_ldap_init = ldap_impacket.LDAPConnection.__init__
+
+def _patched_ldap_init(self, url, baseDN='', dstIp=None, signing=True):
+    parsed = urlparse(url)
+    self._custom_port = parsed.port
+    _original_ldap_init(self, url, baseDN=baseDN, dstIp=dstIp, signing=signing)
+
+ldap_impacket.LDAPConnection.__init__ = _patched_ldap_init
+
+def _dstPort_getter(self):
+    return self._custom_port if getattr(self, '_custom_port', None) else self._original_dstPort
+
+def _dstPort_setter(self, value):
+    self._original_dstPort = value
+
+ldap_impacket.LDAPConnection._dstPort = property(_dstPort_getter, _dstPort_setter)
+
 from impacket.ldap import ldaptypes
 from impacket.ldap import ldapasn1 as ldapasn1_impacket
 from impacket.ldap.ldap import LDAPFilterSyntaxError
@@ -92,10 +112,19 @@ class ldap(connection):
 
         connection.__init__(self, args, db, host)
 
+    def proto_flow(self):
+        self.protocol = getattr(self.args, "scheme", "ldaps")
+        if not getattr(self.args, "port_explicitly_set", False):
+            if self.protocol == "ldaps":
+                self.port = 636
+            else:
+                self.port = 389
+        super().proto_flow()
+
     def proto_logger(self):
         self.logger = NXCAdapter(
             extra={
-                "protocol": "LDAP",
+                "protocol": self.protocol.upper(),
                 "host": self.host,
                 "port": self.port,
                 "hostname": self.hostname,
@@ -104,8 +133,8 @@ class ldap(connection):
 
     def create_conn_obj(self):
         try:
-            proto = "ldaps" if self.port == 636 else "ldap"
-            ldap_url = f"{proto}://{self.host}"
+            proto = self.protocol
+            ldap_url = f"{proto}://{self.host}:{self.port}"
             self.logger.info(f"Connecting to {ldap_url} with no baseDN")
 
             self.ldap_connection = ldap_impacket.LDAPConnection(ldap_url, dstIp=self.host)
@@ -148,7 +177,7 @@ class ldap(connection):
 
     def check_ldap_signing(self):
         self.signing_required = False
-        ldap_url = f"ldap://{self.target}"
+        ldap_url = f"ldap://{self.target}:{self.port}"
         try:
             ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host, signing=False)
             ldap_connection.login(domain=self.domain)
@@ -162,7 +191,8 @@ class ldap(connection):
 
     def check_ldaps_cbt(self):
         self.cbt_status = "Never"
-        ldap_url = f"ldaps://{self.target}"
+        ldaps_port = 636 if self.protocol == "ldap" else self.port
+        ldap_url = f"ldaps://{self.target}:{ldaps_port}"
         try:
             ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
             ldap_connection.channel_binding_value = None
@@ -283,7 +313,7 @@ class ldap(connection):
         cbt_status = colored(f"channel binding:{self.cbt_status}", host_info_colors[3], attrs=["bold"]) if self.cbt_status == "Always" else colored(f"channel binding:{self.cbt_status}", host_info_colors[2], attrs=["bold"])
         ntlm = colored(f"(NTLM:{not self.no_ntlm})", host_info_colors[2], attrs=["bold"]) if self.no_ntlm else ""
 
-        self.logger.extra["protocol"] = "LDAP" if str(self.port) == "389" else "LDAPS"
+        self.logger.extra["protocol"] = self.protocol.upper()
         self.logger.extra["port"] = self.port
         self.logger.extra["hostname"] = self.hostname
         self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain}) ({signing}) ({cbt_status}) {ntlm}")
@@ -326,10 +356,10 @@ class ldap(connection):
 
         try:
             # Connect to LDAP
-            self.logger.extra["protocol"] = "LDAPS" if self.port == 636 else "LDAP"
-            self.logger.extra["port"] = "636" if self.port == 636 else "389"
-            proto = "ldaps" if self.port == 636 else "ldap"
-            ldap_url = f"{proto}://{self.target}"
+            self.logger.extra["protocol"] = self.protocol.upper()
+            self.logger.extra["port"] = self.port
+            proto = self.protocol
+            ldap_url = f"{proto}://{self.target}:{self.port}"
             self.logger.info(f"Connecting to {ldap_url} - {self.baseDN} - {self.host} [1]")
             self.ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host)
             self.ldap_connection.kerberosLogin(username, password, domain, self.lmhash, self.nthash, aesKey, kdcHost=kdcHost, useCache=useCache)
@@ -388,7 +418,7 @@ class ldap(connection):
                     self.logger.extra["protocol"] = "LDAPS"
                     self.logger.extra["port"] = "636"
                     self.port = 636
-                    ldaps_url = f"ldaps://{self.target}"
+                    ldaps_url = f"ldaps://{self.target}:{self.port}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host} [2]")
                     self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
                     self.ldap_connection.kerberosLogin(username, password, domain, self.lmhash, self.nthash, aesKey, kdcHost=kdcHost, useCache=useCache)
@@ -449,10 +479,10 @@ class ldap(connection):
 
         try:
             # Connect to LDAP
-            self.logger.extra["protocol"] = "LDAPS" if self.port == 636 else "LDAP"
-            self.logger.extra["port"] = "636" if self.port == 636 else "389"
-            proto = "ldaps" if self.port == 636 else "ldap"
-            ldap_url = f"{proto}://{self.target}"
+            self.logger.extra["protocol"] = self.protocol.upper()
+            self.logger.extra["port"] = self.port
+            proto = self.protocol
+            ldap_url = f"{proto}://{self.target}:{self.port}"
             self.logger.info(f"Connecting to {ldap_url} - {self.baseDN} - {self.host} [3]")
             self.ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host, signing=self.auth_choice != "simple")
             self.ldap_connection.login(self.username, self.password, self.domain, self.lmhash, self.nthash, authenticationChoice=self.auth_choice)
@@ -481,7 +511,7 @@ class ldap(connection):
                     self.logger.extra["protocol"] = "LDAPS"
                     self.logger.extra["port"] = "636"
                     self.port = 636
-                    ldaps_url = f"ldaps://{self.target}"
+                    ldaps_url = f"ldaps://{self.target}:{self.port}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host} [4]")
                     self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
                     self.ldap_connection.login(self.username, self.password, self.domain, self.lmhash, self.nthash, authenticationChoice=self.auth_choice)
@@ -515,8 +545,8 @@ class ldap(connection):
             return False
 
     def hash_login(self, domain, username, ntlm_hash):
-        self.logger.extra["protocol"] = "LDAP"
-        self.logger.extra["port"] = "389"
+        self.logger.extra["protocol"] = self.protocol.upper()
+        self.logger.extra["port"] = self.port
         lmhash = ""
         nthash = ""
 
@@ -545,10 +575,10 @@ class ldap(connection):
 
         try:
             # Connect to LDAP
-            self.logger.extra["protocol"] = "LDAPS" if self.port == 636 else "LDAP"
-            self.logger.extra["port"] = "636" if self.port == 636 else "389"
-            proto = "ldaps" if self.port == 636 else "ldap"
-            ldaps_url = f"{proto}://{self.target}"
+            self.logger.extra["protocol"] = self.protocol.upper()
+            self.logger.extra["port"] = self.port
+            proto = self.protocol
+            ldaps_url = f"{proto}://{self.target}:{self.port}"
             self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host}")
             self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
             self.ldap_connection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
@@ -574,7 +604,7 @@ class ldap(connection):
                     self.logger.extra["protocol"] = "LDAPS"
                     self.logger.extra["port"] = "636"
                     self.port = 636
-                    ldaps_url = f"ldaps://{self.target}"
+                    ldaps_url = f"ldaps://{self.target}:{self.port}"
                     self.logger.info(f"Connecting to {ldaps_url} - {self.baseDN} - {self.host}")
                     self.ldap_connection = ldap_impacket.LDAPConnection(url=ldaps_url, baseDN=self.baseDN, dstIp=self.host)
                     self.ldap_connection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -8,7 +8,7 @@ def proto_args(parser, parents):
     dgroup.add_argument("-H", "--hash", metavar="HASH", dest="hash", nargs="+", default=[], help="NTLM hash(es) or file(s) containing NTLM hashes")
     dgroup.add_argument("--simple-bind", action="store_true", help="Use simple bind authentication (no signing/sealing)")
     ldap_parser.add_argument("--port", type=int, default=389, action=DefaultTrackingAction, help="LDAP port")
-    ldap_parser.add_argument("--protocol", dest="scheme", type=str, choices=["ldap", "ldaps"], default="ldaps", help="Protocol to use (ldap or ldaps).")
+    ldap_parser.add_argument("--scheme", type=str, choices=["ldap", "ldaps"], default="ldaps", help="Protocol to use (ldap or ldaps).")
     ldap_parser.add_argument("-d", metavar="DOMAIN", dest="domain", type=str, default=None, help="domain to authenticate to")
 
     egroup = ldap_parser.add_argument_group("Retrieve hash on the remote DC", "Options to get hashes from Kerberos")

--- a/nxc/protocols/ldap/proto_args.py
+++ b/nxc/protocols/ldap/proto_args.py
@@ -8,6 +8,7 @@ def proto_args(parser, parents):
     dgroup.add_argument("-H", "--hash", metavar="HASH", dest="hash", nargs="+", default=[], help="NTLM hash(es) or file(s) containing NTLM hashes")
     dgroup.add_argument("--simple-bind", action="store_true", help="Use simple bind authentication (no signing/sealing)")
     ldap_parser.add_argument("--port", type=int, default=389, action=DefaultTrackingAction, help="LDAP port")
+    ldap_parser.add_argument("--protocol", dest="scheme", type=str, choices=["ldap", "ldaps"], default="ldaps", help="Protocol to use (ldap or ldaps).")
     ldap_parser.add_argument("-d", metavar="DOMAIN", dest="domain", type=str, default=None, help="domain to authenticate to")
 
     egroup = ldap_parser.add_argument_group("Retrieve hash on the remote DC", "Options to get hashes from Kerberos")


### PR DESCRIPTION
## Description

This PR addresses an issue where custom ports specified with `nxc ldap --port` were not being properly respected or passed to the underlying Impacket LDAP connection. Additionally, it allows the user to manually specify protocol scheme (`ldap` vs `ldaps`) and defaults to LDAPS.

**Key Changes**
1. **Impacket LDAPConnection Monkey Patch**: Added a monkey patch for `impacket.ldap.ldap.LDAPConnection` to support custom ports in the connection URL (`ldap://host:port` or `ldaps://host:port`), which is not natively supported by Impacket. 
2. **Refactored Protocol Arguments**: Modified the argument parser in `proto_args.py` to use `--scheme` instead of capturing the protocol under a conflicting `scheme` destination.
3. **Accurate Logging**: Refactored `nxc/protocols/ldap.py` logging statements to use the dynamically computed scheme and port instead of hardcoding protocol names based on standard port numbers.

## How and why we fixed

I tried to use the `--port` option in an environment where a DC had a custom LDAP port set, not a standard one (no idea why) and realized only the default LDAP and LDAPs ports worked, not ports like `1111`. I leaned on `socat` until I managed to write this patch. Much easier after this patch.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Deprecation of feature or functionality
  - [ ] This change requires a documentation update
  - [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
  - [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

 Any target with an LDAP service running on a non-standard port, I used `1111`.

## Testing Performed

**Tests run:**
* Verified that `nxc ldap <ip> --port <custom_port>` connects to the correct custom port.
* Verified that `nxc ldap <ip> --scheme ldap` defaults to connecting to port 389.
* Verified that `nxc ldap <ip> --scheme ldaps` (or the default behavior) defaults to connecting to port 636.

  ## Checklist:
  - [ ] I have ran Ruff against my changes
  - [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary
  - [ ] If reliant on changes of third party dependencies, I have linked the relevant PRs
  - [ ] I have linked relevant sources that describes the added technique
  - [X] I have performed a self-review of my own code (_not_ an AI review)
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation