### PR TITLE
Add chmod to NFS

### DIFF
--- a/nxc/protocols/nfs.py
+++ b/nxc/protocols/nfs.py
@@ -526,6 +526,62 @@ class nfs(connection):
         else:
             self.logger.highlight(f"File {local_file_path} successfully uploaded to {remote_file_path}")
 
+    def chmod(self):
+        try:
+            # Connect to NFS
+            nfs_port = self.portmap.getport(NFS_PROGRAM, NFS_V3)
+            self.nfs3 = NFSv3(self.host, nfs_port, self.args.nfs_timeout, self.auth)
+            self.nfs3.connect()
+
+            # Mount the NFS share or get the root handle
+            if self.root_escape and not self.args.share:
+                mount_fh = self.escape_fh
+            elif not self.args.share:
+                self.logger.fail("No root escape possible, please specify a share")
+                return
+            else:
+                mnt_info = self.mount.mnt(self.args.share, self.auth)
+                if mnt_info["status"] != 0:
+                    self.logger.fail(f"Error mounting share {self.args.share}: {NFSSTAT3[mnt_info['status']]}")
+                    return
+                mount_fh = mnt_info["mountinfo"]["fhandle"]
+
+            # Iterate over the path
+            curr_fh = mount_fh
+            privs = int(self.args.chmod[0], 8)
+            filepath = self.args.chmod[1]
+            file_path, file_name = os.path.split(filepath)
+
+            # If target dir is "" or "/" without filter we would get one item with [""]
+            for sub_path in list(filter(None, file_path.lstrip("/").split("/"))):
+                self.update_auth(curr_fh)
+                res = self.nfs3.lookup(curr_fh, sub_path, auth=self.auth)
+
+                # If the path does not exist, create it
+                if "resfail" in res and res["status"] == NFS3ERR_NOENT:
+                    self.logger.fail(f"Directory '{sub_path}' does not exist on path '{file_path}/'")
+
+                curr_fh = res["resok"]["object"]["data"]
+
+            # Update the UID and GID from the directory
+            self.update_auth(curr_fh)
+
+            # Checking if file_name already exists on remote file path
+            lookup_response = self.nfs3.lookup(curr_fh, file_name, auth=self.auth)
+
+            if "resfail" in lookup_response and lookup_response["status"] == NFS3ERR_NOENT:
+                self.logger.fail(f"File '{file_name}' does not exist on path '{file_path}/'")
+                return
+
+            current_privs = self.nfs3.getattr(lookup_response["resok"]["object"]["data"], auth=self.auth)["attributes"]["mode"]
+            res = self.nfs3.setattr(lookup_response["resok"]["object"]["data"], mode=privs, auth=self.auth)
+            if "resfail" in res:
+                self.logger.fail(f"Failed to change permissions for '{filepath}': {NFSSTAT3[res['status']]}")
+            else:
+                self.logger.success(f"Permissions for '{filepath}' successfully changed from {format(current_privs, 'o')} to {format(privs, 'o')}")
+        except Exception as e:
+            self.logger.fail(f"Error occurred while processing path: {e}")
+
     def get_root_handles(self, mount_fh):
         """
         Get possible root handles to escape to the root filesystem

--- a/nxc/protocols/nfs/proto_args.py
+++ b/nxc/protocols/nfs/proto_args.py
@@ -10,5 +10,6 @@ def proto_args(parser, parents):
     dgroup.add_argument("--ls", const="/", nargs="?", metavar="PATH", help="List files in the specified NFS share. Example: --ls /")
     dgroup.add_argument("--get-file", nargs=2, metavar="FILE", help="Download remote NFS file. Example: --get-file remote_file local_file")
     dgroup.add_argument("--put-file", nargs=2, metavar="FILE", help="Upload remote NFS file with chmod 777 permissions to the specified folder. Example: --put-file local_file remote_file")
+    dgroup.add_argument("--chmod", nargs=2, metavar=("PERMISSIONS", "FILE"), help="Change permissions of remote NFS file. Example: --chmod 777 /path/to/file")
 
     return parser

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -332,3 +332,4 @@ netexec nfs TARGET_HOST -u "" -p "" --shares
 netexec nfs TARGET_HOST -u "" -p "" --enum-shares
 netexec nfs TARGET_HOST -u "" -p "" --get-file /NFStest/test/test.txt ../test.txt
 netexec nfs TARGET_HOST -u "" -p "" --put-file ../test.txt /NFStest/test
+netexec nfs TARGET_HOST -u "" -p "" --chmod 666 /NFStest/test/test.txt


### PR DESCRIPTION
## Description
We decided to upload files in NFS with permissions "777" by default. However, there are circumstances where we need to change file permissions, e.g. to make files executable etc. This PR adds `--chmod` to the NFS protocol to solve that problem.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
On the target:
```bash
sudo apt update
sudo apt install nfs-kernel-server
# Add nfs config
sudo mkdir /var/nfs/general
echo "/var/nfs/general *(rw,no_root_squash)" | sudo tee -a sudo nano /etc/exports
```
Now connect to the nfs host and change arbitrary permissions:
```bash
nxc nfs ... --chmod 777 /etc/shadow
```

## Screenshots (if appropriate):
<img width="1013" height="348" alt="image" src="https://github.com/user-attachments/assets/177bcb9a-859c-4ea7-930f-695b3f1fde98" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
