### PR TITLE
Fix premature self.context usage in modify-group

### DIFF
--- a/nxc/modules/modify-group.py
+++ b/nxc/modules/modify-group.py
@@ -49,7 +49,7 @@ class NXCModule:
         self.remove = module_options.get("REMOVE", "False").lower() == "true"
 
         if not (self.target_user and self.group):
-            self.context.log.fail("USER and GROUP parameters are required!")
+            context.log.fail("USER and GROUP parameters are required!")
             sys.exit(1)
 
     def on_login(self, context, connection):


### PR DESCRIPTION
## Description
This PR fixes modfiy-group module's non-arg run  error.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Tested on local, non agains system

## Screenshots (if appropriate):

Before:
<img width="1018" height="254" alt="image" src="https://github.com/user-attachments/assets/fe44b1ff-3be7-4bab-9d42-ac5f087c0354" />

After:
<img width="946" height="42" alt="image" src="https://github.com/user-attachments/assets/dc351c1a-19d7-4c3e-a59e-f12cd6ba28f4" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
