### PR TITLE
Fix delegation

### DIFF
--- a/nxc/helpers/rpc.py
+++ b/nxc/helpers/rpc.py
@@ -71,8 +71,10 @@ class NXCRPCConnection:
     def create_smb_transport(self, named_pipe, target_ip=None):
         conn = self.connection
 
-        if conn.conn is not None and conn.host == target_ip:
-            return transport.SMBTransport(conn.conn.getRemoteHost(), filename=named_pipe, smb_connection=conn.conn,)
+        # Create a new SMB conn if we don't have one already or
+        # if we are targetting a different IP (e.g. the DC instead of the original host) and therefore need to recreate the conn
+        if conn.conn is not None and (target_ip is None or conn.host == target_ip):
+            return transport.SMBTransport(conn.conn.getRemoteHost(), filename=named_pipe, smb_connection=conn.conn)
         rpc_transport = transport.SMBTransport(conn.remoteName, conn.port, named_pipe, conn.username, conn.password if conn.password else "", conn.domain, conn.lmhash, conn.nthash, conn.aesKey, doKerberos=conn.kerberos, kdcHost=conn.kdcHost)
         if target_ip or conn.host:
             rpc_transport.setRemoteHost(target_ip or conn.host)


### PR DESCRIPTION
## Description

Initially I fixed a bug in the NXCRPCConnection object that when we targeted a different IP with our TCP connection (`conn.host != target_ip`) we would need to recreate that connection. However, I missed that if we DON'T supply any target_ip (default value) obviously the statement `conn.host == target_ip` would be `conn.host == None` and therefore `False`. This would lead to always recreation of the connection when we don't manually supply a target_ip. Of course, we only want to recreate the connection if we have supplied a target_ip (not None) and the target_ip is different than our conn.host. Therefore, we now check if the target_ip is even set.

TLDR; Only recreate the connection if we actually switch targets from the original connection. Broke e.g. delegation.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
`poetry run nxc smb 192.168.56.22 -u CASTELBLACK$ -H 5adccd24446d2c1dc9b381dcc7152d5e --delegate Administrator --self`

## Screenshots (if appropriate):
Before&After:
<img width="1449" height="248" alt="image" src="https://github.com/user-attachments/assets/5f103758-24cb-4095-8cfd-96ea5ab76082" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
