### PR TITLE
Fix carrying over of admin privs while bruteforcing

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -648,6 +648,10 @@ class ldap(connection):
             for item in resp_parsed:
                 if item:
                     self.admin_privs = True
+                    return
+
+        # If nothing matched we are not admin
+        self.admin_privs = False
 
     def getUnixTime(self, t):
         t -= 116444736000000000


### PR DESCRIPTION
## Description
Got a bug report via discord from @0xAnk: When bruteforcing (or checking) multiple user/password combinations the state of `self.admin_privs` is carried over to the next user because it is never reset or set to `False`. This is fixed now by just setting `self.admin_privs = False` if we don't find any matching admin group.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Log in with an admin user and then with a low priv user, e.g.:
`poetry run nxc ldap 192.168.56.11 -u jon.snow Eddard.stark arya.stark -p iknownothing FightP3aceAndHonor! Needle --continue-on-success --no-bruteforce`

## Screenshots (if appropriate):
Before&After:
<img width="1500" height="306" alt="image" src="https://github.com/user-attachments/assets/3b914cce-c62e-4a92-8c93-42d9656b4bf8" />


## Checklist: