### PR TITLE
Fix add-computer module

### DIFF
--- a/nxc/modules/add-computer.py
+++ b/nxc/modules/add-computer.py
@@ -191,7 +191,7 @@ class NXCModule:
             request["Name"] = self.computer_name
             request["AccountType"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
             request["DesiredAccess"] = samr.USER_FORCE_PASSWORD_CHANGE
-            return dce.request(request)
+            return dce.request(request)["UserHandle"]
         except samr.DCERPCSessionError as e:
             if "STATUS_USER_EXISTS" in str(e):
                 self.context.log.fail(f"Computer '{self.computer_name}' already exists")

--- a/nxc/modules/add-computer.py
+++ b/nxc/modules/add-computer.py
@@ -16,14 +16,14 @@ class NXCModule:
     """
 
     name = "add-computer"
-    description = "Adds or deletes a domain computer via SAMR (SMB) or LDAPS"
+    description = "Adds or deletes a domain computer via SAMR (SMB) or LDAP"
     supported_protocols = ["smb", "ldap"]
     category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """
         add-computer: Adds, deletes, or changes the password of a domain computer account.
-        Uses SAMR when invoked with nxc smb, LDAPS when invoked with nxc ldap.
+        Uses SAMR when invoked with nxc smb.
 
         NAME        Computer name (required). Trailing '$' is added automatically.
         PASSWORD    Computer password (required for add/changepw).


### PR DESCRIPTION
## Description
Currently adding computers over SAMR crashes due to returning not the actual user handle when creating the account, but the entire impacket object. Therefore, we do not have a handle and changing the password afterwards crashes.

Reported by @azoxlpf 

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
`nxc smb ... -M add-computer -o NAME="PC20" PASSWORD="Password123!"`

## Screenshots (if appropriate):
Before&After:
<img width="1568" height="920" alt="image" src="https://github.com/user-attachments/assets/aaf6d139-04c1-4a34-ad92-d57eb2c90efc" />

