### PR TITLE
fix: catch invalid PFX/PEM errors in certificate authentication

### DIFF
--- a/nxc/helpers/pfx.py
+++ b/nxc/helpers/pfx.py
@@ -478,14 +478,21 @@ def pfx_auth(self):
     self.logger.info("Loading certificate and key from file")
 
     # Load the certificate and key from file
-    if self.args.pfx_cert or self.args.pfx_base64:
-        pfx = self.args.pfx_cert if self.args.pfx_cert else self.args.pfx_base64
-        ini = myPKINIT.from_pfx(pfx, self.args.pfx_pass, dhparams, bool(self.args.pfx_base64))
-    elif self.args.pem_cert and self.args.pem_key:
-        ini = myPKINIT.from_pem(self.args.pem_cert, self.args.pem_key, dhparams)
-    else:
-        self.logger.fail("You must either specify a PFX file + optional password or a combination of Cert PEM file and Private key PEM file")
-        return None
+    try:
+        if self.args.pfx_cert or self.args.pfx_base64:
+            pfx = self.args.pfx_cert if self.args.pfx_cert else self.args.pfx_base64
+            ini = myPKINIT.from_pfx(pfx, self.args.pfx_pass, dhparams, bool(self.args.pfx_base64))
+        elif self.args.pem_cert and self.args.pem_key:
+            ini = myPKINIT.from_pem(self.args.pem_cert, self.args.pem_key, dhparams)
+        else:
+            self.logger.fail("You must either specify a PFX file + optional password or a combination of Cert PEM file and Private key PEM file")
+            return None
+    except FileNotFoundError as e:
+        self.logger.fail(f"Certificate or key file not found: {e.filename}")
+        return False
+    except Exception as e:
+        self.logger.fail(f"Failed to load certificate/key: {e}")
+        return False
 
     username = self.args.username[0]
     basename = f"{self.hostname}_{self.host}_{datetime.datetime.now().strftime('%Y-%m-%d_%H%M%S')}-{username}.ccache"


### PR DESCRIPTION
## Description
This PR fixes certificate authentication errors (invalid PFX/PEM, missing files, wrong password) being shown as full stack traces by catching them in `pfx_auth()` and logging a short fail message instead.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

use an encrypted certificate with a password without providing the password

## Screenshots (if appropriate):

Before : 

<img width="1905" height="987" alt="image" src="https://github.com/user-attachments/assets/7ad31597-a47f-418a-a4b8-46fb19177096" />


After : 

<img width="1906" height="275" alt="image" src="https://github.com/user-attachments/assets/aeb2d6c4-271f-4329-87cb-672794fbb7a9" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
