### PR TITLE
Handle None in username check for SQL query results when rid-brute with mssql

### DIFF
--- a/nxc/modules/enum_links.py
+++ b/nxc/modules/enum_links.py
@@ -32,7 +32,7 @@ class NXCModule:
 
         if connection.admin_privs:
             res = self.mssql_conn.sql_query("EXEC sp_helplinkedsrvlogin")
-            srvs = [srv for srv in res if srv["Local Login"] != "NULL"]
+            srvs = [srv for srv in res if srv["Local Login"] is not None]
             if not srvs:
                 self.context.log.fail("No linked servers found.")
                 return

--- a/nxc/modules/link_xpcmd.py
+++ b/nxc/modules/link_xpcmd.py
@@ -40,7 +40,7 @@ class NXCModule:
             output_lines = []
             for row in result:
                 output_value = row.get("output")
-                if output_value and output_value != "NULL":
+                if output_value:
                     output_lines.append(str(output_value))
 
             if output_lines:

--- a/nxc/modules/mssql_priv.py
+++ b/nxc/modules/mssql_priv.py
@@ -446,7 +446,7 @@ class NXCModule:
         res = self.query_and_get_output(f"SELECT IS_SRVROLEMEMBER('sysadmin', '{username}')")
         is_admin = res[0][""]
         try:
-            if is_admin != "NULL" and int(is_admin):
+            if is_admin is not None and int(is_admin):
                 self.admin_privs = True
                 self.context.log.debug(f"Updated: {username} is admin!")
                 return True

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -469,7 +469,7 @@ class mssql(connection):
 
             for n, item in enumerate(raw_output):
                 username = item[""]
-                if username == "NULL":
+                if username == "NULL" or username is None:
                     continue
                 rid = so_far + n
                 self.logger.highlight(f"{rid}: {username}")

--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -469,7 +469,7 @@ class mssql(connection):
 
             for n, item in enumerate(raw_output):
                 username = item[""]
-                if username == "NULL" or username is None:
+                if username is None:
                     continue
                 rid = so_far + n
                 self.logger.highlight(f"{rid}: {username}")

--- a/nxc/protocols/mssql/mssqlexec.py
+++ b/nxc/protocols/mssql/mssqlexec.py
@@ -21,7 +21,7 @@ class MSSQLEXEC:
             raw = self.mssql_conn.sql_query(cmd)
             self.logger.debug(f"Raw results from query: {raw}")
             if raw:
-                result = "\n".join(line["output"] for line in raw if line["output"] != "NULL")
+                result = "\n".join(line["output"] for line in raw if line["output"] is not None)
                 self.logger.debug(f"Concatenated result together for easier parsing: {result}")
                 # if you prepend SilentlyContinue it will still output the error, but it will still continue on (so it's not silent...)
                 if "Preparing modules for first use" in result and "Completed" not in result:


### PR DESCRIPTION
## Description
Fix stacktrace on --rid-brute with mssql proto

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Tested against GOAD Light

## Screenshots (if appropriate):
Before
<img width="1613" height="903" alt="image" src="https://github.com/user-attachments/assets/26270db2-c2d4-40d0-8666-f5b885172b6e" />


After
<img width="1633" height="775" alt="image" src="https://github.com/user-attachments/assets/30aa2d3d-02de-4693-923f-abcb38720e6e" />

<img width="1806" height="562" alt="image" src="https://github.com/user-attachments/assets/82b04981-c640-4d0c-9d15-c0ef27235058" />



## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
