### PR TITLE
Fix SMBv1 None

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -614,12 +614,15 @@ class smb(connection):
                 self.logger.debug(f"Timeout creating SMBv1 connection to {self.host}")
             else:
                 self.logger.info(f"Error creating SMBv1 connection to {self.host}: {e}")
+            self.smbv1 = False
             return False
         except NetBIOSError:
             self.logger.info(f"SMBv1 disabled on {self.host}")
+            self.smbv1 = False
             return False
         except (Exception, NetBIOSTimeout) as e:
             self.logger.info(f"Error creating SMBv1 connection to {self.host}: {e}")
+            self.smbv1 = False
             return False
         return True
 
@@ -641,6 +644,7 @@ class smb(connection):
                 self.logger.debug(f"Timeout creating SMBv3 connection to {self.host}")
             else:
                 self.logger.info(f"Error creating SMBv3 connection to {self.host}: {e}")
+            self.smbv3 = False
             return False
         return True
 

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -49,6 +49,7 @@ from impacket.smb3structs import (
     SMB2_0_IOCTL_IS_FSCTL,
     WRITE_DAC,
     WRITE_OWNER,
+    SMB2_DIALECT_302,
 )
 
 from impacket.dcerpc.v5 import tsts as TSTS
@@ -631,6 +632,7 @@ class smb(connection):
                 None,
                 self.port,
                 timeout=self.args.smb_timeout,
+                preferredDialect=SMB2_DIALECT_302,
             )
             self.smbv3 = True
         except (Exception, NetBIOSTimeout, OSError) as e:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -50,7 +50,6 @@ from impacket.smb3structs import (
     SMB2_0_IOCTL_IS_FSCTL,
     WRITE_DAC,
     WRITE_OWNER,
-    SMB2_DIALECT_302,
 )
 
 from impacket.dcerpc.v5 import tsts as TSTS
@@ -655,7 +654,6 @@ class smb(connection):
                 None,
                 self.port,
                 timeout=self.args.smb_timeout,
-                preferredDialect=SMB2_DIALECT_302,
             )
             self.smbv3 = True
         except (Exception, NetBIOSTimeout, OSError) as e:


### PR DESCRIPTION
## Description
With commit https://github.com/fortra/impacket/commit/8f8172055c12d7c219c633a21fc74e2bd9aa1371 impacket will automatically negotiate SMB 3.1.1. Unfortunately, from SMB 3.1.1 and onwards SMB signing seems to be [required by default](https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-feature-descriptions?tabs=smb-dialect#smb-signing-required-by-default), see issue #1292. Therefore, for the intermediate future we should pin the SMB version to 3.0.2 so we still have signing enumeration (otherwise relaying would probably fail as well). We should add another round for creating SMBv3 connections should our preferred dialect be rejected.

Depends on https://github.com/fortra/impacket/pull/2220 being merged first tho.

Also fixed SMBv1 enumeration text to be "False" when actually not available instead of "None".

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Run NetExec against a host with signing not required

## Screenshots (if appropriate):
Before&After:
<img width="1484" height="195" alt="image" src="https://github.com/user-attachments/assets/7d5b2e9d-1a1a-44b3-9a97-2cdb4facc648" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
