### PR TITLE
Bug fix : `drop-library-ms` not using NAME option

### DIFF
--- a/nxc/modules/drop-library-ms.py
+++ b/nxc/modules/drop-library-ms.py
@@ -50,6 +50,7 @@ class NXCModule:
             self.cleanup = bool(module_options["CLEANUP"])
             context.log.debug(f"CLEANUP is set to {self.cleanup}")
 
+        self.lms_name = module_options["NAME"]
         self.local_path = f"{TMP_PATH}/{self.lms_name}.library-ms"
         self.remote_path = ntpath.join("\\", f"{self.lms_name}.library-ms")
 


### PR DESCRIPTION
## Description
Like described in #1269, the module doesn't use the NAME option, letting the `lms_name` variable empty. Not a breaking bug as the result remain predictable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Conditions :
- Working target with exposed shares
- Account with WRITE rights on at least one share

Command: `netexec smb 192.168.1.10 -u username -p password -M drop-library-ms -o SERVER=192.168.1.100 NAME=mymodule`
Resulted in:

```
$ netexec smb 192.168.1.10 -u username -p password -M drop-library-ms -o SERVER=192.168.1.100 NAME=mymodule

SMB         192.168.1.10       445    FS-WS01  [*] Windows Server 2025 Build 26100 x64 (name:FS-WS01) (domain:foo-domain.local) (signing:True) (SMBv1:None)
SMB         192.168.1.10       445    FS-WS01  [+] foo-domain.local\User:User123! 
SMB         192.168.1.10       445    FS-WS01  [*] Enumerated shares
SMB         192.168.1.10       445    FS-WS01  Share           Permissions     Remark
SMB         192.168.1.10       445    FS-WS01  -----           -----------     ------
SMB         192.168.1.10       445    FS-WS01  ADMIN$                          Remote Admin
SMB         192.168.1.10       445    FS-WS01  C$                              Default share
SMB         192.168.1.10       445    FS-WS01  IPC$            READ            Remote IPC
SMB         192.168.1.10       445    FS-WS01  print$          READ            Printer Drivers
SMB         192.168.1.10       445    FS-WS01  Kool Aid Pineapple   WRITE           Pineapple
DROP-LIB... 192.168.1.10       445    FS-WS01  [+] Found writable share : Kool Aid Pineapple
DROP-LIB... 192.168.1.10       445    FS-WS01  [+] Created .library-ms file on share 'Kool Aid Pineapple'
```
## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)