### PR TITLE
Minor fixes for LDAP and RDP

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -772,7 +772,8 @@ class ldap(connection):
             else:
                 for item in resp_parsed:
                     # Display sAMAccountName or CN if sAMAccountName not present (could be a group)
-                    self.logger.highlight(item["sAMAccountName"] if "group" not in item["objectClass"] else item["cn"])
+                    # Fallback to cn should sAMAccountName not be present (e.g. Service Principal Names)
+                    self.logger.highlight(item.get("sAMAccountName", item["cn"]) if "group" not in item["objectClass"] else item["cn"])
         else:
             # Display all groups
             self.logger.highlight(f"{'-Group-':<40} {'-Members-':<9} {'-Description-':<60}")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -744,7 +744,7 @@ class ldap(connection):
             self.logger.debug(f"Dumping group: {self.args.groups}")
 
             # Resolve group DN and primaryGroupID (objectSid)
-            group_resp = self.search(f"(cn={self.args.groups})", ["distinguishedName", "objectSid"])
+            group_resp = self.search(f"(&(cn={self.args.groups})(objectClass=group))", ["distinguishedName", "objectSid"])
             group_parsed = parse_result_attributes(group_resp)
 
             if not group_parsed:

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -109,7 +109,10 @@ class rdp(connection):
             self.logger.display(f"Probably old, doesn't not support HYBRID or HYBRID_EX ({nla})")
         else:
             self.logger.display(f"{self.server_os} (name:{self.hostname}) (domain:{self.domain}) ({nla})")
-            self.db.add_host(self.host, self.port, self.hostname, self.domain, self.server_os, self.nla)
+            try:
+                self.db.add_host(self.host, self.port, self.hostname, self.domain, self.server_os, self.nla)
+            except Exception as e:
+                self.logger.debug(f"Error adding host {self.host} into db: {e!s}")
 
     def create_conn_obj(self):
         self.target = RDPTarget(ip=self.host, domain="FAKE", port=self.port, timeout=self.args.rdp_timeout)


### PR DESCRIPTION
## Description
Small fixes for issues I encountered in LDAP and RDP:
- If there is a container with the same name as a group previously the LDAP query crashed because it got the container instead of the group -> Filtering for groups only
- If security principals are part of a group the query crashes when displaying that entity because they are missing a sAMAccountName -> fallback to common name if sAMAccountName is not present
- Eliminate stack traces and protocol crashes when adding the host to the nxcdb fails in RDP

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Run: 
- `nxc ldap ... --groups users`
- `nxc rdp <ip-range>` a few times until the db fails

## Screenshots (if appropriate):
Before&After of the ldap crash(es):
<img width="1590" height="1053" alt="image" src="https://github.com/user-attachments/assets/fb66e8a8-dac8-4d7c-9b9e-1532bd94cfe1" />

## Checklist:
