### PR TITLE
Refactor TSCH_EXEC and SMBEXEC

### DIFF
--- a/nxc/modules/schtask_as.py
+++ b/nxc/modules/schtask_as.py
@@ -173,25 +173,15 @@ class NXCModule:
         self.logger.display("Connecting to the remote Service control endpoint")
         try:
             exec_method = TSCH_EXEC(
-                connection.host if not connection.kerberos else connection.hostname + "." + connection.domain,
-                connection.smb_share_name,
-                connection.username,
-                connection.password,
-                connection.domain,
-                connection.kerberos,
-                connection.aesKey,
-                connection.host,
-                connection.kdcHost,
-                connection.hash,
-                self.logger,
-                connection.args.get_output_tries,
-                connection.args.share,
-                self.run_task_as,
-                self.command_to_run,
-                self.output_filename,
-                self.task_name,
-                self.output_file_location,
                 connection=connection,
+                logger=self.logger,
+                tries=connection.args.get_output_tries,
+                share=connection.args.share,
+                run_task_as=self.run_task_as,
+                run_cmd=self.command_to_run,
+                output_filename=self.output_filename,
+                task_name=self.task_name,
+                output_file_location=self.output_file_location,
             )
 
             if self.show_output is False:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -902,20 +902,10 @@ class smb(connection):
             elif method == "atexec":
                 try:
                     exec_method = TSCH_EXEC(
-                        self.host if not self.kerberos else self.hostname + "." + self.domain,
-                        self.smb_share_name,
-                        self.username,
-                        self.password,
-                        self.domain,
-                        self.kerberos,
-                        self.aesKey,
-                        self.host,
-                        self.kdcHost,
-                        self.hash,
-                        self.logger,
-                        self.args.get_output_tries,
-                        self.args.share,
                         connection=self,
+                        logger=self.logger,
+                        tries=self.args.get_output_tries,
+                        share=self.args.share,
                     )
                     self.logger.info("Executed command via atexec")
                     break
@@ -926,22 +916,10 @@ class smb(connection):
             elif method == "smbexec":
                 try:
                     exec_method = SMBEXEC(
-                        self.host if not self.kerberos else self.hostname + "." + self.domain,
-                        self.smb_share_name,
-                        self.conn,
-                        self.username,
-                        self.password,
-                        self.domain,
-                        self.kerberos,
-                        self.aesKey,
-                        self.host,
-                        self.kdcHost,
-                        self.hash,
-                        self.args.share,
-                        self.port,
-                        self.logger,
-                        self.args.get_output_tries,
                         connection=self,
+                        share=self.args.share,
+                        logger=self.logger,
+                        tries=self.args.get_output_tries,
                     )
                     self.logger.info("Executed command via smbexec")
                     break

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -4,37 +4,26 @@ from datetime import datetime, timedelta
 from textwrap import dedent
 from time import sleep
 
-from impacket.dcerpc.v5 import transport, tsch
+from impacket.dcerpc.v5 import tsch
 from impacket.dcerpc.v5.dtypes import NULL
-from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE, RPC_C_AUTHN_LEVEL_PKT_PRIVACY
+from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 
 from nxc.helpers.misc import gen_random_string
 from nxc.helpers.rpc import NXCRPCConnection
 
 
 class TSCH_EXEC:
-    def __init__(self, target, share_name, username, password, domain, doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, logger=None, tries=None, share=None,
+    def __init__(self, connection, logger=None, tries=None, share=None,
                  # These options are used by the schtask_as module, except the run_task_as
                  # that defaults to NT AUTHORITY\System user (SID S-1-5-18) if not specified
-                 run_task_as="S-1-5-18", run_cmd=None, output_filename=None, task_name=None, output_file_location=None, connection=None):
-        self.__target = target
-        self.__username = username
-        self.__password = password
-        self.__domain = domain
-        self.__share_name = share_name
-        self.__lmhash = ""
-        self.__nthash = ""
+                 run_task_as="S-1-5-18", run_cmd=None, output_filename=None, task_name=None, output_file_location=None):
+        self.__connection = connection
         self.__outputBuffer = b""
         self.__retOutput = False
-        self.__aesKey = aesKey
-        self.__doKerberos = doKerberos
-        self.__remoteHost = remoteHost
-        self.__kdcHost = kdcHost
         self.__tries = tries
         self.__output_filename = None
         self.__share = share
         self.logger = logger
-        self.__connection = connection
 
         # Optional args for finetuning the task execution, e.g. used in nxc/modules/schtask_as.py
         self.task_name = task_name if task_name else gen_random_string(8)
@@ -42,32 +31,6 @@ class TSCH_EXEC:
         self.run_cmd = run_cmd
         self.output_filename = output_filename
         self.output_file_location = output_file_location
-
-        if hashes is not None:
-            # This checks to see if we didn't provide the LM Hash
-            if hashes.find(":") != -1:
-                self.__lmhash, self.__nthash = hashes.split(":")
-            else:
-                self.__nthash = hashes
-
-        if self.__password is None:
-            self.__password = ""
-
-        if not self.__connection:
-            stringbinding = rf"ncacn_np:{self.__target}[\pipe\atsvc]"
-            self.__rpctransport = transport.DCERPCTransportFactory(stringbinding)
-            self.__rpctransport.setRemoteHost(self.__remoteHost)
-
-            if hasattr(self.__rpctransport, "set_credentials"):
-                self.__rpctransport.set_credentials(
-                    self.__username,
-                    self.__password,
-                    self.__domain,
-                    self.__lmhash,
-                    self.__nthash,
-                    self.__aesKey,
-                )
-                self.__rpctransport.set_kerberos(self.__doKerberos, self.__kdcHost)
 
     def execute(self, command, output=False):
         self.__retOutput = output
@@ -176,23 +139,12 @@ class TSCH_EXEC:
         return dedent(xml)
 
     def execute_handler(self, command):
-        if self.__connection:
-            dce = NXCRPCConnection(self.__connection).connect(r"\atsvc", tsch.MSRPC_UUID_TSCHS, auth_level=RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-        else:
-            dce = self.__rpctransport.get_dce_rpc()
-            if self.__doKerberos:
-                dce.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
-            dce.set_credentials(*self.__rpctransport.get_credentials())
-            dce.connect()
+        dce = NXCRPCConnection(self.__connection).connect(r"\atsvc", tsch.MSRPC_UUID_TSCHS, auth_level=RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
 
         xml = self.gen_xml(command)
         self.logger.debug(f"Task XML: {xml}")
         self.logger.info(f"Creating task \\{self.task_name}")
         try:
-            if not self.__connection:
-                # Windows server 2003 has no MSRPC_UUID_TSCHS, if it bind, it will return abstract_syntax_not_supported
-                dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-                dce.bind(tsch.MSRPC_UUID_TSCHS)
             tsch.hSchRpcRegisterTask(dce, f"\\{self.task_name}", xml, tsch.TASK_CREATE, NULL, tsch.TASK_LOGON_NONE)
         except Exception as e:
             if e.error_code and hex(e.error_code) == "0x80070005":
@@ -219,10 +171,7 @@ class TSCH_EXEC:
         tsch.hSchRpcDelete(dce, f"\\{self.task_name}")
 
         if self.__retOutput:
-            if self.__connection:
-                smbConnection = self.__connection.conn
-            else:
-                smbConnection = self.__rpctransport.get_smb_connection()
+            smbConnection = self.__connection.conn
             tries = 1
             # Give the command a bit of time to execute before we try to read the output, 0.4 seconds was good in testing
             sleep(0.4)

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -171,14 +171,13 @@ class TSCH_EXEC:
         tsch.hSchRpcDelete(dce, f"\\{self.task_name}")
 
         if self.__retOutput:
-            smbConnection = self.__connection.conn
             tries = 1
             # Give the command a bit of time to execute before we try to read the output, 0.4 seconds was good in testing
             sleep(0.4)
             while True:
                 try:
                     self.logger.info(f"Attempting to read {self.__share}\\{self.__output_filename}")
-                    smbConnection.getFile(self.__share, self.__output_filename, self.output_callback)
+                    self.__connection.conn.getFile(self.__share, self.__output_filename, self.output_callback)
                     break
                 except Exception as e:
                     if tries >= self.__tries:
@@ -206,7 +205,7 @@ class TSCH_EXEC:
                         sleep(1)
             try:
                 self.logger.debug(f"Deleting file {self.__share}\\{self.__output_filename}")
-                smbConnection.deleteFile(self.__share, self.__output_filename)
+                self.__connection.conn.deleteFile(self.__share, self.__output_filename)
             except Exception:
                 pass
 

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -18,12 +18,12 @@ class TSCH_EXEC:
                  # that defaults to NT AUTHORITY\System user (SID S-1-5-18) if not specified
                  run_task_as="S-1-5-18", run_cmd=None, output_filename=None, task_name=None, output_file_location=None):
         self.__connection = connection
+        self.logger = logger
+        self.__tries = tries
+        self.__share = share
         self.__outputBuffer = b""
         self.__retOutput = False
-        self.__tries = tries
         self.__output_filename = None
-        self.__share = share
-        self.logger = logger
 
         # Optional args for finetuning the task execution, e.g. used in nxc/modules/schtask_as.py
         self.task_name = task_name if task_name else gen_random_string(8)

--- a/nxc/protocols/smb/smbexec.py
+++ b/nxc/protocols/smb/smbexec.py
@@ -1,79 +1,28 @@
 import os
 from os.path import join as path_join
 from time import sleep
-from impacket.dcerpc.v5 import transport, scmr
-from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_GSS_NEGOTIATE
+from impacket.dcerpc.v5 import scmr
 from nxc.helpers.misc import gen_random_string
 from nxc.paths import TMP_PATH
 from nxc.helpers.rpc import NXCRPCConnection
 
 
 class SMBEXEC:
-    def __init__(self, host, share_name, smbconnection, username="", password="", domain="", doKerberos=False, aesKey=None, remoteHost=None, kdcHost=None, hashes=None, share=None, port=445, logger=None, tries=None, connection=None):
-        self.__host = host
-        self.__share_name = share_name
-        self.__port = port
-        self.__username = username
-        self.__password = password
+    def __init__(self, connection, share=None, logger=None, tries=None):
         self.__serviceName = gen_random_string()
-        self.__domain = domain
-        self.__lmhash = ""
-        self.__nthash = ""
         self.__share = share
-        self.__smbconnection = smbconnection
         self.__output = None
         self.__batchFile = None
         self.__outputBuffer = b""
         self.__shell = "%COMSPEC% /Q /c "
         self.__retOutput = False
-        self.__scmr = None
-        self.__aesKey = aesKey
-        self.__doKerberos = doKerberos
-        self.__remoteHost = remoteHost
-        self.__kdcHost = kdcHost
         self.__tries = tries
         self.logger = logger
         self.__connection = connection
 
-        if hashes is not None:
-            # This checks to see if we didn't provide the LM Hash
-            if hashes.find(":") != -1:
-                self.__lmhash, self.__nthash = hashes.split(":")
-            else:
-                self.__nthash = hashes
-
-        if self.__password is None:
-            self.__password = ""
-
-        if self.__connection:
-            rpc = NXCRPCConnection(self.__connection)
-            self.__scmr = rpc.connect(r"\svcctl", scmr.MSRPC_UUID_SCMR)
-            self.__rpctransport = rpc.transport
-        else:
-            stringbinding = f"ncacn_np:{self.__host}[\\pipe\\svcctl]"
-            self.logger.debug(f"StringBinding {stringbinding}")
-            self.__rpctransport = transport.DCERPCTransportFactory(stringbinding)
-            self.__rpctransport.set_dport(self.__port)
-
-            if hasattr(self.__rpctransport, "setRemoteHost"):
-                self.__rpctransport.setRemoteHost(self.__remoteHost)
-
-            if hasattr(self.__rpctransport, "set_credentials"):
-                self.__rpctransport.set_credentials(
-                    self.__username,
-                    self.__password,
-                    self.__domain,
-                    self.__lmhash,
-                    self.__nthash,
-                    self.__aesKey,
-                )
-                self.__rpctransport.set_kerberos(self.__doKerberos, self.__kdcHost)
-
-            self.__scmr = self.__rpctransport.get_dce_rpc()
-            if self.__doKerberos:
-                self.__scmr.set_auth_type(RPC_C_AUTHN_GSS_NEGOTIATE)
-            self.__scmr.connect()
-            self.__scmr.bind(scmr.MSRPC_UUID_SCMR)
+        rpc = NXCRPCConnection(self.__connection)
+        self.__scmr = rpc.connect(r"\svcctl", scmr.MSRPC_UUID_SCMR)
+        self.__rpctransport = rpc.transport
 
         s = self.__rpctransport.get_smb_connection()
         # We don't wanna deal with timeouts from now on.
@@ -148,10 +97,11 @@ class SMBEXEC:
             return
 
         tries = 1
+        smbConnection = self.__connection.conn
         while True:
             try:
                 self.logger.info(f"Attempting to read {self.__share}\\{self.__output}")
-                self.__smbconnection.getFile(self.__share, self.__output, self.output_callback)
+                smbConnection.getFile(self.__share, self.__output, self.output_callback)
                 break
             except Exception as e:
                 if tries >= self.__tries:
@@ -180,57 +130,9 @@ class SMBEXEC:
 
         try:
             self.logger.debug(f"Deleting file {self.__share}\\{self.__output}")
-            self.__smbconnection.deleteFile(self.__share, self.__output)
+            smbConnection.deleteFile(self.__share, self.__output)
         except Exception:
             pass
-
-    def execute_fileless(self, data):
-        self.__output = gen_random_string(6)
-        self.__batchFile = gen_random_string(6) + ".bat"
-        local_ip = self.__rpctransport.get_socket().getsockname()[0]
-
-        command = self.__shell + data + f" ^> \\\\{local_ip}\\{self.__share_name}\\{self.__output}" if self.__retOutput else self.__shell + data
-
-        with open(path_join(TMP_PATH, self.__batchFile), "w") as batch_file:
-            batch_file.write(command)
-
-        self.logger.debug("Hosting batch file with command: " + command)
-
-        command = self.__shell + f"\\\\{local_ip}\\{self.__share_name}\\{self.__batchFile}"
-        self.logger.debug("Command to execute: " + command)
-
-        self.logger.debug(f"Remote service {self.__serviceName} created.")
-        resp = scmr.hRCreateServiceW(
-            self.__scmr,
-            self.__scHandle,
-            self.__serviceName,
-            self.__serviceName,
-            lpBinaryPathName=command,
-            dwStartType=scmr.SERVICE_DEMAND_START,
-        )
-        service = resp["lpServiceHandle"]
-
-        try:
-            self.logger.debug(f"Remote service {self.__serviceName} started.")
-            scmr.hRStartServiceW(self.__scmr, service)
-        except Exception:
-            pass
-        self.logger.debug(f"Remote service {self.__serviceName} deleted.")
-        scmr.hRDeleteService(self.__scmr, service)
-        scmr.hRCloseServiceHandle(self.__scmr, service)
-        self.get_output_fileless()
-
-    def get_output_fileless(self):
-        if not self.__retOutput:
-            return
-
-        while True:
-            try:
-                with open(path_join(TMP_PATH, self.__output), "rb") as output:
-                    self.output_callback(output.read())
-                break
-            except OSError:
-                sleep(2)
 
     def finish(self):
         # Just in case the service is still created

--- a/nxc/protocols/smb/smbexec.py
+++ b/nxc/protocols/smb/smbexec.py
@@ -9,16 +9,17 @@ from nxc.helpers.rpc import NXCRPCConnection
 
 class SMBEXEC:
     def __init__(self, connection, share=None, logger=None, tries=None):
-        self.__serviceName = gen_random_string()
+        self.__connection = connection
         self.__share = share
+        self.logger = logger
+        self.__tries = tries
+
+        self.__serviceName = gen_random_string()
         self.__output = None
         self.__batchFile = None
         self.__outputBuffer = b""
         self.__shell = "%COMSPEC% /Q /c "
         self.__retOutput = False
-        self.__tries = tries
-        self.logger = logger
-        self.__connection = connection
 
         rpc = NXCRPCConnection(self.__connection)
         self.__scmr = rpc.connect(r"\svcctl", scmr.MSRPC_UUID_SCMR)

--- a/nxc/protocols/smb/smbexec.py
+++ b/nxc/protocols/smb/smbexec.py
@@ -98,11 +98,10 @@ class SMBEXEC:
             return
 
         tries = 1
-        smbConnection = self.__connection.conn
         while True:
             try:
                 self.logger.info(f"Attempting to read {self.__share}\\{self.__output}")
-                smbConnection.getFile(self.__share, self.__output, self.output_callback)
+                self.__connection.conn.getFile(self.__share, self.__output, self.output_callback)
                 break
             except Exception as e:
                 if tries >= self.__tries:
@@ -131,7 +130,7 @@ class SMBEXEC:
 
         try:
             self.logger.debug(f"Deleting file {self.__share}\\{self.__output}")
-            smbConnection.deleteFile(self.__share, self.__output)
+            self.__connection.conn.deleteFile(self.__share, self.__output)
         except Exception:
             pass
 

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -66,7 +66,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --force-ps32 --obfs --amsi-bypass AMSI_BYPASS_FILE --no-encode --exec-method smbexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --force-ps32 --obfs --amsi-bypass AMSI_BYPASS_FILE --no-encode --exec-method mmcexec
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --clear-obfscripts # current we don't really use?
-netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --wmi "select Name from win32_computersystem"
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --wmi-query "select Name from win32_computersystem"
 netexec --jitter 2 smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS
 netexec --jitter 1-3 smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS
 netexec --jitter 2-2 smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS


### PR DESCRIPTION
## Description

Following [#1191](https://github.com/Pennyw0rth/NetExec/pull/1191), this PR cleans up `TSCH_EXEC` and `SMBEXEC` by removing duplicate authentication parameters (username, password, hashes, share_name, etc.) and the legacy manual RPC transport setup, since `NXCRPCConnection` now handles credentials via the SMB connection object. Call sites in `smb.py` and `schtask_as.py` are updated accordingly, and unused `execute_fileless` code is removed from `SMBEXEC`

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

- `nxc smb <IP> -u <user> -p '<pass>' --exec-method smbexec -x whoami`

- `nxc smb <IP> -u <user> -p '<pass>' --exec-method smbexec -x whoami --no-output`

- `nxc smb <IP> -u <user> -p '<pass>' --exec-method smbexec -X "Get-Date; hostname"`

- `nxc smb <IP> -u <user> -p '<pass>' --exec-method atexec -x whoami`

- `nxc smb <IP> -u <user> -p '<pass>' --exec-method atexec -x whoami --no-output`

- `nxc smb <IP> -u <user> -p '<pass>' --exec-method atexec -X "hostname; whoami"`

- `nxc smb <IP> -u <user> -p '<pass>' -M schtask_as -o USER=Administrator CMD=whoami`

- `nxc smb <IP> -u <user> -p '<pass>' -M schtask_as -o USER=Administrator CMD=whoami SILENTCOMMAND=True`


## Screenshots (if appropriate):

I ran several tests, and it sounds good to me : 

<img width="1896" height="715" alt="image" src="https://github.com/user-attachments/assets/188f5644-a914-4e42-946e-1d73c23973a5" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
