### PR TITLE
Replace ldap3 with impacket in sccm module

### DIFF
--- a/nxc/modules/sccm.py
+++ b/nxc/modules/sccm.py
@@ -1,6 +1,6 @@
 from impacket.ldap import ldap, ldaptypes
 from impacket.ldap.ldap import LDAPSearchError
-from ldap3.protocol.microsoft import security_descriptor_control
+from impacket.ldap.ldapasn1 import SDFlagsControl
 from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
@@ -56,7 +56,7 @@ class NXCModule:
         try:
             # Search for SCCM root object
             search_filter = f"(distinguishedName=CN=System Management,CN=System,{self.base_dn})"
-            controls = security_descriptor_control(sdflags=0x04)
+            controls = [SDFlagsControl(criticality=False, flags=0x04)]
             context.log.display(f"Looking for the SCCM container with filter: '{search_filter}'")
             result = connection.ldap_connection.search(
                 searchFilter=search_filter,


### PR DESCRIPTION
## Description

This PR replaces `ldap3's security_descriptor_contro`l with impacket's `SDFlagsControl` in the `sccm module` to remove the `ldap3` dependency.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
run `nxc ldap DC_IP -u 'user' -p 'Password' -M sccm` 

## Screenshots (if appropriate):


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [X] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
