### PR TITLE
Fix netexec.spec

### DIFF
--- a/netexec.spec
+++ b/netexec.spec
@@ -19,6 +19,7 @@ a = Analysis(
         'aardwolf.commons.iosettings',
         'aardwolf.commons.target',
         'aardwolf.protocol.x224.constants',
+        'certihound',
         'certipy.commands.find',
         'certipy.lib.formatting',
         'certipy.lib.target',


### PR DESCRIPTION
Add 'certihound' needed for LDAP
Fix #1197

## Description
Modify the netexec.spec file to include 'certihound' needed by the LDAP module

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Run:
`nxc ldap localhost`

## Screenshots (if appropriate):

<img width="913" height="472" alt="nxc_fix_PR" src="https://github.com/user-attachments/assets/471ce3ea-7ea4-45c9-b64f-1567c71d93e6" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
