### PR TITLE
Remove unused ldap3 import from get-network module

### DIFF
--- a/nxc/modules/get-network.py
+++ b/nxc/modules/get-network.py
@@ -7,21 +7,10 @@ from datetime import datetime
 from struct import unpack
 
 from impacket.structure import Structure
-from ldap3 import LEVEL
 from os.path import expanduser
 from nxc.helpers.misc import CATEGORY
 from nxc.paths import NXC_PATH
 from nxc.parsers.ldap_results import parse_result_attributes
-
-
-def get_dns_zones(connection, root, debug=False):
-    connection.search(root, "(objectClass=dnsZone)", search_scope=LEVEL, attributes=["dc"])
-    zones = []
-    for entry in connection.response:
-        if entry["type"] != "searchResEntry":
-            continue
-        zones.append(entry["attributes"]["dc"])
-    return zones
 
 
 def ldap2domain(baseDN):


### PR DESCRIPTION
## Description

This PR removes the unused `ldap3` import and dead `get_dns_zones()` helper from the `get-network` module.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

run `nxc ldap DC_IP -u 'user'  -p 'password' -M get-network`

## Screenshots (if appropriate):

<img width="1892" height="655" alt="image" src="https://github.com/user-attachments/assets/492041b8-0bac-4222-9a20-706fbdb5dbc7" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [X] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
