### PR TITLE
fix(onelogon): allow onelogon module to work with same forrests and cross forrest

### DIFF
--- a/nxc/modules/onelogon.py
+++ b/nxc/modules/onelogon.py
@@ -24,7 +24,7 @@ class NXCModule:
 
         found_dacls = []
 
-        policies = connection.conn.listPath("SYSVOL", f"{connection.domain}/Policies/*")
+        policies = connection.conn.listPath("SYSVOL", f"{connection.targetDomain}/Policies/*")
         for policy in policies:
             # Skip "." and ".." directory pointers to avoid path errors
             if policy.get_longname() in [".", ".."]:
@@ -32,7 +32,7 @@ class NXCModule:
 
             try:
                 self.gpo_data = b""
-                connection.conn.getFile("SYSVOL", f"{connection.domain}/Policies/{policy.get_longname()}/MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf", output_callback)
+                connection.conn.getFile("SYSVOL", f"{connection.targetDomain}/Policies/{policy.get_longname()}/MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf", output_callback)
 
                 try:
                     decoded_data = self.gpo_data.decode("utf-8")


### PR DESCRIPTION
## Description
Hi very small bug fix. The onelogon module builds the path in which it searches for GPOs with the domain the user authenticates with not with the domain the user sets as target. 

Found this with: Claude Code, Sonnet 5. 

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
I used standard GOAD and had Claude walk me through setting up a new GPO to test the new onelogon module. Specifically, I created it inside sevenkingdoms.local. Added security options: "Domain controller: Allow vulnerable Netlogon secure channel connections" and added an ACE to allow "Create Vulnerable Connections" for KINGSLANDING$. 

Before:
```
kali@kali ~> nxc smb sevenkingdoms.local -d north.sevenkingdoms.local -u arya.stark -p Needle -M onelogon                                                                   SMB         10.2.10.10      445    KINGSLANDING     [*] Windows 10 / Server 2019 Build 17763 x64 (name:KINGSLANDING) (domain:sevenkingdoms.local) (signing:True) (SMBv1:False) (Null Auth:True)
SMB         10.2.10.10      445    KINGSLANDING     [+] north.sevenkingdoms.local\arya.stark:Needle
[20:35:55] ERROR    Exception while calling proto_flow() on target sevenkingdoms.local: SMB SessionError: code: 0xc000003a - STATUS_OBJECT_PATH_NOT_FOUND  connection.py:190
                    - {Path Not Found} The path %hs does not exist.
                    ╭──────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────╮
                    │ /home/kali/.local/share/uv/tools/netexec/lib/python3.13/site-packages/impacket/smbconnection.py:418 in listPath                    │
                    │                                                                                                                                    │
                    │    415 │   │   """                                                                                                                 │
                    │    416 │   │                                                                                                                       │
                    │    417 │   │   try:                                                                                                                │
                    │ ❱  418 │   │   │   return self._SMBConnection.list_path(shareName, path, password)                                                 │
                    │    419 │   │   except (smb.SessionError, smb3.SessionError) as e:                                                                  │
                    │    420 │   │   │   raise SessionError(e.get_error_code(), e.get_error_packet())                                                    │
                    │    421                                                                                                                             │
                    │                                                                                                                                    │
                    │ /home/kali/.local/share/uv/tools/netexec/lib/python3.13/site-packages/impacket/smb3.py:1810 in listPath                            │
                    │                                                                                                                                    │
                    │   1807 │   │   fileId = None                                                                                                       │
                    │   1808 │   │   try:                                                                                                                │
                    │   1809 │   │   │   # ToDo, we're assuming it's a directory, we should check what the file type                                     │
                    │        is                                                                                                                          │
                    │ ❱ 1810 │   │   │   fileId = self.create(treeId, ntpath.dirname(path), FILE_READ_ATTRIBUTES |                                       │
                    │        FILE_READ_DATA, FILE_SHARE_READ |                                                                                           │
                    │   1811 │   │   │   │   │   │   │   │    FILE_SHARE_WRITE | FILE_SHARE_DELETE,                                                      │
                    │   1812 │   │   │   │   │   │   │   │    FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT,                                        │
                    │        FILE_OPEN, 0,                                                                                                               │
                    │   1813 │   │   │   │   │   │   │   │    createContexts=createContexts)                                                             │
                    │                                                                                                                                    │
                    │ /home/kali/.local/share/uv/tools/netexec/lib/python3.13/site-packages/impacket/smb3.py:1327 in create                              │
                    │                                                                                                                                    │
                    │   1324 │   │                                                                                                                       │
                    │   1325 │   │   packetID = self.sendSMB(packet)                                                                                     │
                    │   1326 │   │   ans = self.recvSMB(packetID)                                                                                        │
                    │ ❱ 1327 │   │   if ans.isValidAnswer(STATUS_SUCCESS):                                                                               │
                    │   1328 │   │   │   createResponse = SMB2Create_Response(ans['Data'])                                                               │
                    │   1329 │   │   │                                                                                                                   │
                    │   1330 │   │   │   openFile = copy.deepcopy(OPEN)                                                                                  │
                    │                                                                                                                                    │
                    │ /home/kali/.local/share/uv/tools/netexec/lib/python3.13/site-packages/impacket/smb3structs.py:587 in isValidAnswer                 │
                    │                                                                                                                                    │
                    │    584 │   def isValidAnswer(self, status):                                                                                        │
                    │    585 │   │   if self['Status'] != status:                                                                                        │
                    │    586 │   │   │   from . import smb3                                                                                              │
                    │ ❱  587 │   │   │   raise smb3.SessionError(self['Status'], self)                                                                   │
                    │    588 │   │   return True                                                                                                         │
                    │    589 │                                                                                                                           │
                    │    590 │   def __init__(self, data = None):                                                                                        │
                    ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                    SessionError: SMB SessionError: STATUS_OBJECT_PATH_NOT_FOUND({Path Not Found} The path %hs does not exist.)

                    During handling of the above exception, another exception occurred:

                    ╭──────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────╮
                    │ /home/kali/.local/share/uv/tools/netexec/lib/python3.13/site-packages/nxc/connection.py:180 in __init__                            │
                    │                                                                                                                                    │
                    │   177 │   │   self.logger.info(f"Socket info: host={self.host}, hostname={self.hostname},                                          │
                    │       kerberos={self.kerberos}, ipv6={self.is_ipv6}, link-local                                                                    │
                    │       ipv6={self.is_link_local_ipv6}")                                                                                             │
                    │   178 │   │                                                                                                                        │
                    │   179 │   │   try:                                                                                                                 │
                    │ ❱ 180 │   │   │   self.proto_flow()                                                                                                │
                    │   181 │   │   except FileNotFoundError as e:                                                                                       │
                    │   182 │   │   │   self.logger.error(f"File not found error on target {target}: {e}")                                               │
                    │   183 │   │   except Exception as e:                                                                                               │
                    │                                                                                                                                    │
                    │ /home/kali/.local/share/uv/tools/netexec/lib/python3.13/site-packages/nxc/connection.py:263 in proto_flow                          │
                    │                                                                                                                                    │
                    │   260 │   │   │   │   if self.args.module:                                                                                         │
                    │   261 │   │   │   │   │   self.load_modules()                                                                                      │
                    │   262 │   │   │   │   │   self.logger.debug("Calling modules")                                                                     │
                    │ ❱ 263 │   │   │   │   │   self.call_modules()                                                                                      │
                    │   264 │   │   │   self.disconnect()                                                                                                │
                    │   265 │                                                                                                                            │
                    │   266 │   def call_cmd_args(self):                                                                                                 │
                    │                                                                                                                                    │
                    │ /home/kali/.local/share/uv/tools/netexec/lib/python3.13/site-packages/nxc/connection.py:310 in call_modules                        │
                    │                                                                                                                                    │
                    │   307 │   │   │                                                                                                                    │
                    │   308 │   │   │   if hasattr(module, "on_login"):                                                                                  │
                    │   309 │   │   │   │   self.logger.debug(f"Module {module.name} has on_login method")                                               │
                    │ ❱ 310 │   │   │   │   module.on_login(context, self)                                                                               │
                    │   311 │   │   │                                                                                                                    │
                    │   312 │   │   │   if self.admin_privs and hasattr(module, "on_admin_login"):                                                       │
                    │   313 │   │   │   │   self.logger.debug(f"Module {module.name} has on_admin_login method")                                         │
                    │                                                                                                                                    │
                    │ /home/kali/.local/share/uv/tools/netexec/lib/python3.13/site-packages/nxc/modules/onelogon.py:27 in on_login                       │
                    │                                                                                                                                    │
                    │   24 │   │                                                                                                                         │
                    │   25 │   │   found_dacls = []                                                                                                      │
                    │   26 │   │                                                                                                                         │
                    │ ❱ 27 │   │   policies = connection.conn.listPath("SYSVOL", f"{connection.domain}/Policies/*")                                      │
                    │   28 │   │   for policy in policies:                                                                                               │
                    │   29 │   │   │   # Skip "." and ".." directory pointers to avoid path errors                                                       │
                    │   30 │   │   │   if policy.get_longname() in [".", ".."]:                                                                          │
                    │                                                                                                                                    │
                    │ /home/kali/.local/share/uv/tools/netexec/lib/python3.13/site-packages/impacket/smbconnection.py:420 in listPath                    │
                    │                                                                                                                                    │
                    │    417 │   │   try:                                                                                                                │
                    │    418 │   │   │   return self._SMBConnection.list_path(shareName, path, password)                                                 │
                    │    419 │   │   except (smb.SessionError, smb3.SessionError) as e:                                                                  │
                    │ ❱  420 │   │   │   raise SessionError(e.get_error_code(), e.get_error_packet())                                                    │
                    │    421 │                                                                                                                           │
                    │    422 │   def createFile(self, treeId, pathName, desiredAccess=GENERIC_ALL,                                                       │
                    │    423 │   │   │   │      shareMode=FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,                                        │
                    ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                    SessionError: SMB SessionError: code: 0xc000003a - STATUS_OBJECT_PATH_NOT_FOUND - {Path Not Found} The path %hs does not exist.
```
Then:
```
kali@kali ~> sed -i 's/connection\.domain}\/Policies/connection.targetDomain}\/Policies/' /home/kali/.local/share/uv/tools/
```
After:
```
netexec/lib/python3.13/site-packages/nxc/modules/onelogon.py
kali@kali ~> nxc smb sevenkingdoms.local -d north.sevenkingdoms.local -u arya.stark -p Needle -M onelogon                                                                   SMB         10.2.10.10      445    KINGSLANDING     [*] Windows 10 / Server 2019 Build 17763 x64 (name:KINGSLANDING) (domain:sevenkingdoms.local) (signing:True) (SMBv1:False) (Null Auth:True)
SMB         10.2.10.10      445    KINGSLANDING     [+] north.sevenkingdoms.local\arya.stark:Needle
ONELOGON    10.2.10.10      445    KINGSLANDING     [+] Found 1 matching policies in SYSVOL Share.
ONELOGON    10.2.10.10      445    KINGSLANDING     [+] Found vulnerable channel allow list in policy '{D8322AE1-744E-4938-811E-BAE018E619ED}': 'O:BAG:BAD:(A;;RC;;;BA)(A;;RC;;;S-1-5-21-1896333292-1174436157-3381432861-1001)'
```

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
