### PR TITLE
Add mssql version and encryption req flags in DB

### DIFF
--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -97,6 +97,12 @@ class mssql(connection):
             resp = self.conn.preLogin()
             self.encryption = False
 
+            # Parses the MSSQL version
+            self.edition, self.version = (
+                str(self.conn.mssql_version).split("Server ")[1].split(" (")[0],
+                str(self.conn.mssql_version).rsplit("(", 1)[1].rstrip(")")
+            )
+
             if resp["Encryption"] == TDS_ENCRYPT_REQ or resp["Encryption"] == TDS_ENCRYPT_OFF:
                 # We switch to a TLS context handled by tds.py
                 self.conn.set_tls_context()
@@ -148,7 +154,7 @@ class mssql(connection):
                 self.logger.debug(f"Server does not support NTLM{detail}")
                 self.no_ntlm = True
 
-        self.db.add_host(self.host, self.hostname, self.domain, self.server_os, len(self.mssql_instances))
+        self.db.add_host(self.host, self.hostname, self.domain, self.server_os, self.version, len(self.mssql_instances), self.encryption)
 
         if self.args.domain:
             self.domain = self.args.domain
@@ -165,13 +171,7 @@ class mssql(connection):
     def print_host_info(self):
         encryption = colored(f"EncryptionReq:{self.encryption}", host_info_colors[0 if self.encryption else 1], attrs=["bold"])
         ntlm = colored(f"(NTLM:{not self.no_ntlm})", host_info_colors[2], attrs=["bold"]) if self.no_ntlm else ""
-
-        edition, version = (
-            str(self.conn.mssql_version).split("Server ")[1].split(" (")[0],
-            str(self.conn.mssql_version).rsplit("(", 1)[1].rstrip(")")
-        )
-
-        self.logger.display(f"{self.server_os} ({edition} {version}) (name:{self.hostname}) (domain:{self.targetDomain}) ({encryption}) {ntlm}")
+        self.logger.display(f"{self.server_os} ({self.edition} {self.version}) (name:{self.hostname}) (domain:{self.targetDomain}) ({encryption}) {ntlm}")
 
     @reconnect_mssql
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):

--- a/nxc/protocols/mssql/database.py
+++ b/nxc/protocols/mssql/database.py
@@ -1,6 +1,6 @@
 import warnings
 
-from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, func, select, insert, delete
+from sqlalchemy import Column, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, func, select, insert, delete, Boolean
 from sqlalchemy.dialects.sqlite import Insert  # used for upsert
 from sqlalchemy.exc import SAWarning
 from sqlalchemy.orm import declarative_base
@@ -29,7 +29,9 @@ class database(BaseDB):
         hostname = Column(String)
         domain = Column(String)
         os = Column(String)
+        mssqlversion = Column(String)
         instances = Column(Integer)
+        encryptionReq = Column(Boolean)
 
         __table_args__ = (
             PrimaryKeyConstraint("id"),
@@ -83,12 +85,12 @@ class database(BaseDB):
         self.AdminRelationsTable = self.reflect_table(self.AdminRelation)
         self.LoggedinRelationsTable = self.reflect_table(self.LoggedInRelation)
 
-    def add_host(self, ip, hostname, domain, os, instances):
+    def add_host(self, ip, hostname, domain, os, mssqlversion, instances, encryptionReq):
         """
         Check if this host has already been added to the database, if not, add it in.
         TODO: return inserted or updated row ids as a list
         """
-        nxc_logger.debug(f"{domain} {ip} {os} {instances}")
+        nxc_logger.debug(f"{domain} {ip} {os} {mssqlversion} {instances} {encryptionReq}")
         if not domain:
             domain = ""
         hosts = []
@@ -102,7 +104,9 @@ class database(BaseDB):
             "hostname": hostname,
             "domain": domain,
             "os": os,
+            "mssqlversion": mssqlversion,
             "instances": instances,
+            "encryptionReq": encryptionReq
         }
 
         if not results:
@@ -118,8 +122,12 @@ class database(BaseDB):
                     host_data["domain"] = domain
                 if os is not None:
                     host_data["os"] = os
+                if mssqlversion is not None:
+                    host_data["mssqlversion"] = mssqlversion
                 if instances is not None:
                     host_data["instances"] = instances
+                if encryptionReq is not None:
+                    host_data["encryptionReq"] = encryptionReq
                 if host_data not in hosts:
                     hosts.append(host_data)
 

--- a/nxc/protocols/mssql/db_navigator.py
+++ b/nxc/protocols/mssql/db_navigator.py
@@ -21,7 +21,7 @@ class navigator(DatabaseNavigator):
         print_table(data, title="Credentials")
 
     def display_hosts(self, hosts):
-        data = [["HostID", "Admins", "IP", "Hostname", "Domain", "OS", "DB Instances"]]
+        data = [["HostID", "Admins", "IP", "Hostname", "Domain", "OS", "MSSQL Version", "DB Instances", "EncryptionReq"]]
         for host in hosts:
             links = self.db.get_admin_relations(host_id=host[0])
             data.append(
@@ -33,6 +33,8 @@ class navigator(DatabaseNavigator):
                     host[3],
                     host[4],
                     host[5],
+                    host[6],
+                    host[7]
                 ]
             )
         print_table(data, title="Hosts")
@@ -49,12 +51,12 @@ class navigator(DatabaseNavigator):
             if len(hosts) > 1:
                 self.display_hosts(hosts)
             elif len(hosts) == 1:
-                data = [["HostID", "IP", "Hostname", "Domain", "OS"]]
+                data = [["HostID", "IP", "Hostname", "Domain", "OS", "MSSQL Version", "DB Instances", "EncryptionReq"]]
                 host_id_list = []
 
                 for host in hosts:
                     host_id_list.append(host[0])
-                    data.append([host[0], host[1], host[2], host[3], host[4]])
+                    data.append([host[0], host[1], host[2], host[3], host[4], host[5], host[6], host[7]])
 
                 print_table(data, title="Host(s)")
 


### PR DESCRIPTION
## Description
This PR adds 2 new columns in the NXCDB for the MSSQL protocol, MSSQL version and EncryptionReq:

<img width="1401" height="331" alt="image" src="https://github.com/user-attachments/assets/a7cbb1ca-4438-47ce-9cc6-8a76fe2906d8" />

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Nothign new.

## Screenshots (if appropriate):

No.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
