### PR TITLE
QoL DPAPI - Log message when empty

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -2215,9 +2215,8 @@ class smb(connection):
         if self.output_file:
             self.output_file.close()
             with open(self.output_file_template.format(output_folder="dpapi")) as f:
-                count = sum(1 for _ in f)
-                if count == 0:
-                    self.logger.fail("No loot retrieved")
+                if sum(1 for _ in f) == 0:
+                    self.logger.fail("No dpapi loot retrieved")
 
     @requires_admin
     def list_snapshots(self):

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -2214,6 +2214,10 @@ class smb(connection):
 
         if self.output_file:
             self.output_file.close()
+            with open(self.output_file_template.format(output_folder="dpapi")) as f:
+                count = sum(1 for _ in f)
+                if count == 0:
+                    self.logger.fail("No loot retrieved")
 
     @requires_admin
     def list_snapshots(self):


### PR DESCRIPTION
## Description:
Add a simple comment in --dpapi option for SMB, requested by issue #1076. As for now, the message is displayed as `.fail()` in order to be visible, but it can be `.info()` like mentionned in the issue. 

The technique used maybe not the most efficient but it doesn't add to much code.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review:

- User with sufficient rights to collect masterkeys
- No DPAPI secrets on the target

## Screenshots:

<img width="1723" height="99" alt="image" src="https://github.com/user-attachments/assets/9a6cbd64-0f65-49ce-ab9c-089962bcc0b5" />

## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
