### PR TITLE
Handle situation where LDAP user objects do not have userAccount

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1011,25 +1011,11 @@ class ldap(connection):
             return
 
         # Filter disabled and invalid accounts
-        disabled_accounts = []
-        for x in resp_parsed:
-            if "userAccountControl" in x:
-                # account is disabled
-                if (int(x["userAccountControl"]) & UF_ACCOUNTDISABLE):
-                    disabled_accounts.append(x)
-            else:
-                # ldap object does not have UAC field, weird but happens
-                disabled_accounts.append(x)
+        disabled_accounts = [x for x in resp_parsed if int(x.get("userAccountControl", 0)) & UF_ACCOUNTDISABLE]
         for account in disabled_accounts:
-            self.logger.display(f"Skipping disabled or invalid account: {account['sAMAccountName']}")
+            self.logger.display(f"Skipping disabled account: {account['sAMAccountName']}")
 
-        # Get all enabled accounts
-        enabled = []
-        for x in resp_parsed:
-            if "userAccountControl" in x:
-                if not (int(x["userAccountControl"]) & UF_ACCOUNTDISABLE):
-                    enabled.append(x)
-        self.logger.display(f"Total of records returned {len(enabled):d}")
+        enabled = [x for x in resp_parsed if not int(x.get("userAccountControl", 0)) & UF_ACCOUNTDISABLE]
 
         if self.args.targeted_kerberoast:
             self.logger.success(f"Found {len(enabled)} enabled users without SPN.")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1010,11 +1010,26 @@ class ldap(connection):
             self.logger.highlight("No entries found!")
             return
 
-        disabled_accounts = [x for x in resp_parsed if int(x["userAccountControl"]) & UF_ACCOUNTDISABLE]
+        # Filter disabled and invalid accounts
+        disabled_accounts = []
+        for x in resp_parsed:
+            if "userAccountControl" in x:
+                # account is disabled
+                if (int(x["userAccountControl"]) & UF_ACCOUNTDISABLE):
+                    disabled_accounts.append(x)
+            else:
+                # ldap object does not have UAC field, weird but happens
+                disabled_accounts.append(x)
         for account in disabled_accounts:
-            self.logger.display(f"Skipping disabled account: {account['sAMAccountName']}")
+            self.logger.display(f"Skipping disabled or invalid account: {account['sAMAccountName']}")
 
-        enabled = [x for x in resp_parsed if not int(x["userAccountControl"]) & UF_ACCOUNTDISABLE]
+        # Get all enabled accounts
+        enabled = []
+        for x in resp_parsed:
+            if "userAccountControl" in x:
+                if not (int(x["userAccountControl"]) & UF_ACCOUNTDISABLE):
+                    enabled.append(x)
+        self.logger.display(f"Total of records returned {len(enabled):d}")
 
         if self.args.targeted_kerberoast:
             self.logger.success(f"Found {len(enabled)} enabled users without SPN.")


### PR DESCRIPTION
- ## Description

Proposed fixes for issue #1293. When some LDAP user objects are missing the `userAccountControl` field, it causes kerberoasting to crash ungracefully. Now, such users are discarded just like disabled accounts.

- ## Type of change
Just added some conditional logic to check the existence of `userAccountControl`  during kerberoasting.

- ## Setup guide for the review
Attempt a kerberoasting on an Active Directory with malformed (?) user objects 

- ## Checklist
Attempt a kerberoasting on an Active Directory with malformed (?) user objects 

