### PR TITLE
[WIP] Rework the linked server usage

### DIFF
--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -618,3 +618,28 @@ class mssql(connection):
             )
             LSA.dumpCachedHashes()
             LSA.dumpSecrets()
+
+    def list_linked_servers(self):
+        self.logger.display("Listing linked servers and their credentials")
+        query = """
+        SELECT s.name AS linked_server,
+        l.remote_name AS remote_login
+        FROM sys.servers s
+        LEFT JOIN sys.linked_logins l ON s.server_id = l.server_id
+        LEFT JOIN sys.server_principals p ON l.local_principal_id = p.principal_id
+        WHERE s.is_linked = 1;
+        """
+        rows = self.conn.sql_query(query)
+        if self.conn.lastError:
+            self.logger.fail(f"Error listing linked servers: {self.conn.lastError}")
+
+        if not rows:
+            self.logger.fail("No linked servers configured")
+        else:
+            self.logger.display("Enumerated linked servers")
+            self.logger.highlight(f"{'Linked server':<30} {'Remote login'}")
+            self.logger.highlight(f"{'----------':<30} {'----------'}")
+            for row in rows:
+                linked_server = row.get("linked_server")
+                remote_login = row.get("remote_login")
+                self.logger.highlight(f"{linked_server:<30} {remote_login}")

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -292,7 +292,7 @@ class mssql(connection):
             return None
         self.logger.info(f"Query to run: {self.args.query}")
         try:
-            raw_output = self.conn.sql_query(self.args.query)
+            raw_output = self.conn.sql_query(self._wrap_linked(self.args.query))
             self.logger.debug(f"Raw output: {raw_output}")
             if self.conn.lastError:
                 self.logger.debug(f"Error during query execution: {self.conn.lastError}")
@@ -619,11 +619,45 @@ class mssql(connection):
             LSA.dumpCachedHashes()
             LSA.dumpSecrets()
 
+    def _wrap_linked(self, query):
+        if not getattr(self.args, "on_linked_server", None):
+            return query
+
+        # Enable RPC out for complexe queries
+        # Here we should check the value, back it up
+        # enable then restore
+        check_rpc_out_query = f"""
+        EXEC sp_serveroption @server = N'{self.args.on_linked_server}', @optname = 'rpc out', @optvalue = 'true';
+        """
+        self.conn.sql_query(check_rpc_out_query)
+
+        # Second we need to check that the actual user can rely on the linked server link
+        check_user_has_access_query = f"""
+        SELECT l.remote_name, l.uses_self_credential
+        FROM sys.linked_logins l
+        JOIN sys.servers s ON s.server_id = l.server_id
+        WHERE s.name = N'{self.args.on_linked_server}'
+        AND (l.local_principal_id = 0 OR l.local_principal_id = USER_ID(SYSTEM_USER));
+        """
+        rows = self.conn.sql_query(check_user_has_access_query)
+        if not rows or not rows[0].get("remote_name"):
+            self.logger.fail(f"No valid login mapping found for {self.username} on linked server '{self.args.on_linked_server}'")
+
+        escaped = query.replace("'", "''")
+        wrapped_query = f"EXEC('{escaped}') AT [{self.args.on_linked_server}];"
+        print(wrapped_query)
+        return wrapped_query
+
     def list_linked_servers(self):
         self.logger.display("Listing linked servers and their credentials")
         query = """
         SELECT s.name AS linked_server,
-        l.remote_name AS remote_login
+            p.name AS local_login,
+            l.remote_name AS remote_login,
+            CASE l.uses_self_credential
+                WHEN 1 THEN 'true'
+                ELSE 'false'
+            END AS uses_self_credential
         FROM sys.servers s
         LEFT JOIN sys.linked_logins l ON s.server_id = l.server_id
         LEFT JOIN sys.server_principals p ON l.local_principal_id = p.principal_id
@@ -636,10 +670,11 @@ class mssql(connection):
         if not rows:
             self.logger.fail("No linked servers configured")
         else:
-            self.logger.display("Enumerated linked servers")
-            self.logger.highlight(f"{'Linked server':<30} {'Remote login'}")
-            self.logger.highlight(f"{'----------':<30} {'----------'}")
+            self.logger.highlight(f"{'Linked server':<30} {'Local login':<30} {'Remote login':<30} {'Use self':5}")
+            self.logger.highlight(f"{'----------':<30} {'----------':<30} {'----------':<30} {'----------':<5}")
             for row in rows:
                 linked_server = row.get("linked_server")
                 remote_login = row.get("remote_login")
-                self.logger.highlight(f"{linked_server:<30} {remote_login}")
+                local_login = row.get("local_login")
+                use_self = row.get("use_self")
+                self.logger.highlight(f"{linked_server:<30} {local_login:<30} {remote_login:<30} {use_self}")

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -648,7 +648,7 @@ class mssql(connection):
         print(wrapped_query)
         return wrapped_query
 
-    def list_linked_servers(self):
+    def links(self):
         self.logger.display("Listing linked servers and their credentials")
         query = """
         SELECT s.name AS linked_server,
@@ -670,11 +670,11 @@ class mssql(connection):
         if not rows:
             self.logger.fail("No linked servers configured")
         else:
-            self.logger.highlight(f"{'Linked server':<30} {'Local login':<30} {'Remote login':<30} {'Use self':5}")
+            self.logger.highlight(f"{'Local login':<30} {'Linked server':<30}  {'Remote login':<30} {'Use self':5}")
             self.logger.highlight(f"{'----------':<30} {'----------':<30} {'----------':<30} {'----------':<5}")
             for row in rows:
                 linked_server = row.get("linked_server")
                 remote_login = row.get("remote_login")
                 local_login = row.get("local_login")
                 use_self = row.get("use_self")
-                self.logger.highlight(f"{linked_server:<30} {local_login:<30} {remote_login:<30} {use_self}")
+                self.logger.highlight(f"{local_login:<30} {linked_server:<30} {remote_login:<30} {use_self}")

--- a/nxc/protocols/mssql/proto_args.py
+++ b/nxc/protocols/mssql/proto_args.py
@@ -8,6 +8,7 @@ def proto_args(parser, parents):
     mssql_parser.add_argument("--mssql-timeout", help="SQL server connection timeout", type=int, default=5)
     mssql_parser.add_argument("-q", "--query", metavar="QUERY", type=str, help="execute the specified query against the mssql db")
     mssql_parser.add_argument("--database", nargs="?", const=True, metavar="NAME", help="list databases or list tables for NAME")
+    mssql_parser.add_argument("--on-linked-server", nargs="?", const=True, metavar="NAME", help="Linked server on which execute the query")
 
     dgroup = mssql_parser.add_mutually_exclusive_group()
     dgroup.add_argument("-d", metavar="DOMAIN", dest="domain", type=str, help="domain name")

--- a/nxc/protocols/mssql/proto_args.py
+++ b/nxc/protocols/mssql/proto_args.py
@@ -36,4 +36,6 @@ def proto_args(parser, parents):
 
     mapping_enum_group = mssql_parser.add_argument_group("Mapping/Enumeration")
     mapping_enum_group.add_argument("--rid-brute", nargs="?", type=int, const=4000, metavar="MAX_RID", help="enumerate users by bruteforcing RIDs")
+    mapping_enum_group.add_argument("--list-linked-servers", action="store_true", default=False, help="List linked servers and their credentials")
+
     return parser

--- a/nxc/protocols/mssql/proto_args.py
+++ b/nxc/protocols/mssql/proto_args.py
@@ -37,6 +37,6 @@ def proto_args(parser, parents):
 
     mapping_enum_group = mssql_parser.add_argument_group("Mapping/Enumeration")
     mapping_enum_group.add_argument("--rid-brute", nargs="?", type=int, const=4000, metavar="MAX_RID", help="enumerate users by bruteforcing RIDs")
-    mapping_enum_group.add_argument("--list-linked-servers", action="store_true", default=False, help="List linked servers and their credentials")
+    mapping_enum_group.add_argument("--links", action="store_true", default=False, help="List linked servers and their credentials")
 
     return parser


### PR DESCRIPTION
## Description
So far NXC MSSQL can list linked servers via the enum_links module which output is the following:

<img width="1350" height="237" alt="image" src="https://github.com/user-attachments/assets/07dd4ad7-0975-4c0f-af2d-549fe635a8c8" />

The module is great because it allows listing both the local login, the remote login and the target server. 

From there a user could use modules *_links to execute code on the linked server. Let's say the user wants to get the version of the SQL database via the following request:

```sql
SELECT @@VERSION;
```

If using the *_links module, the module will wrap it that way:

```sql
EXEC('SELECT @@VERSION;') AT [TARGET_LINKED_SERVER];
```

Whil it works, I believe we shouldn't have a module to use this feature as it clearly limitates what we can do with it. For example, it is not yet possible to do a simple SQL query via a linked server. Why ? Because modules only allow running xpcmdshell via a linked server. It's not a proper way of handling this amazing feature so here is my proposal.

First, note this is a crash test PR (hence WIP). The idea is to provide a working solution and estimate whether or not we should deploy it globally. To handle this issue, I added the following function:

```python
def _wrap_linked(self, query):
        if not getattr(self.args, "on_linked_server", None):
            return query

        # Enable RPC out for complexe queries
        # Here we should check the value, back it up
        # enable then restore
        check_rpc_out_query = f"""
        EXEC sp_serveroption @server = N'{self.args.on_linked_server}', @optname = 'rpc out', @optvalue = 'true';
        """
        self.conn.sql_query(check_rpc_out_query)

        # Second we need to check that the actual user can rely on the linked server link
        check_user_has_access_query = f"""
        SELECT l.remote_name, l.uses_self_credential
        FROM sys.linked_logins l
        JOIN sys.servers s ON s.server_id = l.server_id
        WHERE s.name = N'{self.args.on_linked_server}'
        AND (l.local_principal_id = 0 OR l.local_principal_id = USER_ID(SYSTEM_USER));
        """
        rows = self.conn.sql_query(check_user_has_access_query)
        if not rows or not rows[0].get("remote_name"):
            self.logger.fail(f"No valid login mapping found for {self.username} on linked server '{self.args.on_linked_server}'")

        escaped = query.replace("'", "''")
        wrapped_query = f"EXEC('{escaped}') AT [{self.args.on_linked_server}];"
        print(wrapped_query)
        return wrapped_query
```

It does a few things:

* Checks whether RPC OUT is enabled on the local server to the linked server. Indeed, using EXEC requires being able to have RPC coming out from the source DB. I didn't implement the check/enable/restore code because we don't need to have that yet.  This PR https://github.com/Pennyw0rth/NetExec/pull/1268 shows the idea ;
* Checks if the current user can use a linked server link (because it's not always the case) ;
* Wraps the initial query and executes it.

For testing purpose I have added the following --list-linked-servers option:

```bash
nxc mssql 192.168.56.72 -u Administrator -p Defte@WF   --list-linked-servers
```

Whose output is the following:

<img width="992" height="179" alt="image" src="https://github.com/user-attachments/assets/c5a9820d-7be3-4993-87b0-45065d759deb" />

* Linked server = the target SQL server ;
* local login = the local users that have the right to use that linked server link ;
* Remote login = the remote user that will run the query thourgh the linked server link ;
* Use self = whether we rely on the same context (ie: whiteflag/administrator in that case).

From the output we understand that, being connected on SRV22 as WHITEFLAG/administrator, I can run queries as SA on DC25. Using the --on-linked-server, I can now select where to run the query:

```bash
nxc mssql 192.168.56.72 -u Administrator -p Defte@WF  -q "SELECT @@VERSION;" --on-linked-server DC25
```

<img width="1308" height="171" alt="image" src="https://github.com/user-attachments/assets/68c3b30d-63c0-40c3-8901-4fdb2f0a35b5" />

And here without the option, we have a different output:

<img width="1346" height="163" alt="image" src="https://github.com/user-attachments/assets/dc19daa9-6d4b-4e17-9439-a78d6b188eb6" />

Because:
* DC25 has got a 2025 MSSQL DB installed ;
* SRV22 has got a 2022 MSSQL DB installed.

Now about the wrapping, we simply have the following modification to replicate everywher we use self.conn.sql_query:

```sql
raw_output = self.conn.sql_query(self._wrap_linked(self.args.query))
```

Doing so we will be able to eliminate 4 modules that were great at the time but not necessary anymore. This will also allow using linked servers on SQLEXEC methods which is why I believe we should rework that part.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
More on that later.

## Screenshots (if appropriate):

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
