### PR TITLE
Fix handling of empty SMB share folder

### DIFF
--- a/nxc/modules/spider_plus.py
+++ b/nxc/modules/spider_plus.py
@@ -127,6 +127,8 @@ class SMBSpiderPlus:
                 self.logger.debug(f"The folder {subfolder} does not exist.")
             elif "STATUS_STOPPED_ON_SYMLINK" in str(e):
                 self.logger.debug(f"The folder {subfolder} is a symlink that cannot be followed. Skipping.")
+            elif "STATUS_NO_SUCH_FILE" in str(e):
+                self.logger.debug(f"The folder {subfolder} is empty.")
             elif self.reconnect():
                 filelist = self.list_path(share, subfolder)
         except NetBIOSTimeout as e:


### PR DESCRIPTION
## Description
Fix a bug where spider_plus gets stuck in an endless loop crawling an empty SMB share folder.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
When having an empty SMB share folder (such as `C$`), spider_plus gets stuck in an endless reconnect loop as it does not handle the `STATUS_NO_SUCH_FILE` error properly.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
