### PR TITLE
fix stracktrace port 636 closed

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -191,6 +191,10 @@ class ldap(connection):
                 self.cbt_status = "No TLS cert"
             else:
                 raise
+        except OSError as e:
+            # Should catch TimeoutError ([Errno 110]), ConnectionRefusedError, host/network unreachable, etc.
+            self.logger.debug(f"Connection error while checking LDAPS channel binding on {self.host}: {e!s}")
+            self.cbt_status = "Unknown"
 
     def enum_host_info(self):
         # Enumerate LDAP info


### PR DESCRIPTION
## Description
If port 636 is closed, the proto ldap stracktrace unless you force the port.

this pr fix this issue by catching the timeout.

(i noticed the --timeout option is not implemented for ldap but that's for another pr)

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
```
sudo iptables -A OUTPUT -p tcp -d 10.4.10.10 --dport 636 -j DROP
uv --directory /home/bonclay/NetExec run netexec ldap 10.4.10.10
```

## Screenshots (if appropriate):
<img width="1512" height="756" alt="2026-06-29_15-07" src="https://github.com/user-attachments/assets/04ab8e4e-7574-440e-97ac-fdbf4e73e63b" />


fixed
<img width="1517" height="124" alt="2026-06-29_15-07_1" src="https://github.com/user-attachments/assets/601f22a4-1104-455b-98f7-4ad247d91c11" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
