### PR TITLE
Feature(audit-mode): redact SAM/LSA/NTDS, DPAPI/SCCM and Kerberos/GMSA secrets when audit_mode is enabled

### DIFF
--- a/nxc/config.py
+++ b/nxc/config.py
@@ -50,15 +50,16 @@ def process_secret(text):
     return text if not audit_mode else reveal + (audit_mode if len(audit_mode) > 1 else audit_mode * 8)
 
 
-def process_secret_dump(line, sep=":"):
+def process_secret_dump(line, sep=":", keep=1):
     """
     Redacts the credential material of a dumped secret line (SAM/LSA/NTDS) when audit_mode is
-    enabled, keeping only the identifier (username, secret name, etc.) before the first separator.
+    enabled, keeping only the first `keep` fields (username, RID, secret name, etc.) before
+    masking the rest of the line.
     """
     if not audit_mode:
         return line
-    if sep not in line:
+    parts = line.split(sep)
+    if len(parts) <= keep:
         return process_secret(line)
-    identifier, _, _ = line.partition(sep)
     mask = audit_mode if len(audit_mode) > 1 else audit_mode * 8
-    return f"{identifier}{sep}{mask}"
+    return sep.join([*parts[:keep], mask])

--- a/nxc/config.py
+++ b/nxc/config.py
@@ -48,3 +48,17 @@ if len(host_info_colors) != 4:
 def process_secret(text):
     reveal = text[:reveal_chars_of_pwd]
     return text if not audit_mode else reveal + (audit_mode if len(audit_mode) > 1 else audit_mode * 8)
+
+
+def process_secret_dump(line, sep=":"):
+    """
+    Redacts the credential material of a dumped secret line (SAM/LSA/NTDS) when audit_mode is
+    enabled, keeping only the identifier (username, secret name, etc.) before the first separator.
+    """
+    if not audit_mode:
+        return line
+    if sep not in line:
+        return process_secret(line)
+    identifier, _, _ = line.partition(sep)
+    mask = audit_mode if len(audit_mode) > 1 else audit_mode * 8
+    return f"{identifier}{sep}{mask}"

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -38,7 +38,7 @@ from impacket.ldap.ldap import LDAPFilterSyntaxError, MODIFY_REPLACE
 from impacket.smbconnection import SessionError
 from impacket.ntlm import getNTLMSSPType1
 
-from nxc.config import process_secret, host_info_colors
+from nxc.config import process_secret, process_secret_dump, host_info_colors
 from nxc.connection import connection
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.misc import get_bloodhound_info, convert, d2b, parse_argument
@@ -321,7 +321,7 @@ class ldap(connection):
         if self.username and self.password == "" and self.args.asreproast:
             hash_tgt = KerberosAttacks(self).get_tgt_asroast(self.username)
             if hash_tgt:
-                self.logger.highlight(f"{hash_tgt}")
+                self.logger.highlight(process_secret_dump(hash_tgt))
                 with open(self.args.asreproast, "a+") as hash_asreproast:
                     hash_asreproast.write(f"{hash_tgt}\n")
             return False
@@ -446,7 +446,7 @@ class ldap(connection):
         if self.username and self.password == "" and self.args.asreproast:
             hash_tgt = KerberosAttacks(self).get_tgt_asroast(self.username)
             if hash_tgt:
-                self.logger.highlight(f"{hash_tgt}")
+                self.logger.highlight(process_secret_dump(hash_tgt))
                 with open(self.args.asreproast, "a+") as hash_asreproast:
                     hash_asreproast.write(f"{hash_tgt}\n")
             return False
@@ -542,7 +542,7 @@ class ldap(connection):
         if self.username and self.hash == "" and self.args.asreproast:
             hash_tgt = KerberosAttacks(self).get_tgt_asroast(self.username)
             if hash_tgt:
-                self.logger.highlight(f"{hash_tgt}")
+                self.logger.highlight(process_secret_dump(hash_tgt))
                 with open(self.args.asreproast, "a+") as hash_asreproast:
                     hash_asreproast.write(f"{hash_tgt}\n")
             return False
@@ -969,7 +969,7 @@ class ldap(connection):
             for user in resp_parsed:
                 hash_TGT = KerberosAttacks(self).get_tgt_asroast(user["sAMAccountName"])
                 if hash_TGT:
-                    self.logger.highlight(f"{hash_TGT}")
+                    self.logger.highlight(process_secret_dump(hash_TGT))
                     with open(self.args.asreproast, "a+") as hash_asreproast:
                         hash_asreproast.write(f"{hash_TGT}\n")
 
@@ -1071,7 +1071,7 @@ class ldap(connection):
                         pwdLastSet = "<never>" if str(user.get("pwdLastSet", 0)) == "0" else str(datetime.fromtimestamp(self.getUnixTime(int(user["pwdLastSet"]))))
                         lastLogon = "<never>" if str(user.get("lastLogon", 0)) == "0" else str(datetime.fromtimestamp(self.getUnixTime(int(user["lastLogon"]))))
                         self.logger.display(f"sAMAccountName: {user['sAMAccountName']}, memberOf: {user.get('memberOf', [])}, pwdLastSet: {pwdLastSet}, lastLogon: {lastLogon}")
-                        self.logger.highlight(out)
+                        self.logger.highlight(process_secret_dump(out, sep="*", keep=2))
                         if self.args.kerberoasting:
                             with open(self.args.kerberoasting, "a+") as hash_kerberoasting:
                                 hash_kerberoasting.write(out + "\n")

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1339,10 +1339,10 @@ class ldap(connection):
                 aes128 = aes256 = ""
                 if "msDS-ManagedPassword" in acc:
                     rc4, aes128, aes256 = self.gmsa_compute_secrets(acc["msDS-ManagedPassword"], acc["sAMAccountName"])
-                self.logger.highlight(f"Account: {acc['sAMAccountName']:<20} NTLM: {rc4:<36} PrincipalsAllowedToReadPassword: {principal_with_read}")
+                self.logger.highlight(f"Account: {acc['sAMAccountName']:<20} NTLM: {process_secret(rc4):<36} PrincipalsAllowedToReadPassword: {principal_with_read}")
                 if aes128 and aes256:
-                    self.logger.highlight(f"Account: {acc['sAMAccountName']:<20} aes128-cts-hmac-sha1-96: {aes128}")
-                    self.logger.highlight(f"Account: {acc['sAMAccountName']:<20} aes256-cts-hmac-sha1-96: {aes256}")
+                    self.logger.highlight(f"Account: {acc['sAMAccountName']:<20} aes128-cts-hmac-sha1-96: {process_secret(aes128)}")
+                    self.logger.highlight(f"Account: {acc['sAMAccountName']:<20} aes256-cts-hmac-sha1-96: {process_secret(aes256)}")
 
     def gmsa_compute_secrets(self, password_data: bytes, sAMAccountName: str):
         """Generate RC4, AES128, and AES256 keys for a GMSA account based on the provided password data and username."""
@@ -1407,12 +1407,12 @@ class ldap(connection):
             # Compute the password and keys
             data = bytes.fromhex(gmsa_pass)
             rc4, aes128, aes256 = self.gmsa_compute_secrets(data, sAMAccountName)
-            self.logger.highlight(f"Account: {sAMAccountName:<20} NTLM: {rc4}")
+            self.logger.highlight(f"Account: {sAMAccountName:<20} NTLM: {process_secret(rc4)}")
             if not sAMAccountName:
                 self.logger.fail("Could not find the GMSA account associated with the provided ID.")
             else:
-                self.logger.highlight(f"Account: {sAMAccountName:<20} aes128-cts-hmac-sha1-96: {aes128}")
-                self.logger.highlight(f"Account: {sAMAccountName:<20} aes256-cts-hmac-sha1-96: {aes256}")
+                self.logger.highlight(f"Account: {sAMAccountName:<20} aes128-cts-hmac-sha1-96: {process_secret(aes128)}")
+                self.logger.highlight(f"Account: {sAMAccountName:<20} aes256-cts-hmac-sha1-96: {process_secret(aes256)}")
         else:
             self.logger.fail("The provided string does not appear to be a valid GMSA LSA secret.")
 

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -54,7 +54,7 @@ from impacket.smb3structs import (
 
 from impacket.dcerpc.v5 import tsts as TSTS
 
-from nxc.config import process_secret, host_info_colors, check_guest_account
+from nxc.config import process_secret, process_secret_dump, host_info_colors, check_guest_account
 from nxc.connection import connection, sem, requires_admin, dcom_FirewallChecker
 from nxc.helpers.misc import gen_random_string, validate_ntlm
 from nxc.logger import NXCAdapter
@@ -2102,7 +2102,7 @@ class smb(connection):
             host_id = self.db.get_hosts(filter_term=self.host)[0][0]
 
             def add_sam_hash(sam_hash, host_id):
-                self.logger.highlight(sam_hash)
+                self.logger.highlight(process_secret_dump(sam_hash))
                 if "_history" in sam_hash:
                     return
                 username, _, lmhash, nthash, _, _, _ = sam_hash.split(":")
@@ -2422,7 +2422,7 @@ class smb(connection):
 
             def add_lsa_secret(secret):
                 add_lsa_secret.secrets += 1
-                self.logger.highlight(secret)
+                self.logger.highlight(process_secret_dump(secret))
                 if "_SC_GMSA_{84A78B8C" in secret:
                     gmsa_id = secret.split("_")[4].split(":")[0]
                     data = bytes.fromhex(secret.split("_")[4].split(":")[1])
@@ -2432,7 +2432,7 @@ class smb(connection):
                     ntlm_hash = MD4.new()
                     ntlm_hash.update(currentPassword)
                     passwd = binascii.hexlify(ntlm_hash.digest()).decode("utf-8")
-                    self.logger.highlight(f"GMSA ID: {gmsa_id:<20} NTLM: {passwd}")
+                    self.logger.highlight(process_secret_dump(f"GMSA ID: {gmsa_id:<20} NTLM: {passwd}", sep="NTLM: "))
 
             add_lsa_secret.secrets = 0
 
@@ -2494,10 +2494,10 @@ class smb(connection):
             if self.args.enabled:
                 if "Enabled" in secret:
                     secret = " ".join(secret.split(" ")[:-1])
-                    self.logger.highlight(secret)
+                    self.logger.highlight(process_secret_dump(secret))
             else:
                 secret = " ".join(secret.split(" ")[:-1]) if " " in secret else secret
-                self.logger.highlight(secret)
+                self.logger.highlight(process_secret_dump(secret))
 
             # Filter out computer accounts, history hashes and kerberos keys for adding to db
             if secret.find("$") == -1 and secret_type == NTDSHashes.SECRET_TYPE.NTDS and "_history" not in secret:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -2267,7 +2267,7 @@ class smb(connection):
         # Collect User and Machine Credentials Manager secrets
         def credential_callback(credential):
             tag = "CREDENTIAL"
-            line = f"[{credential.winuser}][{tag}] {credential.target} - {credential.username}:{credential.password}"
+            line = f"[{credential.winuser}][{tag}] {credential.target} - {credential.username}:{process_secret(credential.password)}"
             self.logger.highlight(line)
             if self.output_file:
                 self.output_file.write(line + "\n")
@@ -2305,7 +2305,7 @@ class smb(connection):
         def browser_callback(secret):
             if isinstance(secret, LoginData):
                 secret_url = secret.url + " -" if secret.url != "" else "-"
-                line = f"[{secret.winuser}][{secret.browser.upper()}] {secret_url} {secret.username}:{secret.password}"
+                line = f"[{secret.winuser}][{secret.browser.upper()}] {secret_url} {secret.username}:{process_secret(secret.password)}"
                 self.logger.highlight(line)
                 if self.output_file:
                     self.output_file.write(line + "\n")
@@ -2318,7 +2318,7 @@ class smb(connection):
                     secret.url,
                 )
             elif isinstance(secret, GoogleRefreshToken):
-                line = f"[{secret.winuser}][{secret.browser.upper()}] Google Refresh Token: {secret.service}:{secret.token}"
+                line = f"[{secret.winuser}][{secret.browser.upper()}] Google Refresh Token: {secret.service}:{process_secret(secret.token)}"
                 self.logger.highlight(line)
                 if self.output_file:
                     self.output_file.write(line + "\n")
@@ -2331,7 +2331,7 @@ class smb(connection):
                     "Google Refresh Token",
                 )
             elif isinstance(secret, Cookie):
-                line = f"[{secret.winuser}][{secret.browser.upper()}] {secret.host}{secret.path} - {secret.cookie_name}:{secret.cookie_value}"
+                line = f"[{secret.winuser}][{secret.browser.upper()}] {secret.host}{secret.path} - {secret.cookie_name}:{process_secret(secret.cookie_value)}"
                 self.logger.highlight(line)
                 if self.output_file:
                     self.output_file.write(line + "\n")
@@ -2346,7 +2346,7 @@ class smb(connection):
             tag = "IEX"
             if secret.type == "Internet Explorer":
                 resource = secret.resource + " -" if secret.resource != "" else "-"
-                line = f"[{secret.winuser}][{tag}] {resource} - {secret.username}:{secret.password}"
+                line = f"[{secret.winuser}][{tag}] {resource} - {secret.username}:{process_secret(secret.password)}"
                 self.logger.highlight(line)
                 if self.output_file:
                     self.output_file.write(line + "\n")
@@ -2370,7 +2370,7 @@ class smb(connection):
             tag = "FIREFOX"
             if isinstance(secret, FirefoxData):
                 url = secret.url + " -" if secret.url != "" else "-"
-                line = f"[{secret.winuser}][{tag}] {url} {secret.username}:{secret.password}"
+                line = f"[{secret.winuser}][{tag}] {url} {secret.username}:{process_secret(secret.password)}"
                 self.logger.highlight(line)
                 if self.output_file:
                     self.output_file.write(line + "\n")
@@ -2383,7 +2383,7 @@ class smb(connection):
                     secret.url,
                 )
             elif isinstance(secret, FirefoxCookie):
-                line = f"[{secret.winuser}][{tag}] {secret.host}{secret.path} {secret.cookie_name}:{secret.cookie_value}"
+                line = f"[{secret.winuser}][{tag}] {secret.host}{secret.path} {secret.cookie_name}:{process_secret(secret.cookie_value)}"
                 self.logger.highlight(line)
                 if self.output_file:
                     self.output_file.write(line + "\n")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -2185,7 +2185,7 @@ class smb(connection):
         def sccm_callback(secret):
             if isinstance(secret, SCCMCred):
                 tag = "NAA Account"
-                self.logger.highlight(f"[{tag}] {secret.username.decode('latin-1')}:{secret.password.decode('latin-1')}")
+                self.logger.highlight(f"[{tag}] {secret.username.decode('latin-1')}:{process_secret(secret.password.decode('latin-1'))}")
                 self.db.add_dpapi_secrets(
                     target.address,
                     f"SCCM - {tag}",
@@ -2196,7 +2196,7 @@ class smb(connection):
                 )
             elif isinstance(secret, SCCMSecret):
                 tag = "Task sequences secret"
-                self.logger.highlight(f"[{tag}] {secret.secret.decode('latin-1')}")
+                self.logger.highlight(f"[{tag}] {process_secret(secret.secret.decode('latin-1'))}")
                 self.db.add_dpapi_secrets(
                     target.address,
                     f"SCCM - {tag}",
@@ -2207,7 +2207,7 @@ class smb(connection):
                 )
             elif isinstance(secret, SCCMCollection):
                 tag = "Collection Variable"
-                self.logger.highlight(f"[{tag}] {secret.variable.decode('latin-1')}:{secret.value.decode('latin-1')}")
+                self.logger.highlight(f"[{tag}] {secret.variable.decode('latin-1')}:{process_secret(secret.value.decode('latin-1'))}")
                 self.db.add_dpapi_secrets(
                     target.address,
                     f"SCCM - {tag}",

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -2494,10 +2494,10 @@ class smb(connection):
             if self.args.enabled:
                 if "Enabled" in secret:
                     secret = " ".join(secret.split(" ")[:-1])
-                    self.logger.highlight(process_secret_dump(secret))
+                    self.logger.highlight(process_secret_dump(secret, keep=2))
             else:
                 secret = " ".join(secret.split(" ")[:-1]) if " " in secret else secret
-                self.logger.highlight(process_secret_dump(secret))
+                self.logger.highlight(process_secret_dump(secret, keep=2))
 
             # Filter out computer accounts, history hashes and kerberos keys for adding to db
             if secret.find("$") == -1 and secret_type == NTDSHashes.SECRET_TYPE.NTDS and "_history" not in secret:


### PR DESCRIPTION
## Description
`audit_mode` (set via `nxc.conf`) already masked most single-value secrets (`process_secret`), but a bunch of dump outputs still printed credential material in full even with the option turned on:

- SAM/LSA/NTDS dumps (`--sam`, `--lsa`, `--ntds`), including GMSA LSA secrets
- DPAPI/SCCM loot (`--dpapi`, `--sccm`): NAA accounts, task sequence secrets, collection variables, browser/vault credentials
- LDAP-side Kerberoasting and AS-REP roasting hashes
- GMSA NTLM/AES keys read from LDAP

This is meant for demos/screenshots/audit reports where you want to show that a secret *was* recovered without leaking the actual value.

Changes:
- Added `process_secret_dump()` in `nxc/config.py`: splits a dump line on a separator and redacts everything past the first `keep` fields (so username/RID/tag stays visible, the actual secret gets masked), falling back to `process_secret()` for lines with no separator.
- Wired `process_secret_dump()` into the SAM/LSA/NTDS dump paths and the SCCM/DPAPI credential lines in `nxc/protocols/smb.py`.
- Wired `process_secret()`/`process_secret_dump()` into the Kerberoasting/AS-REP roasting and GMSA key output in `nxc/protocols/ldap.py`.
- When `audit_mode` is disabled (the default), all of this is a no-op: `process_secret`/`process_secret_dump` return the line unchanged.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (Claude Code, used to draft the redaction logic and wire it into the SMB/LDAP dump paths; reviewed and tested manually)

## Setup guide for the review
Enable audit mode in `~/.nxc/nxc.conf` under the `[nxc]` section (`audit_mode = X`, any masking character/string), then run against a target with recoverable secrets:
- `--sam`, `--lsa`, `--ntds` on a domain controller or local machine
- `--dpapi` / `--sccm wmi` on a host with SCCM/DPAPI secrets
- LDAP `--kerberoasting` / `--asreproast` / `--gmsa` against the domain

Compare output with `audit_mode` disabled: usernames/RIDs/tags stay visible, but the actual hash/password/secret value should be masked with the configured character. With `audit_mode` disabled (default), output should be byte-for-byte identical to before this change.

## Screenshots (if appropriate):
**SAM/LSA/NTDS**:
<img width="2130" height="1208" alt="image" src="https://github.com/user-attachments/assets/cda8509d-b7c7-4160-9669-eb8bb4285aea" />

**DPAPI/SCCM**:
<img width="1382" height="284" alt="image" src="https://github.com/user-attachments/assets/891bd6f4-06bf-4c0f-ae0e-0cc1c2424dcf" />

**Kerberoasting and AS-REP roasting**:
<img width="3046" height="398" alt="image" src="https://github.com/user-attachments/assets/2c7cfaa6-c6e6-437f-b417-8e3df45024f9" />

**gmsa**:
<img width="1514" height="158" alt="image" src="https://github.com/user-attachments/assets/fae37960-32f7-4f19-8e12-17554ef8f116" />

## Checklist:
- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)