### PR TITLE
Replace ldap3 with impacket in daclread module

### DIFF
--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -13,20 +13,6 @@ import traceback
 from os.path import isfile
 
 
-def escape_filter_chars(text, encoding="utf-8"):
-    """Escape special characters in an LDAP search filter assertion value (RFC 4515)."""
-    if isinstance(text, (bytes, bytearray)):
-        try:
-            text = text.decode(encoding)
-        except Exception:
-            return "".join(f"\\{b:02x}" for b in text)
-    escaped = text.replace("\\", "\\5c")
-    escaped = escaped.replace("*", "\\2a")
-    escaped = escaped.replace("(", "\\28")
-    escaped = escaped.replace(")", "\\29")
-    return escaped.replace("\x00", "\\00")
-
-
 OBJECT_TYPES_GUID = {}
 OBJECT_TYPES_GUID.update(SCHEMA_OBJECTS)
 OBJECT_TYPES_GUID.update(EXTENDED_RIGHTS)
@@ -204,8 +190,8 @@ class ALLOWED_OBJECT_ACE_MASK_FLAGS(Enum):
 
 
 SEARCH_FILTERS = {
-    "TARGET": lambda target: f"(sAMAccountName={escape_filter_chars(target)})",
-    "TARGET_DN": lambda target: f"(distinguishedName={escape_filter_chars(target)})"
+    "TARGET": lambda target: f"(sAMAccountName={target})",
+    "TARGET_DN": lambda target: f"(distinguishedName={target})"
 }
 
 
@@ -302,7 +288,7 @@ class NXCModule:
         if self.principal_sAMAccountName is not None:
             try:
                 resp = connection.search(
-                    searchFilter=f"(sAMAccountName={escape_filter_chars(self.principal_sAMAccountName)})",
+                    searchFilter=f"(sAMAccountName={self.principal_sAMAccountName})",
                     attributes=["objectSid"],
                 )
                 resp_parsed = parse_result_attributes(resp)[0]

--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -3,15 +3,29 @@ import json
 import datetime
 from enum import Enum
 from impacket.ldap import ldaptypes
+from impacket.ldap.ldapasn1 import SDFlagsControl
 from impacket.uuid import bin_to_string
 from nxc.helpers.misc import CATEGORY
 from nxc.helpers.msada_guids import SCHEMA_OBJECTS, EXTENDED_RIGHTS
 from nxc.parsers.ldap_results import parse_result_attributes
-from ldap3.utils.conv import escape_filter_chars
-from ldap3.protocol.microsoft import security_descriptor_control
 import sys
 import traceback
 from os.path import isfile
+
+
+def escape_filter_chars(text, encoding="utf-8"):
+    """Escape special characters in an LDAP search filter assertion value (RFC 4515)."""
+    if isinstance(text, (bytes, bytearray)):
+        try:
+            text = text.decode(encoding)
+        except Exception:
+            return "".join(f"\\{b:02x}" for b in text)
+    escaped = text.replace("\\", "\\5c")
+    escaped = escaped.replace("*", "\\2a")
+    escaped = escaped.replace("(", "\\28")
+    escaped = escaped.replace(")", "\\29")
+    return escaped.replace("\x00", "\\00")
+
 
 OBJECT_TYPES_GUID = {}
 OBJECT_TYPES_GUID.update(SCHEMA_OBJECTS)
@@ -306,7 +320,7 @@ class NXCModule:
                 resp = connection.search(
                     searchFilter=search_filter(target),
                     attributes=["distinguishedName", "nTSecurityDescriptor"],
-                    searchControls=security_descriptor_control(sdflags=0x04),
+                    searchControls=[SDFlagsControl(criticality=False, flags=0x04)],
                 )
                 resp_parsed = parse_result_attributes(resp)[0]
 

--- a/nxc/modules/daclread.py
+++ b/nxc/modules/daclread.py
@@ -214,7 +214,7 @@ class NXCModule:
 
     This module is essentially inspired from the dacledit.py script of Impacket that we have coauthored, @_nwodtuhs and me.
     It has been converted to an LDAPConnection session, and improvements on the filtering and the ability to specify multiple targets have been added.
-    It could be interesting to implement the write/remove functions here, but a ldap3 session instead of a LDAPConnection one is required to write.
+    It could be interesting to implement the write/remove functions here.
     """
 
     name = "daclread"


### PR DESCRIPTION
## Description

This PR replaces `ldap3` with `impacket` equivalents in the `daclread module` by using `SDFlagsControl` and a local `escape_filter_chars` helper.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
 
 run `nxc ldap 192.168.211.100 -u 'user' -p 'Password' -M daclread -o TARGET=Administrator ACTION=read`

## Screenshots (if appropriate):

<img width="1626" height="1019" alt="image" src="https://github.com/user-attachments/assets/209fc8db-38d4-46db-9813-2e66ea52f852" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [X] I have performed a self-review of my own code (_not_ an AI review)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
