### PR TITLE
Fix atexec task execution on 2025 servers

### DIFF
--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -156,16 +156,25 @@ class TSCH_EXEC:
             return
 
         try:
-            done = False
-            while not done:
-                self.logger.debug(f"Calling SchRpcGetLastRunInfo for \\{self.task_name}")
-                resp = tsch.hSchRpcGetLastRunInfo(dce, f"\\{self.task_name}")
-                if resp["pLastRuntime"]["wYear"] != 0:
-                    done = True
-                else:
-                    sleep(2)
+            tsch.hSchRpcRun(dce, f"\\{self.task_name}")
         except tsch.DCERPCSessionError as e:
-            self.logger.fail(f"Error retrieving task last run info: {e}")
+            self.logger.debug(f"hSchRpcRun returned: {e}")
+
+        done = False
+        while not done:
+            self.logger.debug(f"Calling SchRpcGetLastRunInfo for \\{self.task_name}")
+            try:
+                resp = tsch.hSchRpcGetLastRunInfo(dce, f"\\{self.task_name}")
+            except tsch.DCERPCSessionError as e:
+                if e.error_code == 0x00041303:
+                    sleep(2)
+                    continue
+                self.logger.fail(f"Error retrieving task last run info: {e}")
+                break
+            if resp["pLastRuntime"]["wYear"] != 0:
+                done = True
+            else:
+                sleep(2)
 
         self.logger.info(f"Deleting task \\{self.task_name}")
         tsch.hSchRpcDelete(dce, f"\\{self.task_name}")

--- a/nxc/protocols/smb/atexec.py
+++ b/nxc/protocols/smb/atexec.py
@@ -155,10 +155,12 @@ class TSCH_EXEC:
                 self.logger.fail(str(e))
             return
 
-        try:
-            tsch.hSchRpcRun(dce, f"\\{self.task_name}")
-        except tsch.DCERPCSessionError as e:
-            self.logger.debug(f"hSchRpcRun returned: {e}")
+        # Win2025+ (build 26100): RegistrationTrigger does not start the task over remote TSCH.
+        if self.__connection.server_os_build and int(self.__connection.server_os_build) >= 26100:
+            try:
+                tsch.hSchRpcRun(dce, f"\\{self.task_name}")
+            except tsch.DCERPCSessionError as e:
+                self.logger.debug(f"hSchRpcRun returned: {e}")
 
         done = False
         while not done:


### PR DESCRIPTION
## Description

Fixes `TSCH_EXEC / schtask_as` on recent Windows (e.g. Server 2025) by calling `hSchRpcRun` after task registration (as impacket’s atexec does) and treating `SCHED_S_TASK_HAS_NOT_RUN (0x41303)` as a transient state during `SchRpcGetLastRunInfo` polling instead of failing and deleting the task early.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

run `nxc smb 192.168.56.100 -u 'user' -p 'password' -M schtask_as -o USER='user'' CMD='whoami'`

## Screenshots (if appropriate):

Before : 

<img width="1815" height="188" alt="image" src="https://github.com/user-attachments/assets/5d03c3a8-713f-40a8-800f-451c04b78dd1" />

After : 

<img width="1813" height="165" alt="image" src="https://github.com/user-attachments/assets/72ae1909-8c28-49ee-862d-5ce9c59e2ac1" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [X] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
