### PR TITLE
Fix: persist credentials after Kerberos login (smb/mssql/ldap)

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -338,10 +338,10 @@ class ldap(connection):
 
             self.check_if_admin()
 
-            if password:
+            if password and self.username and not useCache:
                 self.logger.debug(f"Adding credential: {domain}/{self.username}:{self.password}")
                 self.db.add_credential("plaintext", domain, self.username, self.password)
-            elif ntlm_hash:
+            elif ntlm_hash and self.username and not useCache:
                 self.logger.debug(f"Adding credential: {domain}/{self.username}:{self.hash}")
                 self.db.add_credential("hash", domain, self.username, self.hash)
 
@@ -397,10 +397,10 @@ class ldap(connection):
 
                     self.check_if_admin()
 
-                    if password:
+                    if password and self.username and not useCache:
                         self.logger.debug(f"Adding credential: {domain}/{self.username}:{self.password}")
                         self.db.add_credential("plaintext", domain, self.username, self.password)
-                    elif ntlm_hash:
+                    elif ntlm_hash and self.username and not useCache:
                         self.logger.debug(f"Adding credential: {domain}/{self.username}:{self.hash}")
                         self.db.add_credential("hash", domain, self.username, self.hash)
 

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -204,6 +204,20 @@ class mssql(connection):
                 raise
             self.check_if_admin()
             self.logger.success(f"{self.domain}\\{self.username}{used_ccache} {self.mark_pwned()}")
+
+            cred_type = cred_value = None
+            if password:
+                cred_type, cred_value = "plaintext", password
+            elif self.nthash:
+                cred_type, cred_value = "hash", self.nthash
+            if cred_value and self.username and not useCache:
+                self.db.add_credential(cred_type, self.domain, self.username, cred_value)
+                user_id = self.db.get_credential(cred_type, self.domain, self.username, cred_value)
+                host_id = self.db.get_hosts(self.host)[0].id
+                self.db.add_loggedin_relation(user_id, host_id)
+                if self.admin_privs:
+                    self.db.add_admin_user(cred_type, self.domain, self.username, cred_value, self.host, user_id=user_id)
+
             if not self.args.local_auth and self.username != "":
                 add_user_bh(self.username, self.domain, self.logger, self.config)
             if self.admin_privs:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -403,6 +403,25 @@ class smb(connection):
             out = f"{self.domain}\\{self.username}{used_ccache} {self.mark_pwned()}"
             self.logger.success(out)
 
+            # Persist the credential we authenticated with (skip ccache and S4U-as-someone-else)
+            valid_auth = bool(self.username) and not useCache and not self.args.delegate
+            if valid_auth:
+                cred_type = cred_value = None
+                if password:
+                    cred_type, cred_value = "plaintext", password
+                elif nthash:
+                    cred_type = "hash"
+                    cred_value = f"{lmhash}:{nthash}" if lmhash else nthash
+                # aesKey: no matching credtype in DB schema, intentionally skipped
+                if cred_value:
+                    self.logger.debug(f"Adding credential: {domain}/{self.username}:{process_secret(cred_value)}")
+                    self.db.add_credential(cred_type, domain, self.username, cred_value)
+                    user_id = self.db.get_credential(cred_type, domain, self.username, cred_value)
+                    host_id = self.db.get_hosts(self.host)[0].id
+                    self.db.add_loggedin_relation(user_id, host_id)
+                    if self.admin_privs:
+                        self.db.add_admin_user(cred_type, domain, self.username, cred_value, self.host, user_id=user_id)
+
             if not self.args.local_auth and self.username != "" and not self.args.delegate:
                 add_user_bh(self.username, domain, self.logger, self.config)
             if self.admin_privs:


### PR DESCRIPTION
## Description

After a successful Kerberos authentication, credentials were not being saved to the NXC database for SMB and MSSQL. LDAP had the opposite issue: it was storing credentials even when authenticating from a ccache (`--use-kcache`), risking empty or incorrect entries.

- **SMB/MSSQL**: add credential storage (plaintext or hash), `loggedin` relation, and admin tracking after a successful Kerberos login
- **LDAP**: skip credential storage when `useCache=True` to avoid storing stale/empty credentials when using `--use-kcache`
- All three protocols share the same guard: skip if ccache, empty username, or `--delegate` (SMB)

No additional dependencies required.

This PR was created with the assistance of AI (Claude code, used for code
structure).
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

**Bug reproduction:**

Authenticate against a target using Kerberos with a password or NT hash:

```bash
nxc smb <target> -u <user> -p <password> -k
nxc mssql <target> -u <user> -p <password> -k
nxc ldap <target> -u <user> -p <password> -k
```

Before this fix, `nxc smb show creds` would not show the credential after a Kerberos login. After the fix it does.

For the LDAP regression, authenticate from an existing ccache and verify no empty credential is stored:

```bash
KRB5CCNAME=/tmp/user.ccache nxc ldap <target> --use-kcache
```

Tested on: Python 3.14, Arch Linux, against a Windows Server 2022 GOAD lab.

## Screenshots (if appropriate):
### Before
**SMB** 
<img width="1948" height="264" alt="image" src="https://github.com/user-attachments/assets/a03fd30c-4d2e-47ed-95a2-a964327d30d7" />
**MSSQL**
<img width="1674" height="261" alt="image" src="https://github.com/user-attachments/assets/0ad0ca9b-0071-4f7c-8154-21eecfafcd4f" />
**LDAP**
<img width="1847" height="306" alt="image" src="https://github.com/user-attachments/assets/0aae005a-028b-4108-975b-c4a5d92b93fe" />



### After
**SMB**
<img width="1957" height="309" alt="image" src="https://github.com/user-attachments/assets/f0ef7591-a5c1-4e7e-881f-443921541a45" />
**MSSQL**
<img width="1851" height="306" alt="image" src="https://github.com/user-attachments/assets/0c43f440-7457-4435-a2fc-f83b9775d044" />

**LDAP**
<img width="1851" height="284" alt="image" src="https://github.com/user-attachments/assets/ebccc079-66fd-430d-95f6-f4d0d91f1f35" />



## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas