### PR TITLE
Fix: add dploot.triage.cng to netexec.spec

### DIFF
--- a/netexec.spec
+++ b/netexec.spec
@@ -81,6 +81,7 @@ a = Analysis(
         'dploot.triage.wam',
         'dploot.triage.wifi',
         'dploot.triage.sccm',
+        'dploot.triage.cng',
         'dploot.lib.target',
         'dploot.lib.smb',
         'pyasn1_modules.rfc5652',


### PR DESCRIPTION
## Description
Solves #1198

Adding `hiddenimport` to the `netexec.spec` file to prevent a `ModuleNotFoundError` when using a binary built with PyInstaller

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Python version: 3.14.6
OS: Arch Linux (BlackArch repo enabled)
command: nxc smb <target>
Error: ModuleNotFoundError

## Screenshots (if appropriate):
Before
<img width="771" height="245" alt="imagen" src="https://github.com/user-attachments/assets/3f7f339b-f7a3-41c3-bf92-6f6472b73f6e" />
======================================
After
<img width="389" height="98" alt="imagen" src="https://github.com/user-attachments/assets/237b6e8c-8fcd-4778-9864-372ddc0bad01" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
