### PR TITLE
Fix for RDP asyncio timeout

### DIFF
--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from datetime import datetime
 from os import getenv
 from anyio import Path
@@ -124,7 +125,7 @@ class rdp(connection):
                     target=self.target,
                     credentials=self.auth,
                 )
-                asyncio.run(self.connect_rdp())
+                asyncio.run(self.connect_rdp_with_cleanup())
             except OSError as e:
                 if "Errno 104" not in str(e):
                     return False
@@ -188,9 +189,29 @@ class rdp(connection):
             pass
 
     async def connect_rdp(self):
+        """Connect to the RDP server. Does NOT clean up on exit.
+
+        Use this when the caller needs the connection alive after connecting
+        (screen, nla_screen, execute_shell). For sync callers that only need to
+        know whether authentication succeeded and want guaranteed cleanup, use
+        connect_rdp_with_cleanup() instead.
+        """
         _, err = await asyncio.wait_for(self.conn.connect(), timeout=self.args.rdp_timeout)
         if err is not None:
             raise err
+
+    async def terminate_conn(self):
+        """Terminate the RDP connection with a timeout so cleanup doesn't hang."""
+        if self.conn is not None:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(self.conn.terminate(), timeout=self.args.rdp_timeout)
+
+    async def connect_rdp_with_cleanup(self):
+        """Connect to the RDP server and always terminate the connection on exit"""
+        try:
+            await self.connect_rdp()
+        finally:
+            await self.terminate_conn()
 
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
         try:
@@ -245,7 +266,7 @@ class rdp(connection):
                 stype=stype,
             )
             self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
-            asyncio.run(self.connect_rdp())
+            asyncio.run(self.connect_rdp_with_cleanup())
 
             self.admin_privs = True
             self.logger.success(
@@ -301,7 +322,7 @@ class rdp(connection):
                 stype=asyauthSecret.PASS,
             )
             self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
-            asyncio.run(self.connect_rdp())
+            asyncio.run(self.connect_rdp_with_cleanup())
 
             self.admin_privs = True
             self.logger.success(f"{domain}\\{username}:{process_secret(password)} {self.mark_pwned()}")
@@ -335,7 +356,7 @@ class rdp(connection):
                 stype=asyauthSecret.NT,
             )
             self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
-            asyncio.run(self.connect_rdp())
+            asyncio.run(self.connect_rdp_with_cleanup())
 
             self.admin_privs = True
             self.logger.success(f"{self.domain}\\{username}:{process_secret(ntlm_hash)} {self.mark_pwned()}")
@@ -420,7 +441,6 @@ class rdp(connection):
             return None
         self.logger.debug(f"Executing command: {payload_with_clip}")
 
-        # Create a connection
         try:
             self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
             await self.connect_rdp()
@@ -525,13 +545,9 @@ class rdp(connection):
             self.logger.fail(f"Command execution failed: {e!s}")
             return None
         finally:
-            # Always clean up the connection
-            if self.conn is not None:
-                self.logger.debug("Terminating RDP connection")
-                try:
-                    await self.conn.terminate()
-                except Exception as e:
-                    self.logger.debug(f"Error terminating connection: {e!s}")
+            # clean up the connection with a timeout to prevent aardwolf deadlock (see https://github.com/skelsec/aardwolf/issues/43)
+            self.logger.debug("Terminating RDP connection")
+            await self.terminate_conn()
 
     def execute(self, payload=None, shell_type="cmd"):
         """Execute a command via RDP"""
@@ -566,15 +582,17 @@ class rdp(connection):
         try:
             self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
             await self.connect_rdp()
-        except Exception:
-            return
 
-        await asyncio.sleep(5)
-        if self.conn is not None and self.conn.desktop_buffer_has_data is True:
-            buffer = self.conn.get_desktop_buffer(VIDEO_FORMAT.PIL)
-            filename = await Path(f"{NXC_PATH}/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png").expanduser()
-            buffer.save(filename, "png")
-            self.logger.highlight(f"Screenshot saved {filename}")
+            await asyncio.sleep(5)
+            if self.conn is not None and self.conn.desktop_buffer_has_data is True:
+                buffer = self.conn.get_desktop_buffer(VIDEO_FORMAT.PIL)
+                filename = await Path(f"{NXC_PATH}/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png").expanduser()
+                buffer.save(filename, "png")
+                self.logger.highlight(f"Screenshot saved {filename}")
+        except Exception as e:
+            self.logger.debug(f"Error taking screenshot: {e!s}")
+        finally:
+            await self.terminate_conn()
 
     def screenshot(self):
         asyncio.run(self.screen())
@@ -586,19 +604,22 @@ class rdp(connection):
             try:
                 self.iosettings.supported_protocols = proto
                 self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
-
                 await self.connect_rdp()
             except Exception as e:
                 self.logger.debug(f"Failed to connect for nla_screenshot with {proto} {e}")
-                return
+                await self.terminate_conn()
+                continue
 
-            await asyncio.sleep(int(self.args.screentime))
-            if self.conn is not None and self.conn.desktop_buffer_has_data is True:
-                buffer = self.conn.get_desktop_buffer(VIDEO_FORMAT.PIL)
-                filename = await Path(f"{NXC_PATH}/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png").expanduser()
-                buffer.save(filename, "png")
-                self.logger.highlight(f"NLA Screenshot saved {filename}")
-                return
+            try:
+                await asyncio.sleep(int(self.args.screentime))
+                if self.conn is not None and self.conn.desktop_buffer_has_data is True:
+                    buffer = self.conn.get_desktop_buffer(VIDEO_FORMAT.PIL)
+                    filename = await Path(f"{NXC_PATH}/screenshots/{self.hostname}_{self.host}_{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.png").expanduser()
+                    buffer.save(filename, "png")
+                    self.logger.highlight(f"NLA Screenshot saved {filename}")
+                    return
+            finally:
+                await self.terminate_conn()
 
     def nla_screenshot(self):
         if not self.nla:


### PR DESCRIPTION
## Description

Fixes an asyncio deadlock in the RDP protocol that causes `nxc rdp` to hang indefinitely on hosts with misconfigured RDS Session Host deployments (expired licensing grace period, Connection Broker rejection). When the server sends an unexpected PDU instead of `DEMANDACTIVEPDU`, aardwolf's `__handle_mandatory_capability_exchange` blocks forever on `MCS.out_queue.get()`. NXC's outer `asyncio.wait_for` eventually fires, but cancelling the `connect()` coroutine triggers an aardwolf self-deadlock in the `__x224_reader_task` cleanup path, preventing the process from exiting. In a multi-host scan, a single bad host blocks every subsequent host on the same thread.

This PR fixes the NXC-side cleanup so failed/cancelled connections can always terminate cleanly, regardless of what aardwolf is doing internally:

- New `terminate_conn()` helper uses `asyncio.wait_for(..., timeout=self.args.rdp_timeout)` so cleanup itself can't hang. Calling `terminate()` explicitly sets aardwolf's `__terminate_called` flag before `asyncio.run()` cancels the reader task, breaking the cleanup deadlock chain (reference: aardwolf `connection.py:184-185`).
- New `connect_rdp_with_cleanup()` wraps `connect_rdp()` with a `finally` block that always calls `terminate_conn()`. Sync login paths (`create_conn_obj`, `plaintext_login`, `hash_login`, `kerberos_login`) use this so the event loop can cleanly tear down before `asyncio.run()` exits.
- Async callers that need the connection alive after connecting (`screen`, `nla_screen`, `execute_shell`) continue to use `connect_rdp()` and handle cleanup in their own `finally` blocks via `terminate_conn()`.
- Fixes `screen()` to always clean up — previously it had no `finally` block, only returning early on exception.
- Fixes `nla_screen()` protocol fallback: the original code `return`ed after the first protocol failure; now it `continue`s to try the next protocol, matching the clear intent of the `for proto in self.protoflags_nla` loop.
- Fixes `execute_shell()` cleanup: the original `await self.conn.terminate()` had no timeout and could hang on the same aardwolf bug.

Fixes #1169. A complementary upstream aardwolf PR (https://github.com/skelsec/aardwolf/issues/43) addresses the root cause at the library level (`__handle_mandatory_capability_exchange` timeout + `SET_ERROR_INFO_PDU` handling), but this NXC-side change provides defense-in-depth and mitigates the hang even against stock aardwolf.

**AI assistance disclosure**: this PR was produced with Claude Code (Anthropic Claude Opus 4.7) in the following ways: root cause investigation, debugging with network capture and protocol analysis, code authoring, and end-to-end test validation against live lab hosts (Server 2016 / Server 2019 / Server 2022). All changes were manually reviewed by me and verified end-to-end with manual NXC runs before submission.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

**Client**: Python 3.13, Kali Linux, aardwolf 0.2.13 (stock upstream).

**Reproducing the bug on `main`**:

1. Stand up a Windows Server 2019 (Build 17763) with the `RDS-RD-Server` (Session Host) role installed via Server Manager's RDS Deployment Wizard, OR install the role alone and let the 120-day licensing grace period expire without configuring a license server. Either setup produces a server that accepts TCP/CredSSP but rejects the subsequent session via Connection Broker (`ERRINFO_CB_CONNECTION_CANCELLED = 0x1192`).
2. Run `nxc rdp <ip> -u <valid_user> -p <valid_pass>` — the process hangs indefinitely. Multi-host scans with this host in the target list will stall at this target.

**Verifying the fix**:

- Single target: `nxc rdp <broken_host> -u <user> -p <pass>` — should fail within `--rdp-timeout` seconds (5 by default) and exit cleanly.
- Multi-host: `nxc rdp <broken_host> <good_host1> <good_host2> -u <user> -p <pass>` — the broken host fails fast and the good hosts still succeed with `Pwn3d!`.
- Authenticated screenshot: `nxc rdp <good_host> -u <user> -p <pass> --screenshot` — still works; PNG saved to `~/.nxc/screenshots/`.
- Exec: `nxc rdp <good_host> -u <user> -p <pass> -x whoami` — still works; returns output via clipboard channel.

Tested against:
- Windows Server 2016 (Build 14393) — domain controller, `FilterAdministratorToken=1`
- Windows Server 2019 (Build 17763) — member server, misconfigured RDS (reproduction target)
- Windows Server 2022 (Build 20348) — domain controller

## Screenshots (if appropriate):

Before:
<img width="1075" height="71" alt="nxc-asyncio-timeout" src="https://github.com/user-attachments/assets/82ff96b6-d332-4380-a740-722745836b34" />

After:
<img width="1081" height="86" alt="nxc-rdp-timeout-fixed" src="https://github.com/user-attachments/assets/bea65eaf-6157-487c-9db9-95eb48c7167b" />


## Checklist:

- [x] I have ran Ruff against my changes
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)