### PR TITLE
Minor fixes for NFS

### DIFF
--- a/nxc/modules/ntlm_reflection.py
+++ b/nxc/modules/ntlm_reflection.py
@@ -10,7 +10,7 @@ class NXCModule:
     # Modified by azoxlpf to handle BrokenPipe/transport errors gracefully
     # Modified by Defte following the discovery of ctjf (https://github.com/Pennyw0rth/NetExec/issues/928) and the research done along side with @NeffIsBack and I
     name = "ntlm_reflection"
-    description = "Attempt to check if the OS is vulnerable to CVE-2025-33073 (NTLM Reflection attack)"
+    description = "[REMOVED] This module has been integrated into the enum_cve module."
     supported_protocols = ["smb"]
     opsec_safe = True
     multiple_hosts = True

--- a/nxc/modules/pso.py
+++ b/nxc/modules/pso.py
@@ -8,7 +8,7 @@ class NXCModule:
     Module by @_sandw1ch
     """
     name = "pso"
-    description = "Module to get the Fine Grained Password Policy/PSOs"
+    description = "[REMOVED] This module moved to the core option --pso"
     supported_protocols = ["ldap"]
     category = CATEGORY.ENUMERATION
 

--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -733,7 +733,7 @@ class nfs(connection):
                 file_size = convert_size(item["name_attributes"]["attributes"]["size"])
             try:
                 self.logger.highlight(f"{uid:<11}{perms:<7}{file_size:<14}{path.rstrip('/') + '/' + item['name'].decode()}")
-            except UnicodeDecodeError as e:
+            except UnicodeDecodeError:
                 self.logger.highlight(f"{uid:<11}{perms:<7}{file_size:<14}{path.rstrip('/') + '/' + item['name'].decode('CP437')}")
 
     def format_directory(self, raw_directory):

--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -731,7 +731,10 @@ class nfs(connection):
                 read_perm, write_perm, exec_perm = self.get_permissions(item["name_handle"]["handle"]["data"])
                 perms = f"{is_dir}{'r' if read_perm else '-'}{'w' if write_perm else '-'}{'x' if exec_perm else '-'}"
                 file_size = convert_size(item["name_attributes"]["attributes"]["size"])
-            self.logger.highlight(f"{uid:<11}{perms:<7}{file_size:<14}{path.rstrip('/') + '/' + item['name'].decode()}")
+            try:
+                self.logger.highlight(f"{uid:<11}{perms:<7}{file_size:<14}{path.rstrip('/') + '/' + item['name'].decode()}")
+            except UnicodeDecodeError as e:
+                self.logger.highlight(f"{uid:<11}{perms:<7}{file_size:<14}{path.rstrip('/') + '/' + item['name'].decode('CP437')}")
 
     def format_directory(self, raw_directory):
         """Convert the chained directory entries to a list of the entries"""

--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -130,18 +130,22 @@ class nfs(connection):
                 if program["program"] == NFS_PROGRAM:
                     self.nfs_versions.add(program["version"])
         except Exception as e:
-            self.logger.debug(f"Error checking NFS version: {self.host} {e}")
+            self.logger.fail(f"Error checking NFS version: {self.host} {e}")
 
         # Connect to NFS
-        nfs_port = self.portmap.getport(NFS_PROGRAM, NFS_V3)
-        self.nfs3 = NFSv3(self.host, nfs_port, self.args.nfs_timeout, self.auth)
-        self.nfs3.connect()
-        # Check if root escape is possible
-        if NFS_V3 in self.nfs_versions:
-            self.root_escape = self.try_root_escape()
-        else:
-            self.logger.debug("NFSv3 not supported, skipping root escape check")
-        self.nfs3.disconnect()
+        try:
+            nfs_port = self.portmap.getport(NFS_PROGRAM, NFS_V3)
+            if nfs_port:
+                self.nfs3 = NFSv3(self.host, nfs_port, self.args.nfs_timeout, self.auth)
+                self.nfs3.connect()
+                # Check if root escape is possible
+                if NFS_V3 in self.nfs_versions:
+                    self.root_escape = self.try_root_escape()
+                else:
+                    self.logger.debug("NFSv3 not supported, skipping root escape check")
+                self.nfs3.disconnect()
+        except Exception as e:
+            self.logger.fail(f"Failed to connect to NFS3 host: {e}")
 
     def print_host_info(self):
         root_escape_str = colored(f"root escape:{self.root_escape}", host_info_colors[1 if self.root_escape else 0], attrs=["bold"])


### PR DESCRIPTION
## Description
Includes minor fixes for NFS:
- Fixes a stacktrace if the portmapper does not provide a port for nfs to bind (and therefore nfs is not available)
- Fixes an encoding issues for special chars

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Difficult, you need a portmapper that does not provide a port for NFS. Also, scan an NFS share with paths/file names containing special chars (e.g. öäü).

## Screenshots (if appropriate):
Not possible since prod env.