### PR TITLE
Improved Ctrl + c behavior

### DIFF
--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -14,11 +14,13 @@ from nxc.console import nxc_console
 from nxc.logger import nxc_logger
 from nxc.config import nxc_config, nxc_workspace, config_log
 from nxc.database import create_db_engine
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 import asyncio
 from nxc.helpers import powershell
+import signal
 import shutil
 import os
+import contextlib
 from os.path import exists
 from os.path import join as path_join
 from sys import exit
@@ -40,34 +42,51 @@ if platform.system() != "Windows":
     resource.setrlimit(resource.RLIMIT_NOFILE, file_limit)
 
 
-async def start_run(protocol_obj, args, db, targets):  # noqa: RUF029
-    futures = []
+async def start_run(protocol_obj, args, db, targets):
     nxc_logger.debug("Creating ThreadPoolExecutor")
+    loop = asyncio.get_running_loop()
+
     if args.no_progress or len(targets) == 1:
         with ThreadPoolExecutor(max_workers=args.threads) as executor:
             nxc_logger.debug(f"Creating thread for {protocol_obj}")
-            futures = [executor.submit(protocol_obj, args, db, target) for target in targets]
+            futures = [loop.run_in_executor(executor, protocol_obj, args, db, target) for target in targets]
+            await asyncio.gather(*futures, return_exceptions=True)
     else:
         with Progress(console=nxc_console) as progress, ThreadPoolExecutor(max_workers=args.threads) as executor:
-            current = 0
             total = len(targets)
             tasks = progress.add_task(
                 f"[green]Running nxc against {total} {'target' if total == 1 else 'targets'}",
                 total=total,
             )
             nxc_logger.debug(f"Creating thread for {protocol_obj}")
-            futures = [executor.submit(protocol_obj, args, db, target) for target in targets]
-            for _ in as_completed(futures):
-                current += 1  # noqa: SIM113
+            futures = [loop.run_in_executor(executor, protocol_obj, args, db, target) for target in targets]
+            for current, future in enumerate(asyncio.as_completed(futures), 1):
+                with contextlib.suppress(Exception):
+                    await future
                 progress.update(tasks, completed=current)
-    for future in as_completed(futures):
+
+    for i, future in enumerate(futures):
         try:
             future.result()
         except Exception:
-            nxc_logger.exception(f"Exception for target {targets[futures.index(future)]}: {future.exception()}")
+            nxc_logger.exception(f"Exception for target {targets[i]}: {future.exception()}")
+
+
+def ctrl_c(sig, frame):
+    nxc_logger.debug("Got keyboard interrupt")
+    try:
+        if hasattr(nxc_console, "_live_stack") and nxc_console._live_stack:
+            for live in nxc_console._live_stack:
+                live.stop()
+        nxc_console.show_cursor(True)
+    except Exception:
+        pass
+    nxc_logger.highlight("[!] Interrupted, exiting.")
+    os._exit(0)
 
 
 def main():
+    signal.signal(signal.SIGINT, ctrl_c)
     first_run_setup(nxc_logger)
     args, version_info = gen_cli_args()
 
@@ -209,8 +228,6 @@ def main():
 
     try:
         asyncio.run(start_run(protocol_object, args, db, targets))
-    except KeyboardInterrupt:
-        nxc_logger.debug("Got keyboard interrupt")
     finally:
         db_engine.dispose()
 

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -14,13 +14,12 @@ from nxc.console import nxc_console
 from nxc.logger import nxc_logger
 from nxc.config import nxc_config, nxc_workspace, config_log
 from nxc.database import create_db_engine
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import asyncio
 from nxc.helpers import powershell
 import signal
 import shutil
 import os
-import contextlib
 from os.path import exists
 from os.path import join as path_join
 from sys import exit
@@ -42,34 +41,31 @@ if platform.system() != "Windows":
     resource.setrlimit(resource.RLIMIT_NOFILE, file_limit)
 
 
-async def start_run(protocol_obj, args, db, targets):
+async def start_run(protocol_obj, args, db, targets):  # noqa: RUF029
+    futures = []
     nxc_logger.debug("Creating ThreadPoolExecutor")
-    loop = asyncio.get_running_loop()
-
     if args.no_progress or len(targets) == 1:
         with ThreadPoolExecutor(max_workers=args.threads) as executor:
             nxc_logger.debug(f"Creating thread for {protocol_obj}")
-            futures = [loop.run_in_executor(executor, protocol_obj, args, db, target) for target in targets]
-            await asyncio.gather(*futures, return_exceptions=True)
+            futures = [executor.submit(protocol_obj, args, db, target) for target in targets]
     else:
         with Progress(console=nxc_console) as progress, ThreadPoolExecutor(max_workers=args.threads) as executor:
+            current = 0
             total = len(targets)
             tasks = progress.add_task(
                 f"[green]Running nxc against {total} {'target' if total == 1 else 'targets'}",
                 total=total,
             )
             nxc_logger.debug(f"Creating thread for {protocol_obj}")
-            futures = [loop.run_in_executor(executor, protocol_obj, args, db, target) for target in targets]
-            for current, future in enumerate(asyncio.as_completed(futures), 1):
-                with contextlib.suppress(Exception):
-                    await future
+            futures = [executor.submit(protocol_obj, args, db, target) for target in targets]
+            for _ in as_completed(futures):
+                current += 1  # noqa: SIM113
                 progress.update(tasks, completed=current)
-
-    for i, future in enumerate(futures):
+    for future in as_completed(futures):
         try:
             future.result()
         except Exception:
-            nxc_logger.exception(f"Exception for target {targets[i]}: {future.exception()}")
+            nxc_logger.exception(f"Exception for target {targets[futures.index(future)]}: {future.exception()}")
 
 
 def ctrl_c(sig, frame):

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -1,4 +1,5 @@
 # PYTHON_ARGCOMPLETE_OK
+import contextlib
 import sys
 from nxc.helpers.logger import highlight
 from nxc.helpers.misc import identify_target_file, display_modules
@@ -70,13 +71,11 @@ async def start_run(protocol_obj, args, db, targets):  # noqa: RUF029
 
 def ctrl_c(sig, frame):
     nxc_logger.debug("Got keyboard interrupt")
-    try:
+    with contextlib.suppress(Exception):
         if hasattr(nxc_console, "_live_stack") and nxc_console._live_stack:
             for live in nxc_console._live_stack:
                 live.stop()
         nxc_console.show_cursor(True)
-    except Exception:
-        pass
     nxc_logger.highlight("[!] Interrupted, exiting.")
     os._exit(0)
 


### PR DESCRIPTION
## Description

In this version, we use os._exit(0) to stop execution. It is a "Hard Kill" that ends the process without waiting for the threads to finish

When using asyncio.run_in_executor, the main thread is not "working" on the scan, but rather is monitoring the event loop. This allows the CTRL+C signal to be processed instantly rather than waiting for a network socket to respond.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
  You can test it by scaning any /24 or segment on any protocol. Tested on Linux and Windows
  
  Related: https://github.com/Pennyw0rth/NetExec/issues/61

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/1929d2ba-abd5-4b8c-810f-01fb23355a00
https://github.com/user-attachments/assets/bbf1fe46-6094-4461-84f7-3f0b7b5c796d


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)

Note: There are other 2 issues when running ruff not related to my changes