### PR TITLE
Sanitize NTLM hostname to prevent path traversal and injection

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -248,7 +248,7 @@ class connection:
             self.enum_host_info()
             sanitized = re.sub(r'[^\w\-.]', '_', self.hostname)
             if sanitized != self.hostname:
-                self.logger.warning(f"Hostname contains invalid characters (received: {self.hostname!r}), sanitized to: {sanitized!r}")
+                self.logger.display(f"Hostname contains invalid characters (received: {self.hostname!r}), sanitized to: {sanitized!r}")
                 self.hostname = sanitized
 
             # Construct the output file template using os.path.join for OS compatibility

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+import re
 import random
 import sys
 import contextlib
@@ -245,6 +246,7 @@ class connection:
         else:
             self.logger.debug("Created connection object")
             self.enum_host_info()
+            self.hostname = re.sub(r'[^\w\-.]', '_', self.hostname)
 
             # Construct the output file template using os.path.join for OS compatibility
             base_log_dir = os.path.join(NXC_PATH, "logs")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import os
-import re
 import random
 import sys
 import contextlib
@@ -246,10 +245,6 @@ class connection:
         else:
             self.logger.debug("Created connection object")
             self.enum_host_info()
-            sanitized = re.sub(r'[^\w\-.]', '_', self.hostname)
-            if sanitized != self.hostname:
-                self.logger.display(f"Hostname contains invalid characters (received: {self.hostname!r}), sanitized to: {sanitized!r}")
-                self.hostname = sanitized
 
             # Construct the output file template using os.path.join for OS compatibility
             base_log_dir = os.path.join(NXC_PATH, "logs")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -246,7 +246,10 @@ class connection:
         else:
             self.logger.debug("Created connection object")
             self.enum_host_info()
-            self.hostname = re.sub(r'[^\w\-.]', '_', self.hostname)
+            sanitized = re.sub(r'[^\w\-.]', '_', self.hostname)
+            if sanitized != self.hostname:
+                self.logger.warning(f"Hostname contains invalid characters (received: {self.hostname!r}), sanitized to: {sanitized!r}")
+                self.hostname = sanitized
 
             # Construct the output file template using os.path.join for OS compatibility
             base_log_dir = os.path.join(NXC_PATH, "logs")

--- a/nxc/helpers/misc.py
+++ b/nxc/helpers/misc.py
@@ -26,6 +26,20 @@ def gen_random_string(length=10):
     return "".join(random.sample(string.ascii_letters, int(length)))
 
 
+_HOSTNAME_SANITIZE_RE = re.compile(r"[^\w\-.]")
+
+
+def sanitize_hostname(hostname, logger=None):
+    """Strip characters from a server-provided hostname that could cause path
+    traversal, newline injection, or format-string issues when used in file
+    paths or output content.  Logs a warning when the value is modified.
+    """
+    sanitized = _HOSTNAME_SANITIZE_RE.sub("_", hostname)
+    if sanitized != hostname and logger:
+        logger.display(f"Hostname contained invalid characters (received: {hostname!r}), sanitized to: {sanitized!r}")
+    return sanitized
+
+
 def validate_ntlm(data):
     allowed = re.compile(r"^[0-9a-f]{32}", re.IGNORECASE)
     return bool(allowed.match(data))

--- a/nxc/helpers/misc.py
+++ b/nxc/helpers/misc.py
@@ -29,14 +29,14 @@ def gen_random_string(length=10):
 _HOSTNAME_SANITIZE_RE = re.compile(r"[^\w\-.]")
 
 
-def sanitize_hostname(hostname, logger=None):
+def sanitize_hostname(hostname, logger):
     """Strip characters from a server-provided hostname that could cause path
     traversal, newline injection, or format-string issues when used in file
     paths or output content.  Logs a warning when the value is modified.
     """
     sanitized = _HOSTNAME_SANITIZE_RE.sub("_", hostname)
-    if sanitized != hostname and logger:
-        logger.display(f"Hostname contained invalid characters (received: {hostname!r}), sanitized to: {sanitized!r}")
+    if sanitized != hostname:
+        logger.fail(f"Hostname contained invalid characters (received: {hostname!r}), sanitized to: {sanitized!r}")
     return sanitized
 
 

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -6,7 +6,7 @@ from termcolor import colored
 from nxc.config import process_secret, host_info_colors
 from nxc.connection import connection
 from nxc.connection import requires_admin
-from nxc.helpers.misc import gen_random_string
+from nxc.helpers.misc import gen_random_string, sanitize_hostname
 from nxc.logger import NXCAdapter
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.negotiate_parser import parse_challenge, login7_integrated_auth_error_message
@@ -138,7 +138,7 @@ class mssql(connection):
             if challenge.startswith(b"NTLMSSP\x00"):
                 ntlm_info = parse_challenge(challenge)
                 self.targetDomain = self.domain = ntlm_info["domain"]
-                self.hostname = ntlm_info["hostname"]
+                self.hostname = sanitize_hostname(ntlm_info["hostname"], self.logger)
                 self.server_os = ntlm_info["os_version"]
                 self.logger.extra["hostname"] = self.hostname
             else:

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -8,6 +8,7 @@ from termcolor import colored
 from impacket.krb5.ccache import CCache
 
 from nxc.connection import connection
+from nxc.helpers.misc import sanitize_hostname
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.logger import NXCAdapter
 from nxc.config import host_info_colors, process_secret
@@ -142,7 +143,7 @@ class rdp(connection):
                         pass
                     else:
                         self.domain = info_domain["dnsdomainname"]
-                        self.hostname = info_domain["computername"]
+                        self.hostname = sanitize_hostname(info_domain["computername"], self.logger)
                         self.server_os = info_domain["os_guess"] + " Build " + str(info_domain["os_build"])
                         self.logger.extra["hostname"] = self.hostname
                     break

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -6,6 +6,7 @@ import struct
 import ipaddress
 from Cryptodome.Hash import MD4
 from textwrap import dedent
+from nxc.helpers.misc import sanitize_hostname
 
 from impacket.smbconnection import SMBConnection, SessionError
 from impacket.smb import SMB_DIALECT
@@ -200,6 +201,7 @@ class smb(connection):
                 self.hostname = dns_hostname
             else:
                 self.hostname = self.conn.getServerName()
+            self.hostname = sanitize_hostname(self.hostname, self.logger)
             self.targetDomain = self.conn.getServerDNSDomainName()
             if not self.targetDomain:   # Not sure if that can even happen but now we are safe
                 self.targetDomain = self.hostname

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -8,6 +8,7 @@ import ntpath
 import xml.etree.ElementTree as ET
 
 from pypsrp.wsman import NAMESPACES
+from nxc.helpers.misc import sanitize_hostname
 from pypsrp.client import Client
 from pypsrp.powershell import PSDataStreams
 from termcolor import colored
@@ -68,7 +69,7 @@ class winrm(connection):
             return False
 
         self.targetDomain = self.domain = ntlm_info["domain"]
-        self.hostname = ntlm_info["hostname"]
+        self.hostname = sanitize_hostname(ntlm_info["hostname"], self.logger)
         self.server_os = ntlm_info["os_version"]
         self.logger.extra["hostname"] = self.hostname
 

--- a/nxc/protocols/wmi.py
+++ b/nxc/protocols/wmi.py
@@ -2,6 +2,7 @@ import os
 from io import StringIO
 
 from nxc.helpers.negotiate_parser import parse_challenge
+from nxc.helpers.misc import sanitize_hostname
 from nxc.config import process_secret
 from nxc.connection import connection, dcom_FirewallChecker, requires_admin
 from nxc.logger import NXCAdapter
@@ -130,7 +131,7 @@ class wmi(connection):
             bindResp = MSRPCBindAck(response.getData())
             ntlm_info = parse_challenge(bindResp["auth_data"])
             self.targetDomain = self.domain = ntlm_info["domain"]
-            self.hostname = ntlm_info["hostname"]
+            self.hostname = sanitize_hostname(ntlm_info["hostname"], self.logger)
             self.server_os = ntlm_info["os_version"]
             self.logger.extra["hostname"] = self.hostname
         else:


### PR DESCRIPTION
## Description

Sanitize server-provided NTLM hostname before use in file paths or content. A rogue SMB/RDP/VNC server can set its NTLM `AV_NbComputerName` to malicious values (path traversal sequences, null bytes, newlines, format string characters), causing file creation outside `~/.nxc/logs/` or hosts file injection.

Single-line fix: strip all characters except `[a-zA-Z0-9_\-.]` from `self.hostname` immediately after `enum_host_info()` in `connection.py`.

Fixes GHSA-pv83-jh5v-7q4j and GHSA-qqmq-pwrw-2j2w.

### Affected Sinks (all fixed by this single change)

| Sink | File | Impact |
|------|------|--------|
| Credential dump output paths | connection.py:252 | Path traversal |
| DPAPI output | smb.py:2099 | Path traversal |
| SAM/LSA/NTDS output | smb.py (multiple) | Path traversal |
| RDP screenshots | rdp.py:592,620 | Path traversal |
| VNC screenshots | vnc.py:150 | Path traversal |
| `--generate-hosts-file` | smb.py:312 | Newline injection |
| `--generate-krb5-file` | smb.py:317 | Newline injection |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

**Bug trigger (path traversal):**
1. Run `poc-rogue-smb.py` (rogue SMB server with NTLM hostname `../../../tmp/evil`)
2. Run `nxc smb 127.0.0.1 --port 4470 -u guest -p '' --dpapi`
3. Observe file created at `~/evil_127.0.0.1_<timestamp>` instead of `~/.nxc/logs/dpapi/`

**Bug trigger (hosts file newline injection):**
1. Run rogue SMB server with NTLM hostname containing `\n10.13.37.99 dc01.corp.local`
2. Run `nxc smb 127.0.0.1 --port 4472 -u guest -p '' --generate-hosts-file /tmp/hosts`
3. Observe injected entries in `/tmp/hosts`

Tested on: Kali Linux, Python 3.13, NXC 1.5.0, Impacket 0.14.0.

## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)