### PR TITLE
feat(smb): add a cli option to disable the null-auth test for OPSEC reasons

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -94,6 +94,7 @@ def gen_cli_args():
     credential_group.add_argument("--gfail-limit", metavar="LIMIT", type=int, help="max number of global failed login attempts")
     credential_group.add_argument("--ufail-limit", metavar="LIMIT", type=int, help="max number of failed login attempts per username")
     credential_group.add_argument("--fail-limit", metavar="LIMIT", type=int, help="max number of failed login attempts per host")
+    credential_group.add_argument("--no-null-auth", action="store_true", help="No null auth when calling enum_host_info")
 
     kerberos_group = std_parser.add_argument_group("Kerberos Authentication")
     kerberos_group.add_argument("-k", "--kerberos", action="store_true", help="Use Kerberos authentication")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -188,17 +188,30 @@ class smb(connection):
     def enum_host_info(self):
         self.local_ip = self.conn.getSMBServer().get_socket().getsockname()[0]
 
-        try:
-            self.conn.login("", "")
-            self.null_auth = True
-        except BrokenPipeError:
-            self.logger.fail("Broken Pipe Error while attempting to login")
-        except Exception as e:
-            self.null_auth = False
-            if "STATUS_NOT_SUPPORTED" in str(e):
-                # no ntlm supported
-                self.no_ntlm = True
-                self.logger.debug("NTLM not supported")
+        # If the user doesn't want to perform a null-auth test for OPSEC reasons
+        if not self.args.no_null_auth:
+            try:
+                self.conn.login("", "")
+                self.null_auth = True
+            except BrokenPipeError:
+                self.logger.fail("Broken Pipe Error while attempting to login")
+            except Exception as e:
+                self.null_auth = False
+                if "STATUS_NOT_SUPPORTED" in str(e):
+                    # no ntlm supported
+                    self.no_ntlm = True
+                    self.logger.debug("NTLM not supported")
+        else:
+            try:
+                # Needed to get the OS arch and hostname
+                self.conn.login(gen_random_string(10), gen_random_string(10))
+            except BrokenPipeError:
+                self.logger.fail("Broken Pipe Error while attempting to login")
+            except Exception as e:
+                if "STATUS_NOT_SUPPORTED" in str(e):
+                    # no ntlm supported
+                    self.no_ntlm = True
+                    self.logger.debug("NTLM not supported")
 
         if check_guest_account and not self.no_ntlm:
             try:

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -5,6 +5,7 @@ netexec smb TARGET_HOST --generate-hosts-file /tmp/hostsfile
 netexec smb TARGET_HOST --generate-krb5-file /tmp/krb5conf
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec {DNS} smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --no-null-auth
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --shares
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --shares --no-smbv1
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --shares --filter-shares READ WRITE


### PR DESCRIPTION
## Description
When using the SMB protocol, `nxc` performs an anonymous login in the [enum_host_info](https://github.com/Pennyw0rth/NetExec/blob/ff198407f82c0b06855e172603db6a0d98d5599c/nxc/protocols/smb.py#L192) function. 
Null sessions are usually heavily monitored and can cause some OPSEC concerns.

This PR, add a `--no-null-auth` option to disable this authentication, replacing it with an authentication made with a random username and password, in order to still get the hostname and Os architecture. 

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Just run against an host with the `--no-null-auth` flag.

## Screenshots (if appropriate):

<img width="1789" height="224" alt="netexec_disable_null_auth" src="https://github.com/user-attachments/assets/6e9d5a62-f9c8-4558-8b49-9f58e873f619" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
