### PR TITLE
Add reg-query support for MSSQL

### DIFF
--- a/nxc/modules/reg-query.py
+++ b/nxc/modules/reg-query.py
@@ -153,6 +153,12 @@ class NXCModule:
 
     def _registry_mssql(self, context, connection, hive, subpath, key):
         if self.delete:
+            query = f"EXEC xp_regread N'{hive}', N'{subpath}', N'{key}';"
+            rows = connection.conn.sql_query(query)
+            if not rows:
+                context.log.fail(f"Registry key {key} does not exist")
+                return
+
             query = f"EXEC xp_regdeletevalue N'{hive}', N'{subpath}', N'{key}';"
             connection.conn.sql_query(query)
             if connection.conn.lastError:

--- a/nxc/modules/reg-query.py
+++ b/nxc/modules/reg-query.py
@@ -54,11 +54,13 @@ class NXCModule:
             self.path = module_options["PATH"]
         else:
             context.log.fail("Please provide the path of the registry to query (PATH)")
+            return
 
         if module_options and "KEY" in module_options:
             self.key = module_options["KEY"]
         else:
             context.log.fail("Please provide the registry key to query (KEY)")
+            return
 
         if "VALUE" in module_options:
             self.value = module_options["VALUE"]
@@ -153,23 +155,37 @@ class NXCModule:
         if self.delete:
             query = f"EXEC xp_regdeletevalue N'{hive}', N'{subpath}', N'{key}';"
             connection.conn.sql_query(query)
-            context.log.success(f"Registry value {key} deleted")
+            if connection.conn.lastError:
+                context.log.fail(f"Failed to call xp_regdeletevalue: {connection.conn.lastError}")
+                return
+            else:
+                context.log.success(f"Registry key {key} has been deleted successfully")
             return
 
         if self.value is not None:
             type_str = self.REG_TYPE_MAP.get(self.type, "REG_SZ")
             query = f"EXEC xp_regwrite N'{hive}', N'{subpath}', N'{key}', N'{type_str}', N'{self.value!s}';"
             connection.conn.sql_query(query)
-            context.log.success(f"Registry value {key} set to {self.value}")
+            if connection.conn.lastError:
+                context.log.fail(f"Failed to call xp_regwrite: {connection.conn.lastError}")
+                return
+            else:
+                context.log.success(f"Registry value {key} set to {self.value}")
             return
 
         query = f"EXEC xp_regread N'{hive}', N'{subpath}', N'{key}';"
         rows = connection.conn.sql_query(query)
-        if not rows:
-            context.log.fail(f"No result for {subpath}\\{key}")
+        if connection.conn.lastError:
+            context.log.fail(f"Failed to call xp_regread: {connection.conn.lastError}")
             return
-        for row in rows:
-            context.log.highlight(f"{key}: {row}")
+        else:
+            if not rows:
+                context.log.fail(f"No result for {subpath}\\{key}")
+                return
+            for row in rows:
+                value = row.get("Value")
+                data = row.get("Data")
+                context.log.highlight(f"{value}: {data}")
 
     def on_admin_login(self, context, connection):
         hive, subpath = self._parse_registry_path(self.path)

--- a/nxc/modules/reg-query.py
+++ b/nxc/modules/reg-query.py
@@ -3,17 +3,32 @@ from impacket.dcerpc.v5 import rrp
 from impacket.examples.secretsdump import RemoteOperations
 from nxc.helpers.misc import CATEGORY
 
+# Modified by @Deft_ to add support for the MSSQL protocol
+
 
 class NXCModule:
     name = "reg-query"
     description = "Performs a registry query on the machine"
-    supported_protocols = ["smb"]
+    supported_protocols = ["smb", "mssql"]
     category = CATEGORY.ENUMERATION
+
+    REG_TYPE_MAP = {
+        rrp.REG_NONE: "REG_NONE",
+        rrp.REG_SZ: "REG_SZ",
+        rrp.REG_EXPAND_SZ: "REG_EXPAND_SZ",
+        rrp.REG_BINARY: "REG_BINARY",
+        rrp.REG_DWORD: "REG_DWORD",
+        rrp.REG_DWORD_BIG_ENDIAN: "REG_DWORD",
+        rrp.REG_LINK: "REG_SZ",
+        rrp.REG_MULTI_SZ: "REG_MULTI_SZ",
+        rrp.REG_QWORD: "REG_QWORD",
+    }
+    REG_TYPE_MAP_INV = {v: k for k, v in REG_TYPE_MAP.items()}
 
     def __init__(self, context=None, module_options=None):
         self.context = context
         self.module_options = module_options
-        self.delete = None
+        self.delete = False
         self.type = None
         self.value = None
         self.key = None
@@ -26,10 +41,9 @@ class NXCModule:
         VALUE   Registry key value to set (only used for modification)
                 Will add a new registry key if the registry key does not already exist
         TYPE    Type of registry to modify, add or delete. Default type : REG_SZ.
-                Type supported: REG_NONE, REG_SZ, REG_EXPAND_SZ,REG_BINARY, REG_DWORD, REG_DWORD_BIG_ENDIAN, REG_LINK, REG_MULTI_SZ, REG_QWORD
+                Type supported: REG_NONE, REG_SZ, REG_EXPAND_SZ, REG_BINARY, REG_DWORD, REG_DWORD_BIG_ENDIAN, REG_LINK, REG_MULTI_SZ, REG_QWORD
         DELETE  If set to True, delete a registry key if it does exist
         """
-        self.context = context
         self.path = None
         self.key = None
         self.value = None
@@ -38,125 +52,132 @@ class NXCModule:
 
         if module_options and "PATH" in module_options:
             self.path = module_options["PATH"]
+        else:
+            context.log.fail("Please provide the path of the registry to query (PATH)")
 
         if module_options and "KEY" in module_options:
             self.key = module_options["KEY"]
+        else:
+            context.log.fail("Please provide the registry key to query (KEY)")
 
         if "VALUE" in module_options:
             self.value = module_options["VALUE"]
             if "TYPE" in module_options:
-                type_dict = {
-                    "REG_NONE": rrp.REG_NONE,
-                    "REG_SZ": rrp.REG_SZ,
-                    "REG_EXPAND_SZ": rrp.REG_EXPAND_SZ,
-                    "REG_BINARY": rrp.REG_BINARY,
-                    "REG_DWORD": rrp.REG_DWORD,
-                    "REG_DWORD_BIG_ENDIAN": rrp.REG_DWORD_BIG_ENDIAN,
-                    "REG_LINK": rrp.REG_LINK,
-                    "REG_MULTI_SZ": rrp.REG_MULTI_SZ,
-                    "REG_QWORD": rrp.REG_QWORD,
-                }
-                self.type = module_options["TYPE"]
-                if "WORD" in self.type:
+                type_str = module_options["TYPE"]
+                if "WORD" in type_str:
                     try:
                         self.value = int(self.value)
                     except Exception as e:
-                        context.log.fail(f"Invalid registry value type specified: {self.value}: {e}")
+                        context.log.fail(f"Invalid registry value: {self.value}: {e}")
                         return
-                if self.type in type_dict:
-                    self.type = type_dict[self.type]
+                if type_str in self.REG_TYPE_MAP_INV:
+                    self.type = self.REG_TYPE_MAP_INV[type_str]
                 else:
-                    context.log.fail(f"Invalid registry value type specified: {self.type}")
+                    context.log.fail(f"Invalid registry value type specified: {type_str}")
                     return
             else:
-                self.type = 1
+                self.type = rrp.REG_SZ
 
         if module_options and "DELETE" in module_options and module_options["DELETE"].lower() == "true":
             self.delete = True
 
-    def on_admin_login(self, context, connection):
-        self.context = context
-        if not self.path:
-            self.context.log.fail("Please provide the path of the registry to query")
-            return
-        if not self.key:
-            self.context.log.fail("Please provide the registry key to query")
-            return
+    def _parse_registry_path(self, full_path):
+        hive_map = {
+            "HKEY_LOCAL_MACHINE": "HKEY_LOCAL_MACHINE",
+            "HKEY_CURRENT_USER": "HKEY_CURRENT_USER",
+            "HKEY_CLASSES_ROOT": "HKEY_CLASSES_ROOT",
+            "HKLM": "HKEY_LOCAL_MACHINE",
+            "HKCU": "HKEY_CURRENT_USER",
+            "HKCR": "HKEY_CLASSES_ROOT",
+        }
+        upper = full_path.upper()
+        for prefix, full_hive in hive_map.items():
+            if upper.startswith(prefix):
+                subpath = full_path[len(prefix):].lstrip("\\")
+                return full_hive, subpath
+        return None, None
 
+    def _registry_smb(self, context, connection, hive, subpath, key):
         remote_ops = RemoteOperations(connection.conn, False)
         remote_ops.enableRegistry()
-
         try:
-            if "HKLM" in self.path or "HKEY_LOCAL_MACHINE" in self.path:
-                self.path = self.path.replace("HKLM\\", "")
-                ans = rrp.hOpenLocalMachine(remote_ops._RemoteOperations__rrp)
-            elif "HKCU" in self.path or "HKEY_CURRENT_USER" in self.path:
-                self.path = self.path.replace("HKCU\\", "")
-                ans = rrp.hOpenCurrentUser(remote_ops._RemoteOperations__rrp)
-            elif "HKCR" in self.path or "HKEY_CLASSES_ROOT" in self.path:
-                self.path = self.path.replace("HKCR\\", "")
-                ans = rrp.hOpenClassesRoot(remote_ops._RemoteOperations__rrp)
-            else:
-                self.context.log.fail(f"Unsupported registry hive specified in path: {self.path}")
+            hive_openers = {
+                "HKEY_LOCAL_MACHINE": rrp.hOpenLocalMachine,
+                "HKEY_CURRENT_USER": rrp.hOpenCurrentUser,
+                "HKEY_CLASSES_ROOT": rrp.hOpenClassesRoot,
+            }
+            if hive not in hive_openers:
+                context.log.fail(f"Unsupported registry hive: {hive}")
                 return
-
+            ans = hive_openers[hive](remote_ops._RemoteOperations__rrp)
             reg_handle = ans["phKey"]
-            ans = rrp.hBaseRegOpenKey(remote_ops._RemoteOperations__rrp, reg_handle, self.path)
+            ans = rrp.hBaseRegOpenKey(remote_ops._RemoteOperations__rrp, reg_handle, subpath)
             key_handle = ans["phkResult"]
 
             if self.delete:
-                # Delete registry
                 try:
-                    # Check if value exists
-                    data_type, reg_value = rrp.hBaseRegQueryValue(remote_ops._RemoteOperations__rrp, key_handle, self.key)
+                    rrp.hBaseRegQueryValue(remote_ops._RemoteOperations__rrp, key_handle, key)
                 except Exception as e:
-                    self.context.log.fail(f"Registry key {self.key} does not exist: {e}")
+                    context.log.fail(f"Registry key {key} does not exist: {e}")
                     return
-                # Delete value
-                rrp.hBaseRegDeleteValue(remote_ops._RemoteOperations__rrp, key_handle, self.key)
-                self.context.log.success(f"Registry key {self.key} has been deleted successfully")
+                rrp.hBaseRegDeleteValue(remote_ops._RemoteOperations__rrp, key_handle, key)
+                context.log.success(f"Registry key {key} has been deleted successfully")
                 rrp.hBaseRegCloseKey(remote_ops._RemoteOperations__rrp, key_handle)
+                return
 
             if self.value is not None:
-                # Check if value exists
                 try:
-                    # Check if value exists
-                    data_type, reg_value = rrp.hBaseRegQueryValue(remote_ops._RemoteOperations__rrp, key_handle, self.key)
-                    self.context.log.highlight(f"Key {self.key} exists with value {reg_value}")
-                    # Modification
-                    rrp.hBaseRegSetValue(
-                        remote_ops._RemoteOperations__rrp,
-                        key_handle,
-                        self.key,
-                        self.type,
-                        self.value,
-                    )
-                    self.context.log.success(f"Key {self.key} has been modified to {self.value}")
+                    _, reg_value = rrp.hBaseRegQueryValue(remote_ops._RemoteOperations__rrp, key_handle, key)
+                    context.log.highlight(f"Key {key} exists with value {reg_value}")
                 except Exception:
-                    rrp.hBaseRegSetValue(
-                        remote_ops._RemoteOperations__rrp,
-                        key_handle,
-                        self.key,
-                        self.type,
-                        self.value,
-                    )
-                    self.context.log.success(f"New Key {self.key} has been added with value {self.value}")
-                    rrp.hBaseRegCloseKey(remote_ops._RemoteOperations__rrp, key_handle)
+                    pass
+                rrp.hBaseRegSetValue(remote_ops._RemoteOperations__rrp, key_handle, key, self.type, self.value)
+                context.log.success(f"Key {key} has been set to {self.value}")
             else:
-                # Query
                 try:
-                    data_type, reg_value = rrp.hBaseRegQueryValue(remote_ops._RemoteOperations__rrp, key_handle, self.key)
-                    self.context.log.highlight(f"{self.key}: {reg_value}")
+                    _, reg_value = rrp.hBaseRegQueryValue(remote_ops._RemoteOperations__rrp, key_handle, key)
+                    context.log.highlight(f"{key}: {reg_value}")
                 except Exception:
-                    if self.delete:
-                        pass
-                    else:
-                        self.context.log.fail(f"Registry key {self.key} does not exist")
-                        return
+                    if not self.delete:
+                        context.log.fail(f"Registry key {key} does not exist")
+
             rrp.hBaseRegCloseKey(remote_ops._RemoteOperations__rrp, key_handle)
         except DCERPCException as e:
-            self.context.log.fail(f"DCERPC Error while querying or modifying registry: {e}")
+            context.log.fail(f"DCERPC Error: {e}")
         except Exception as e:
-            self.context.log.fail(f"Error while querying or modifying registry: {e}")
+            context.log.fail(f"Error: {e}")
         finally:
             remote_ops.finish()
+
+    def _registry_mssql(self, context, connection, hive, subpath, key):
+        if self.delete:
+            query = f"EXEC xp_regdeletevalue N'{hive}', N'{subpath}', N'{key}';"
+            connection.conn.sql_query(query)
+            context.log.success(f"Registry value {key} deleted")
+            return
+
+        if self.value is not None:
+            type_str = self.REG_TYPE_MAP.get(self.type, "REG_SZ")
+            query = f"EXEC xp_regwrite N'{hive}', N'{subpath}', N'{key}', N'{type_str}', N'{self.value!s}';"
+            connection.conn.sql_query(query)
+            context.log.success(f"Registry value {key} set to {self.value}")
+            return
+
+        query = f"EXEC xp_regread N'{hive}', N'{subpath}', N'{key}';"
+        rows = connection.conn.sql_query(query)
+        if not rows:
+            context.log.fail(f"No result for {subpath}\\{key}")
+            return
+        for row in rows:
+            context.log.highlight(f"{key}: {row}")
+
+    def on_admin_login(self, context, connection):
+        hive, subpath = self._parse_registry_path(self.path)
+        if not hive:
+            context.log.fail(f"Could not parse registry hive from path: {self.path}")
+            return
+
+        if context.protocol == "mssql":
+            self._registry_mssql(context, connection, hive, subpath, self.key)
+        elif context.protocol == "smb":
+            self._registry_smb(context, connection, hive, subpath, self.key)

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -270,6 +270,9 @@ netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --rid-bru
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --database
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sam
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --lsa
+netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M reg-query -o PATH="HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" KEY="CachedLogonsCount"
+netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M reg-query -o PATH="HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" KEY="CachedLogonsCount3" VALUE=5
+netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M reg-query -o PATH="HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" KEY="CachedLogonsCount3" DELETE=TRUE 
 ##### MSSQL PowerShell
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec mssql TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --force-ps32


### PR DESCRIPTION
## Description

This PR adds support to the reg-query module for the MSSQL protocol. MSSQL allows reading, deleting and adding registry keys via multiple stored procedure. As such, and if you have admin privileges via the MSSQL server (means it is running as a local administrator), you can query, add and delete registry keys. 

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Spawn a MSSQL DB and run the commands above.

## Screenshots (if appropriate):

* SMB

<img width="1811" height="310" alt="image" src="https://github.com/user-attachments/assets/3f5d8376-b42f-4f3f-87db-5a55b810cb27" />

* MSSQL

<img width="1851" height="289" alt="image" src="https://github.com/user-attachments/assets/51f5e76d-dfee-4b17-8915-91721e64c43a" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
