### PR TITLE
Refactor the --database argument to comply with security checks

### DIFF
--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -483,27 +483,27 @@ class mssql(connection):
         return "[" + str(ident).replace("]", "]]") + "]"
 
     def list_databases(self):
-        try:
-            q = (
-                "SELECT d.name AS DatabaseName, "
-                "       suser_sname(d.owner_sid) AS Owner "
-                "FROM sys.databases d "
-                "ORDER BY d.name;"
-            )
-            rows = self.conn.sql_query(q) or []
-            if not rows:
-                self.logger.display("No databases returned")
-                return
+        query = """
+        SELECT d.name AS DatabaseName, 
+                suser_sname(d.owner_sid) AS Owner
+        FROM sys.databases d
+        ORDER BY d.name;
+        """
+        rows = self.conn.sql_query(query)
+        if self.conn.lastError:
+            self.logger.fail(f"Error running the SQL query: {self.conn.lastError}")
+        if not rows:
+            self.logger.display("No databases returned")
+            return
 
-            self.logger.display("Enumerated databases")
-            self.logger.highlight(f"{'Database Name':<30} {'Owner':<25}")
-            self.logger.highlight(f"{'-' * 30} {'-' * 25}")
-            for r in rows:
-                self.logger.highlight(f"{r.get('DatabaseName', ''):<30} {r.get('Owner', ''):<25}")
-            self.logger.highlight(f"Total: {len(rows)} database(s)")
-        except Exception as e:
-            self.logger.fail(f"Failed to enumerate databases: {e}")
-            self.logger.debug("list_databases error", exc_info=True)
+        self.logger.display("Enumerated databases")
+        self.logger.highlight(f"{'Database Name':<30} {'Owner':<25}")
+        self.logger.highlight(f"{'-' * 30} {'-' * 25}")
+        for row in rows:
+            database_name = row.get("DatabaseName", "")
+            owner = row.get("Owner", "")
+            self.logger.highlight(f"{database_name:<30} {owner:<25}")
+        self.logger.highlight(f"Total: {len(rows)} database(s)")
 
     def database(self):
         db_arg = self.args.database
@@ -515,23 +515,23 @@ class mssql(connection):
 
         # nxc --database <name> -> tables
         if isinstance(db_arg, str):
-            try:
-                safe = db_arg.replace("'", "''")
-                exists = self.conn.sql_query(f"SELECT 1 FROM sys.databases WHERE name = N'{safe}';")
-                if not exists:
-                    self.logger.fail(f"Database [{db_arg}] does not exist on the server.")
-                    return
-
-                tq = (
-                    f"SELECT t.name AS TableName, t.modify_date "
-                    f"FROM {self._qname(db_arg)}.sys.tables t "
-                    f"ORDER BY t.name;"
-                )
-                rows = self.conn.sql_query(tq) or []
-            except Exception as e:
-                self.logger.fail(f"Insufficient permissions or query error in [{db_arg}]: {e}")
-                self.logger.debug("database() error", exc_info=True)
+            safe = db_arg.replace("'", "''")
+            exists = self.conn.sql_query(f"SELECT 1 FROM sys.databases WHERE name = N'{safe}';")
+            if self.conn.lastError:
+                self.logger.fail(f"Error running the SQL query: {self.conn.lastError}")
+            if not exists:
+                self.logger.fail(f"Database [{db_arg}] does not exist on the server.")
                 return
+
+            query = f"""
+                SELECT t.name AS TableName, t.modify_date
+                FROM {self._qname(db_arg)}.sys.tables t
+                ORDER BY t.name;
+            """
+            rows = self.conn.sql_query(query)
+
+            if self.conn.lastError:
+                self.logger.fail(f"Error running the SQL query: {self.conn.lastError}")
 
             if not rows:
                 self.logger.display(f"Database [{db_arg}] has no user tables.")


### PR DESCRIPTION
## Description
This PR modifies the --database option to comply with security checks such as checking if the self.conn.lastError value is set by tds.py at some point.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

## Screenshots (if appropriate):
Nothing changed:

<img width="970" height="594" alt="image" src="https://github.com/user-attachments/assets/334fd997-42ec-435d-a8c3-9890af6accdb" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
