### PR TITLE
update to match the docs

### DIFF
--- a/nxc/protocols/vnc.py
+++ b/nxc/protocols/vnc.py
@@ -6,7 +6,6 @@ import socket
 import struct
 from nxc.config import host_info_colors
 from nxc.connection import connection
-from nxc.helpers.logger import highlight
 from nxc.logger import NXCAdapter
 from nxc.paths import NXC_PATH
 from aardwolf.commons.target import RDPTarget
@@ -127,18 +126,12 @@ class vnc(connection):
             )
             asyncio.run(self.connect_vnc())
 
-            self.admin_privs = True
-            self.logger.success(
-                "{} {}".format(
-                    password,
-                    highlight(f"({self.config.get('nxc', 'pwn3d_label')})" if self.admin_privs else ""),
-                )
-            )
+            self.logger.success(f":{password}")
             return True
 
         except Exception as e:
             self.logger.debug(str(e))
-            self.logger.fail(f"{password} - Authentication failed")
+            self.logger.fail(f":{password} - Authentication failed")
             return False
 
     async def screen(self):


### PR DESCRIPTION
## Description
So this is purely some "pretty" changes to just match the output of the docs. So I actually didn't know about the vnc protocol not using `username:password`, its just `:password`. 

So I updated the following:
- Added the missing `:` to match nxc format for both auth success and fail. 
- Removed the Pwn3d tag since vnc does not have a check to determine this and might be misleading. 
- Removed the Pwn3d tag related import. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
VNC checks for null, fail and successful auth. FYI, ruff fails for `spider_plus.py`, but I didn't touch that lol. 

## Screenshots:
<img width="2318" height="460" alt="image" src="https://github.com/user-attachments/assets/8448f24e-5a80-455a-8347-ee478888fff6" />

## Checklist:
- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
