### PR TITLE
Fix rid bruteforce in MSSQL

### DIFF
--- a/nxc/protocols/mssql.py
+++ b/nxc/protocols/mssql.py
@@ -451,7 +451,7 @@ class mssql(connection):
 
             # Query known group to determine raw SID & convert to canon
             raw_domain_sid = self.conn.sql_query(f"SELECT SUSER_SID('{domain}\\Domain Admins')")[0][""]
-            domain_sid = SID(bytes.fromhex(raw_domain_sid.decode())).formatCanonical()[:-4]
+            domain_sid = SID(bytes.fromhex(raw_domain_sid)).formatCanonical()[:-4]
         except Exception as e:
             self.logger.fail(f"Error parsing SID. Not domain joined?: {e}")
             return entries

--- a/poetry.lock
+++ b/poetry.lock
@@ -516,7 +516,7 @@ dev = ["black (>=23.0.0)", "mypy (>=1.0.0)", "pytest (>=7.0.0)", "pytest-cov (>=
 
 [[package]]
 name = "certipy-ad"
-version = "5.0.4"
+version = "5.1.0"
 description = "Active Directory Certificate Services enumeration and abuse"
 optional = false
 python-versions = ">=3.10"
@@ -544,7 +544,7 @@ bloodhound = ["neo4j (>=5.28.1,<5.29.0)"]
 type = "git"
 url = "https://github.com/Pennyw0rth/Certipy"
 reference = "HEAD"
-resolved_reference = "49a4aa6b17d2246491a81f89b0d7d74b732c66d4"
+resolved_reference = "069e03113095aa02772aa3d8debea90654933fe4"
 
 [[package]]
 name = "cffi"


### PR DESCRIPTION
## Description
Fixes an issue with `--rid-brute` mentioned on the discord. For some reason the returned SID by impacket is already a string now and doesn't need to be decoded anymore 🤷 

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
`nxc mssql -u -p --rid-brute`

## Screenshots (if appropriate):
Before&After:
<img width="1547" height="482" alt="image" src="https://github.com/user-attachments/assets/06357ee3-d9f3-4ccc-8993-e6d244aa6f89" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
