### PR TITLE
feat(cli): add --exclude and --skip-self target filters (#674)

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -84,6 +84,8 @@ def gen_cli_args():
 
     std_parser = argparse.ArgumentParser(add_help=False, parents=[generic_parser, output_parser, dns_parser], formatter_class=DisplayDefaultsNotNone)
     std_parser.add_argument("target", nargs="+" if not (module_parser.parse_known_args()[0].list_modules is not None or module_parser.parse_known_args()[0].show_module_options or generic_parser.parse_known_args()[0].version) else "*", type=str, help="the target IP(s), range(s), CIDR(s), hostname(s), FQDN(s), file(s) containing a list of targets, NMap XML or .Nessus file(s)")
+    std_parser.add_argument("--exclude", metavar="HOST", nargs="+", default=[], help="IP(s), range(s), CIDR(s), or hostname(s) to remove from the resolved target list — useful when scanning a network where a small subset shouldn't be touched")
+    std_parser.add_argument("--skip-self", action="store_true", help="exclude the attacker host's own primary IPv4 address from the resolved target list (uses a UDP-connect probe to detect the source IP without sending traffic)")
     credential_group = std_parser.add_argument_group("Authentication")
     credential_group.add_argument("-u", "--username", metavar="USERNAME", dest="username", nargs="+", default=[], help="username(s) or file(s) containing usernames")
     credential_group.add_argument("-p", "--password", metavar="PASSWORD", dest="password", nargs="+", default=[], help="password(s) or file(s) containing passwords")

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -1,4 +1,5 @@
 # PYTHON_ARGCOMPLETE_OK
+import socket
 import sys
 from nxc.helpers.logger import highlight
 from nxc.helpers.misc import identify_target_file, display_modules
@@ -38,6 +39,22 @@ if platform.system() != "Windows":
         file_limit[0] = file_limit[1]
     file_limit = tuple(file_limit)
     resource.setrlimit(resource.RLIMIT_NOFILE, file_limit)
+
+
+def _detect_local_ip():
+    """Return the attacker host's primary outbound IPv4 address, or None.
+
+    Uses a UDP `connect` to a non-routable address — no traffic actually
+    leaves the host but the kernel populates the local end of the socket
+    with whichever interface IP would be used to reach the destination.
+    Mirrors the snippet in NetExec issue #674.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("172.31.255.254", 80))
+            return s.getsockname()[0]
+    except OSError:
+        return None
 
 
 async def start_run(protocol_obj, args, db, targets):  # noqa: RUF029
@@ -127,6 +144,27 @@ def main():
                     targets.extend(parse_targets(target))
             except Exception as e:
                 nxc_logger.fail(f"Failed to parse target '{target}': {e}")
+
+    # Build the exclusion set after resolution so users can pass CIDRs / ranges
+    # to --exclude exactly the way they pass them to the positional `target`.
+    excluded = set()
+    if hasattr(args, "exclude") and args.exclude:
+        for entry in args.exclude:
+            try:
+                excluded.update(parse_targets(entry))
+            except Exception as e:  # noqa: BLE001
+                nxc_logger.fail(f"Failed to parse --exclude entry '{entry}': {e}")
+    if hasattr(args, "skip_self") and args.skip_self:
+        local_ip = _detect_local_ip()
+        if local_ip:
+            excluded.add(local_ip)
+            nxc_logger.debug(f"--skip-self: excluding local IP {local_ip}")
+    if excluded:
+        before = len(targets)
+        targets = [t for t in targets if t not in excluded]
+        removed = before - len(targets)
+        if removed:
+            nxc_logger.info(f"Excluded {removed} host(s) from the target list")
 
     # The following is a quick hack for the powershell obfuscation functionality, I know this is yucky
     if hasattr(args, "clear_obfscripts") and args.clear_obfscripts:


### PR DESCRIPTION
Closes #674.

## Background

Right now `nxc` can't remove specific hosts or networks from a resolved target list. On engagements that scan a `/24` containing the attacker host or sensitive infrastructure, the only workarounds are (a) break the scope into smaller CIDRs and feed each separately, or (b) edit the target file by hand — both error-prone, and #674 calls out that "funny things happen" when the attacker host gets caught in its own scan.

## Change

Add two related flags on the standard parser (`std_parser` in `nxc/cli.py`):

| Flag | Behaviour |
|---|---|
| `--exclude HOST [HOST ...]` | IP / range / CIDR / hostname entries to remove from the resolved target list. Accepts the same forms `target` accepts, including ranges (`10.0.0.1-50`) and CIDRs. |
| `--skip-self` | Convenience flag — detects the attacker host's primary outbound IPv4 via a UDP-connect to a non-routable address (no traffic actually leaves the host; the kernel just populates the local end of the socket with whichever interface IP would be used) and adds it to the exclusion set. Mirrors the snippet @hugo-syn included in #674. |

Both run **after** target resolution in `nxc/netexec.py`, so a user can exclude a single IP from a CIDR scope without having to fragment the CIDR into smaller pieces.

```py
excluded = set()
if hasattr(args, "exclude") and args.exclude:
    for entry in args.exclude:
        try:
            excluded.update(parse_targets(entry))
        except Exception as e:
            nxc_logger.fail(f"Failed to parse --exclude entry '{entry}': {e}")
if hasattr(args, "skip_self") and args.skip_self:
    local_ip = _detect_local_ip()
    if local_ip:
        excluded.add(local_ip)
        nxc_logger.debug(f"--skip-self: excluding local IP {local_ip}")
if excluded:
    before = len(targets)
    targets = [t for t in targets if t not in excluded]
    removed = before - len(targets)
    if removed:
        nxc_logger.info(f"Excluded {removed} host(s) from the target list")
```

## Verification

```
$ nxc smb --help | grep -A1 exclude
  --exclude HOST [HOST ...]
                        IP(s), range(s), CIDR(s), or hostname(s) to remove ...

$ nxc smb --help | grep skip-self
  --skip-self           exclude the attacker host's own primary IPv4 ...
```

`python3 -m py_compile nxc/cli.py nxc/netexec.py` clean.

## Notes

- Diff is `+40 / 0` lines across two files.
- The exclusion set uses `set`-based membership for O(1) filter, so a `/16` scan with `--exclude 192.0.2.0/24` is still O(n) in the resolved target count.
- `--skip-self` only handles IPv4. Adding IPv6 detection would mean a second UDP-connect probe to an unreachable v6 destination — happy to follow up if you'd like that included.
- Hostnames in `--exclude` aren't resolved before set-membership comparison (matches the way `parse_targets` handles them today). If a future PR wants resolved-hostname matching, the natural place to add it is in `parse_targets` itself.
