### PR TITLE
fix(mssql): print a clean error for --rid-brute without authentication

### DIFF
--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -442,6 +442,9 @@ class mssql(connection):
         if self.conn.lastError:
             self.logger.fail(f"Cannot perform RID bruteforce due to invalid connection: {self.conn.lastError}")
             return entries
+        if not self.username and not self.password:
+            self.logger.fail("Cannot perform RID bruteforce without authentication, provide credentials with -u/-p, -H (hash), or Kerberos")
+            return entries
         if not max_rid:
             max_rid = int(self.args.rid_brute)
 


### PR DESCRIPTION
## Description

Fixes the confusing error that remains on the MSSQL `--rid-brute` no-credential path after [#1179](https://github.com/Pennyw0rth/NetExec/pull/1179). Closes [#1119](https://github.com/Pennyw0rth/NetExec/issues/1119).

#1179 removed the `UnboundLocalError` stacktrace by aborting `rid_brute` when the connection is invalid after a failed login. However, when a user runs `nxc mssql <host> --rid-brute` with **no** credentials, the connection is *valid* (an anonymous TDS session) and `self.conn.lastError` is unset, so execution falls through to the SID-parsing block. The unauthenticated query returns no rows, `sql_query(...)[0][""]` raises `IndexError`, and the user is shown:

```
MSSQL  10.129.5.44  1433  DC01  Error parsing SID. Not domain joined?: list index out of range
```

This message is misleading: the host *is* domain-joined — the real cause is that RID brute forcing has nothing to query against because the session was never authenticated. As [@NeffIsBack noted on the issue](https://github.com/Pennyw0rth/NetExec/issues/1119#issuecomment), "we should improve that error message."

This PR adds an early guard so the no-credential case exits cleanly with an actionable message instead of leaking an internal exception string.

**Before:**
```
MSSQL  10.129.5.44  1433  DC01  Error parsing SID. Not domain joined?: list index out of range
```

**After:**
```
MSSQL  10.129.5.44  1433  DC01  Cannot perform RID bruteforce without authentication, provide credentials with -u/-p, -H (hash), or Kerberos
```

The guard mirrors `connection.proto_flow()`, which only dispatches command-line actions on an unauthenticated session when `self.username == "" and self.password == ""`. The same predicate is the precise signal that we reached `rid_brute()` without authenticating — hash and Kerberos logins both set `self.username`, so they are unaffected.

No dependency changes.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [X] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

**AI assistance disclosure (per [AI_POLICY.md](https://github.com/Pennyw0rth/NetExec/blob/main/AI_POLICY.md)):** root-cause analysis and the patch were drafted with Claude Code (Anthropic, Opus model). The author reviewed the call graph (`connection.proto_flow` / `call_cmd_args` dispatch and the `mssql` login methods) and confirmed the guard predicate by hand; the change is a three-line early return.

## Setup guide for the review

- Python 3.13 on Linux; target is any reachable MSSQL instance (the bug is independent of the server's domain-join state).
- **Reproduce the bug:** run `nxc mssql <host> --rid-brute` with no `-u/-p`. On `main` this prints `Error parsing SID. Not domain joined?: list index out of range`.
- **Verify the fix:** the same command now prints `Cannot perform RID bruteforce without authentication, provide credentials with -u/-p, -H (hash), or Kerberos` and exits cleanly.
- **Regression check:** `nxc mssql <host> -u <user> -p <pass> --rid-brute` is unchanged — an authenticated session sets `self.username`, so the guard is not triggered. Hash (`-H`) and Kerberos paths are likewise unaffected.

## Checklist

- [X] I have ran Ruff against my changes (`ruff check .` — all checks passed)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (not required — the no-credential failure path is not an e2e target; existing authenticated `--rid-brute` coverage is unchanged)
- [X] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects (N/A — no dependency changes)
- [X] I have linked relevant sources that describes the added technique (issue #1119 and prior fix #1179)
- [X] I have performed a self-review of my own code (_not_ an AI review)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — error-message wording only)
