### PR TITLE
Fix GitHub PR action and adjust AI policy

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,7 +1,7 @@
 name: PR Template Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 permissions:

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -21,12 +21,13 @@ The NetExec project has strict rules for AI usage:
   code for platforms or environments you don't have access to manually
   test on.
 
-- **Issues and discussions can use AI assistance but must have a full
-  human-in-the-loop.** This means that any content generated with AI
-  must have been reviewed _and edited_ by a human before submission.
-  AI is very good at being overly verbose and including noise that
-  distracts from the main point. Humans must do their research and
-  trim this down.
+- **Issues and pull requests should be written by humans.**
+  Communication should remain human, not AI, and should be clear and concise.
+  AI is very good at being overly verbose and including noise that distracts
+  from the main point. While it is fine to cite AI or include AI-generated
+  content, the main content of your issue or pull request should be written
+  by a human. Issues or pull requests that look like they are just the
+  result of an AI prompt will likely be rejected and closed.
 
 - **No AI-generated media is allowed (art, images, videos, audio, etc.).**
   Text and code are the only acceptable AI-generated content, per the


### PR DESCRIPTION
## Description
This PR should:
1. Fix the github action that comments on PRs, but fails when the PR is from a non-maintainer
2. Adjust the AI policy to clarify that issues and PRs are supposed to be written by humans

It looks like to comment on PRs the token needs write privileges onto PRs from this repository. Therefore, the action now has a token in the context of the Pennyw0rth/NetExec repository and not the forked repository (difference of `pull_request` and `pull_request_target` according to https://docs.github.com/de/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target). Security wise this should be fine as we operate on a fixed set of strings that can be injected into the comment. There is not much input that is controlled by the user.

I also adjusted the AI policy to more accurately reflect how I think about communication here. I don't mind when people use AI as an assistance for generating code (or content as well to some extent), but what I want to prevent is people just prompting AI and pasting the answers in Pull Requests or Issues. No one wants to communicate with a chat bot. Let me know what you think @mpgn, @Marshall-Hallenbeck.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
N/A
