### PR TITLE
Add onelogon enumeration module

### DIFF
--- a/nxc/modules/onelogon.py
+++ b/nxc/modules/onelogon.py
@@ -1,0 +1,85 @@
+from nxc.helpers.misc import CATEGORY
+from impacket.examples.secretsdump import RemoteOperations
+from impacket.dcerpc.v5 import rrp
+from impacket.smbconnection import SessionError
+from configparser import ConfigParser
+
+
+class NXCModule:
+    """Module by @NeffIsBack
+    Based on the paper "Onelogon: Taking over Active Directory Accounts via Netlogon": https://softsec.rub.de/files/pdf/woot2026-onelogon.pdf
+    """
+
+    name = "onelogon"
+    description = "Scan GPOs and registry for machine accounts vulnerable to Onelogon"
+    supported_protocols = ["smb"]
+    category = CATEGORY.ENUMERATION
+
+    def options(self, context, module_options):
+        """No options available"""
+
+    def on_login(self, context, connection):
+        def output_callback(data):
+            self.gpo_data += data
+
+        found_dacls = []
+
+        policies = connection.conn.listPath("SYSVOL", f"{connection.domain}/Policies/*")
+        for policy in policies:
+            # Skip "." and ".." directory pointers to avoid path errors
+            if policy.get_longname() in [".", ".."]:
+                continue
+
+            try:
+                self.gpo_data = b""
+                connection.conn.getFile("SYSVOL", f"{connection.domain}/Policies/{policy.get_longname()}/MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf", output_callback)
+
+                try:
+                    decoded_data = self.gpo_data.decode("utf-8")
+                except UnicodeDecodeError:
+                    context.log.debug(f"Failed to decode GPO data for policy {policy.get_shortname()} as UTF-8, trying UTF-16...")
+                    decoded_data = self.gpo_data.decode("utf-16")
+
+                # Use strict=False and interpolation=None to safely handle Windows INI quirks and % variables.
+                # Some sections (e.g. [Service General Setting]) use value-less CSV-style rows like:
+                # "WinRM",2,""
+                # which require allow_no_value=True to avoid ParsingError.
+                config_parser = ConfigParser(strict=False, interpolation=None, allow_no_value=True)
+                config_parser.read_string(decoded_data)
+
+                for section in config_parser.sections():
+                    for key, value in config_parser.items(section):
+                        if key == "MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Netlogon\\Parameters\\VulnerableChannelAllowList".lower():
+                            context.log.debug(f"Found vulnerable channel allow list: {value}")
+                            try:
+                                # Strip the surrounding double quotes from the extracted string
+                                found_dacls.append({"name": policy.get_shortname(), "data": value[2:].strip('"')})
+                            except Exception as e:
+                                context.log.error(f"Could not parse Registry Policy (error: {e}): {section} {key} {value}")
+            except SessionError as e:
+                # Catch and safely ignore expected "file not found" errors for policies without security settings
+                if "STATUS_OBJECT_NAME_NOT_FOUND" in str(e) or "STATUS_NO_SUCH_FILE" in str(e):
+                    pass
+                else:
+                    context.log.debug(f"SMB Session Error reading policy {policy.get_shortname()}: {e}")
+            except Exception as e:
+                context.log.error(f"Error parsing policy {policy.get_shortname()}, {e.__class__.__name__}: {e}")
+
+        if found_dacls:
+            context.log.success(f"Found {len(found_dacls)} matching policies in SYSVOL Share.")
+            for dacl in found_dacls:
+                context.log.success(f"Found vulnerable channel allow list in policy '{dacl['name']}': '{dacl['data']}'")
+        else:
+            context.log.error("No matching policies found in SYSVOL Share.")
+
+    def on_admin_login(self, context, connection):
+        try:
+            remoteOps = RemoteOperations(connection.conn, False)
+            remoteOps.enableRegistry()
+
+            regHandle = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)["phKey"]
+            keyHandle = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, "SYSTEM\\CurrentControlSet\\Services\\Netlogon\\Parameters")["phkResult"]
+            value = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, "VulnerableChannelAllowList")[1].rstrip("\x00")
+            context.log.success(f"Found VulnerableChannelAllowList registry configuration: {value}")
+        except Exception as e:
+            context.log.error(f"Error while querying registry: {e}")


### PR DESCRIPTION
## Description
Very short TLDR; Found a vuln in AD which allows to compromise accounts if a specific legacy GPO is present.

For a short explanation see my Linkedin/Twitter Posts:
- https://www.linkedin.com/posts/alexander-neff-060a65187_onelogon-taking-over-active-directory-accounts-ugcPost-7475248395071348736-Xcyv
- https://x.com/al3x_n3ff/status/2069482623672435049

For the full explanation see our paper: https://softsec.rub.de/files/pdf/woot2026-onelogon.pdf
Independent scanner script and exploit: http://softsec.link/woot26.onelogon

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Configure the GPO: ` "Domain Controller: Allow vulnerable Netlogon secure channel connections group policy"` to include the DC and run the exploit script (see link above).
Result after ~30mins should be:
<img width="739" height="554" alt="image" src="https://github.com/user-attachments/assets/149c6c20-ea1f-4d35-9ecb-b902b9546ed1" />

This module scans for the GPO and the resulting registry key to examine which accounts were exempted from RPC signing&sealing and are therefore vulnerable to the attack:
<img width="852" height="71" alt="image" src="https://github.com/user-attachments/assets/fbd1daab-9d59-4bc7-9872-5a0e7154a00e" />

## Checklist
