### PR TITLE
smb/ldap: flag DCSync-capable logins as (DCSync!)

### DIFF
--- a/nxc/config.py
+++ b/nxc/config.py
@@ -33,6 +33,7 @@ for section in nxc_default_config.sections():
 # THESE OPTIONS HAVE TO EXIST IN THE DEFAULT CONFIG FILE
 nxc_workspace = nxc_config.get("nxc", "workspace", fallback="default")
 pwned_label = nxc_config.get("nxc", "pwn3d_label", fallback="Pwn3d!")
+dcsync_label = nxc_config.get("nxc", "ad_pwn3d_label", fallback="ADPwn3d!")
 audit_mode = nxc_config.get("nxc", "audit_mode", fallback=False)
 reveal_chars_of_pwd = int(nxc_config.get("nxc", "reveal_chars_of_pwd", fallback=0))
 config_log = nxc_config.getboolean("nxc", "log_mode", fallback=False)

--- a/nxc/config.py
+++ b/nxc/config.py
@@ -33,7 +33,7 @@ for section in nxc_default_config.sections():
 # THESE OPTIONS HAVE TO EXIST IN THE DEFAULT CONFIG FILE
 nxc_workspace = nxc_config.get("nxc", "workspace", fallback="default")
 pwned_label = nxc_config.get("nxc", "pwn3d_label", fallback="Pwn3d!")
-dcsync_label = nxc_config.get("nxc", "ad_pwn3d_label", fallback="ADPwn3d!")
+dcsync_label = nxc_config.get("nxc", "dcsync_label", fallback="DCSync!")
 audit_mode = nxc_config.get("nxc", "audit_mode", fallback=False)
 reveal_chars_of_pwd = int(nxc_config.get("nxc", "reveal_chars_of_pwd", fallback=0))
 config_log = nxc_config.getboolean("nxc", "log_mode", fallback=False)

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -12,7 +12,7 @@ from ipaddress import ip_address
 from dns import resolver, rdatatype
 from socket import AF_UNSPEC, SOCK_DGRAM, IPPROTO_IP, AI_CANONNAME, getaddrinfo
 
-from nxc.config import pwned_label
+from nxc.config import pwned_label, dcsync_label
 from nxc.helpers.logger import highlight
 from nxc.loaders.moduleloader import ModuleLoader
 from nxc.logger import nxc_logger, NXCAdapter
@@ -153,6 +153,7 @@ class connection:
         self.aesKey = None if not self.args.aesKey else self.args.aesKey[0]
         self.use_kcache = None if not self.args.use_kcache else self.args.use_kcache
         self.admin_privs = False
+        self.dcsync_privs = False   # has DCSync/replication rights (e.g. DC machine account)
         self.failed_logins = 0
 
         # Network info
@@ -596,7 +597,12 @@ class connection:
                         return True
 
     def mark_pwned(self):
-        return highlight(f"({pwned_label})" if self.admin_privs else "")
+        labels = []
+        if self.admin_privs:
+            labels.append(highlight(f"({pwned_label})"))
+        if self.dcsync_privs:
+            labels.append(highlight(f"({dcsync_label})", color="cyan"))
+        return " ".join(labels)
 
     def load_modules(self):
         self.logger.info(f"Loading modules for target: {self.host}")

--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -601,7 +601,7 @@ class connection:
         if self.admin_privs:
             labels.append(highlight(f"({pwned_label})"))
         if self.dcsync_privs:
-            labels.append(highlight(f"({dcsync_label})", color="cyan"))
+            labels.append(highlight(f"({dcsync_label})"))
         return " ".join(labels)
 
     def load_modules(self):

--- a/nxc/data/nxc.conf
+++ b/nxc/data/nxc.conf
@@ -2,7 +2,7 @@
 workspace = default
 last_used_db = smb
 pwn3d_label = Pwn3d!
-ad_pwn3d_label = ADPwn3d!
+dcsync_label = DCSync!
 audit_mode = 
 reveal_chars_of_pwd = 0
 log_mode = False

--- a/nxc/data/nxc.conf
+++ b/nxc/data/nxc.conf
@@ -2,6 +2,7 @@
 workspace = default
 last_used_db = smb
 pwn3d_label = Pwn3d!
+ad_pwn3d_label = ADPwn3d!
 audit_mode = 
 reveal_chars_of_pwd = 0
 log_mode = False

--- a/nxc/helpers/logger.py
+++ b/nxc/helpers/logger.py
@@ -14,5 +14,3 @@ def highlight(text, color="yellow"):
         return f"{colored(text, 'yellow', attrs=['bold'])}"
     elif color == "red":
         return f"{colored(text, 'red', attrs=['bold'])}"
-    else:
-        return f"{colored(text, color, attrs=['bold'])}"

--- a/nxc/helpers/logger.py
+++ b/nxc/helpers/logger.py
@@ -14,3 +14,5 @@ def highlight(text, color="yellow"):
         return f"{colored(text, 'yellow', attrs=['bold'])}"
     elif color == "red":
         return f"{colored(text, 'red', attrs=['bold'])}"
+    else:
+        return f"{colored(text, color, attrs=['bold'])}"

--- a/nxc/modules/enum_interfaces.py
+++ b/nxc/modules/enum_interfaces.py
@@ -17,7 +17,6 @@ class NXCModule:
     name = "enum_interfaces"
     description = "Retrieve the list of network interfaces info (Name, IP Address, Subnet Mask, Default Gateway) from remote Windows registry (formerly --interfaces)"
     supported_protocols = ["smb"]
-    opsec_safe = False
     category = CATEGORY.ENUMERATION
 
     def __init__(self):

--- a/nxc/modules/ntlm_reflection.py
+++ b/nxc/modules/ntlm_reflection.py
@@ -12,7 +12,6 @@ class NXCModule:
     name = "ntlm_reflection"
     description = "[REMOVED] This module has been integrated into the enum_cve module."
     supported_protocols = ["smb"]
-    opsec_safe = True
     multiple_hosts = True
     category = CATEGORY.ENUMERATION
 

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -653,10 +653,36 @@ class ldap(connection):
             for item in resp_parsed:
                 if item:
                     self.admin_privs = True
+                    # DCSync is a narrower right than the admin set above (Server/Backup Operators
+                    # are admin-equivalent but can't replicate), so check the capable subset separately
+                    self.check_if_dcsync()
                     return
 
         # If nothing matched we are not admin
         self.admin_privs = False
+
+    def check_if_dcsync(self):
+        # Domain Admins (512), Enterprise Admins (519) and Administrators (S-1-5-32-544) hold
+        # Replicating Directory Changes[-All] on the domain NC by default -> they can DCSync.
+        # Server/Backup Operators are deliberately excluded (admin-equivalent, no replication rights).
+        if not getattr(self, "sid_domain", None):
+            return
+        search_filter = (f"(|(objectSid={self.sid_domain}-512)"
+                         f"(objectSid={self.sid_domain}-519)"
+                         "(objectSid=S-1-5-32-544))")
+        resp = self.search(search_filter, attributes=["distinguishedName"], baseDN=self.baseDN)
+        group_dns = [item["distinguishedName"] for item in parse_result_attributes(resp)]
+        if not group_dns:
+            return
+
+        # nested membership (LDAP_MATCHING_RULE_IN_CHAIN) or primaryGroupID of a capable group
+        answers = [f"(memberOf:1.2.840.113556.1.4.1941:={dn})" for dn in group_dns]
+        answers.extend([f"(primaryGroupID={rid})" for rid in ("512", "519")])
+        search_filter = f"(&(objectCategory=user)(sAMAccountName={self.username})(|{''.join(answers)}))"
+        resp = self.search(search_filter, attributes=[], baseDN=self.baseDN)
+        if any(item for item in parse_result_attributes(resp)):
+            self.dcsync_privs = True
+            self.logger.debug(f"{self.username} is in a DCSync-capable group, has DCSync rights")
 
     def getUnixTime(self, t):
         t -= 116444736000000000

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -622,67 +622,69 @@ class ldap(connection):
         resp = self.search(search_filter, attributes, baseDN=self.baseDN)
         resp_parsed = parse_result_attributes(resp)
 
-        if resp and (self.password != "" or self.lmhash != "" or self.nthash != "" or self.aesKey != "" or self.use_kcache) and self.username != "":
-            for item in resp_parsed:
-                self.sid_domain = "-".join(item["objectSid"].split("-")[:-1])
+        if not (resp and (self.password != "" or self.lmhash != "" or self.nthash != "" or self.aesKey != "" or self.use_kcache) and self.username != ""):
+            self.admin_privs = False
+            return
 
-            # 2. get all group cn name
-            search_filter = (f"(|(objectSid={self.sid_domain}-512)"
-                             f"(objectSid={self.sid_domain}-519)"
-                             f"(objectSid={self.sid_domain}-544)"
-                             "(objectSid=S-1-5-32-544)"
-                             "(objectSid=S-1-5-32-549)"
-                             "(objectSid=S-1-5-32-551))")
-            attributes = ["distinguishedName"]
-            resp = self.search(search_filter, attributes, baseDN=self.baseDN)
-            resp_parsed = parse_result_attributes(resp)
-            answers = [f"(memberOf:1.2.840.113556.1.4.1941:={item['distinguishedName']})" for item in resp_parsed]
-            if len(answers) == 0:
-                self.logger.debug("No groups with default privileged RID were found. Assuming user is not a Domain Administrator.")
-                return
+        for item in resp_parsed:
+            self.sid_domain = "-".join(item["objectSid"].split("-")[:-1])
 
-            # 3. Build a filter to query if the primaryGroupID is one of these groups
-            group_ids = ["512", "519", "544", "549", "551"]
-            primaryGroupID_filters = [f"(primaryGroupID={group_id})" for group_id in group_ids]
-            answers.extend(primaryGroupID_filters)
+        # DCSync capability is independent of local admin (a DC machine account can replicate but
+        # isn't a local admin), so evaluate it regardless of the admin result below.
+        self.check_if_dcsync()
 
-            # 4. Check if the user is member of one of these groups OR has one of these primaryGroupID
-            search_filter = f"(&(objectCategory=user)(sAMAccountName={self.username})(|{''.join(answers)}))"
-            resp = self.search(search_filter, attributes=[], baseDN=self.baseDN)
-            resp_parsed = parse_result_attributes(resp)
-            for item in resp_parsed:
-                if item:
-                    self.admin_privs = True
-                    # DCSync is a narrower right than the admin set above (Server/Backup Operators
-                    # are admin-equivalent but can't replicate), so check the capable subset separately
-                    self.check_if_dcsync()
-                    return
+        # 2. get all group cn name
+        search_filter = (f"(|(objectSid={self.sid_domain}-512)"
+                         f"(objectSid={self.sid_domain}-519)"
+                         f"(objectSid={self.sid_domain}-544)"
+                         "(objectSid=S-1-5-32-544)"
+                         "(objectSid=S-1-5-32-549)"
+                         "(objectSid=S-1-5-32-551))")
+        attributes = ["distinguishedName"]
+        resp = self.search(search_filter, attributes, baseDN=self.baseDN)
+        resp_parsed = parse_result_attributes(resp)
+        answers = [f"(memberOf:1.2.840.113556.1.4.1941:={item['distinguishedName']})" for item in resp_parsed]
+        if len(answers) == 0:
+            self.logger.debug("No groups with default privileged RID were found. Assuming user is not a Domain Administrator.")
+            self.admin_privs = False
+            return
 
-        # If nothing matched we are not admin
-        self.admin_privs = False
+        # 3. Build a filter to query if the primaryGroupID is one of these groups
+        group_ids = ["512", "519", "544", "549", "551"]
+        primaryGroupID_filters = [f"(primaryGroupID={group_id})" for group_id in group_ids]
+        answers.extend(primaryGroupID_filters)
+
+        # 4. Check if the user is member of one of these groups OR has one of these primaryGroupID
+        search_filter = f"(&(objectCategory=user)(sAMAccountName={self.username})(|{''.join(answers)}))"
+        resp = self.search(search_filter, attributes=[], baseDN=self.baseDN)
+        self.admin_privs = any(item for item in parse_result_attributes(resp))
 
     def check_if_dcsync(self):
-        # Domain Admins (512), Enterprise Admins (519) and Administrators (S-1-5-32-544) hold
-        # Replicating Directory Changes[-All] on the domain NC by default -> they can DCSync.
-        # Server/Backup Operators are deliberately excluded (admin-equivalent, no replication rights).
+        # Principals that hold Replicating Directory Changes[-All] on the domain NC by default:
+        # Domain Admins (512), Enterprise Admins (519), Administrators (S-1-5-32-544), and
+        # Domain Controllers (516) - the latter covers DC machine accounts, which have
+        # primaryGroupID 516 and aren't local admins. Server/Backup Operators are deliberately
+        # excluded (admin-equivalent, but no replication rights).
         if not getattr(self, "sid_domain", None):
             return
         search_filter = (f"(|(objectSid={self.sid_domain}-512)"
                          f"(objectSid={self.sid_domain}-519)"
+                         f"(objectSid={self.sid_domain}-516)"
                          "(objectSid=S-1-5-32-544))")
         resp = self.search(search_filter, attributes=["distinguishedName"], baseDN=self.baseDN)
         group_dns = [item["distinguishedName"] for item in parse_result_attributes(resp)]
         if not group_dns:
             return
 
-        # nested membership (LDAP_MATCHING_RULE_IN_CHAIN) or primaryGroupID of a capable group
+        # nested membership (LDAP_MATCHING_RULE_IN_CHAIN) or primaryGroupID of a capable group.
+        # No objectCategory filter, so DC computer/machine accounts (primaryGroupID 516) match too.
         answers = [f"(memberOf:1.2.840.113556.1.4.1941:={dn})" for dn in group_dns]
-        answers.extend([f"(primaryGroupID={rid})" for rid in ("512", "519")])
-        search_filter = f"(&(objectCategory=user)(sAMAccountName={self.username})(|{''.join(answers)}))"
+        answers.extend([f"(primaryGroupID={rid})" for rid in ("512", "519", "516")])
+        search_filter = f"(&(sAMAccountName={self.username})(|{''.join(answers)}))"
         resp = self.search(search_filter, attributes=[], baseDN=self.baseDN)
         if any(item for item in parse_result_attributes(resp)):
             self.dcsync_privs = True
-            self.logger.debug(f"{self.username} is in a DCSync-capable group, has DCSync rights")
+            self.logger.debug(f"{self.username} can DCSync (replication-capable principal)")
 
     def getUnixTime(self, t):
         t -= 116444736000000000

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -758,7 +758,6 @@ class smb(connection):
         # Attempt a single-object GetNCChanges on our own account. Generates the same replication
         # traffic (event 4662) as a real DCSync, hence it's gated behind --dcsync-check.
         from impacket.dcerpc.v5 import drsuapi
-        from impacket.dcerpc.v5.rpcrt import DCERPCSessionError
 
         self.logger.debug("Probing DRSUAPI for DCSync rights")
         remote_ops = None
@@ -778,7 +777,7 @@ class smb(connection):
             remote_ops.DRSGetNCChangesGuid(own_guid)  # raises 0x2105 (access denied) if we can't replicate
             self.dcsync_privs = True
             self.logger.debug(f"{self.username} has DCSync rights")
-        except DCERPCSessionError as e:
+        except drsuapi.DCERPCSessionError as e:
             self.logger.debug(f"No DCSync rights: {e}")
         except Exception as e:
             self.logger.debug(f"DRSUAPI probe failed: {e}")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -732,10 +732,9 @@ class smb(connection):
     def check_if_dcsync(self):
         # DCSync-capable accounts (e.g. DC machine accounts) aren't local admins, so check_if_admin misses them
         # A DC's own machine account (HOSTNAME$) always has replication rights - free to flag, no extra traffic
-        if not self.dcsync_privs and self.isdc and self.username and self.hostname:
-            if self.username.rstrip("$").upper() == self.hostname.upper():
-                self.logger.debug(f"{self.username} is the DC machine account, has DCSync rights")
-                self.dcsync_privs = True
+        if not self.dcsync_privs and self.isdc and self.username and self.hostname and self.username.rstrip("$").upper() == self.hostname.upper():
+            self.logger.debug(f"{self.username} is the DC machine account, has DCSync rights")
+            self.dcsync_privs = True
 
         # --dcsync-check confirms replication rights over DRSUAPI (also catches delegated users / other DCs)
         if not self.dcsync_privs and self.isdc and self.args.dcsync_check:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -730,14 +730,28 @@ class smb(connection):
             self.admin_privs = False
 
     def check_if_dcsync(self):
-        # DCSync-capable accounts (e.g. DC machine accounts) aren't local admins, so check_if_admin misses them
-        # A DC's own machine account (HOSTNAME$) always has replication rights - free to flag, no extra traffic
-        if not self.dcsync_privs and self.isdc and self.username and self.hostname and self.username.rstrip("$").upper() == self.hostname.upper():
+        if self.dcsync_privs or not self.username:
+            return
+
+        # DCSync-capable accounts (e.g. DC machine accounts) aren't local admins, so check_if_admin misses them.
+        # A DC's own machine account (HOSTNAME$) always has replication rights - flagged with no replication traffic.
+        # Match the account name first (cheap) so is_host_dc() only fires for a machine-account-looking login.
+        name_match = self.hostname and self.username.rstrip("$").upper() == self.hostname.upper()
+        if not (name_match or self.args.dcsync_check):
+            return
+
+        # isdc is resolved lazily - it isn't set in the default login flow (only with --generate-hosts/krb5-file or over LDAP)
+        if self.isdc is None:
+            self.is_host_dc()
+        if not self.isdc:
+            return
+
+        if name_match:
             self.logger.debug(f"{self.username} is the DC machine account, has DCSync rights")
             self.dcsync_privs = True
 
         # --dcsync-check confirms replication rights over DRSUAPI (also catches delegated users / other DCs)
-        if not self.dcsync_privs and self.isdc and self.args.dcsync_check:
+        if not self.dcsync_privs and self.args.dcsync_check:
             self.probe_dcsync_rights()
 
     def probe_dcsync_rights(self):

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -421,6 +421,8 @@ class smb(connection):
             elif not self.args.delegate:
                 self.username = username
 
+            self.check_if_dcsync()
+
             used_ccache = " from ccache" if useCache else f":{process_secret(kerb_pass)}"
             if self.args.delegate:
                 u2u_str = "+U2U" if self.args.u2u else ""
@@ -495,6 +497,7 @@ class smb(connection):
             self.logger.debug(f"{self.is_guest=}")
             if "Unix" not in self.server_os:
                 self.check_if_admin()
+            self.check_if_dcsync()
 
             # Only do database/bloodhound stuff if we don't have guest/null auth
             valid_auth = not self.is_guest and self.username
@@ -563,6 +566,7 @@ class smb(connection):
             self.logger.debug(f"{self.is_guest=}")
             if "Unix" not in self.server_os:
                 self.check_if_admin()
+            self.check_if_dcsync()
 
             # Only do database/bloodhound stuff if we don't have guest
             valid_auth = not self.is_guest and self.username and self.hash
@@ -724,6 +728,51 @@ class smb(connection):
         except Exception as e:
             self.logger.fail(f"Error checking if user is admin on {self.host}: {e}")
             self.admin_privs = False
+
+    def check_if_dcsync(self):
+        # DCSync-capable accounts (e.g. DC machine accounts) aren't local admins, so check_if_admin misses them
+        # A DC's own machine account (HOSTNAME$) always has replication rights - free to flag, no extra traffic
+        if not self.dcsync_privs and self.isdc and self.username and self.hostname:
+            if self.username.rstrip("$").upper() == self.hostname.upper():
+                self.logger.debug(f"{self.username} is the DC machine account, has DCSync rights")
+                self.dcsync_privs = True
+
+        # --dcsync-check confirms replication rights over DRSUAPI (also catches delegated users / other DCs)
+        if not self.dcsync_privs and self.isdc and self.args.dcsync_check:
+            self.probe_dcsync_rights()
+
+    def probe_dcsync_rights(self):
+        # Attempt a single-object GetNCChanges on our own account. Generates the same replication
+        # traffic (event 4662) as a real DCSync, hence it's gated behind --dcsync-check.
+        from impacket.dcerpc.v5 import drsuapi
+        from impacket.dcerpc.v5.rpcrt import DCERPCSessionError
+
+        self.logger.debug("Probing DRSUAPI for DCSync rights")
+        remote_ops = None
+        try:
+            remote_ops = RemoteOperations(self.conn, self.kerberos, self.kdcHost)
+            # resolve our own account to its objectGUID (this also binds DRSUAPI)
+            crack = remote_ops.DRSCrackNames(
+                formatOffered=drsuapi.DS_NAME_FORMAT.DS_NT4_ACCOUNT_NAME,
+                formatDesired=drsuapi.DS_NAME_FORMAT.DS_UNIQUE_ID_NAME,
+                name=f"{self.domain}\\{self.username}",
+            )
+            result = crack["pmsgOut"]["V1"]["pResult"]
+            if result["cItems"] < 1 or result["rItems"][0]["status"] != 0:
+                self.logger.debug("Could not resolve own account GUID over DRSUAPI")
+                return
+            own_guid = result["rItems"][0]["pName"][:-1]  # {GUID} with trailing null
+            remote_ops.DRSGetNCChangesGuid(own_guid)  # raises 0x2105 (access denied) if we can't replicate
+            self.dcsync_privs = True
+            self.logger.debug(f"{self.username} has DCSync rights")
+        except DCERPCSessionError as e:
+            self.logger.debug(f"No DCSync rights: {e}")
+        except Exception as e:
+            self.logger.debug(f"DRSUAPI probe failed: {e}")
+        finally:
+            if remote_ops:
+                with contextlib.suppress(Exception):
+                    remote_ops.finish()
 
     def gen_relay_list(self):
         if self.server_os.lower().find("windows") != -1 and self.signing is False:

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -764,14 +764,17 @@ class smb(connection):
         try:
             remote_ops = RemoteOperations(self.conn, self.kerberos, self.kdcHost)
             # resolve our own account to its objectGUID (this also binds DRSUAPI)
+            # SANS_DOMAIN takes the bare sAMAccountName, avoiding the NetBIOS-vs-FQDN mismatch
+            # that DS_NT4_ACCOUNT_NAME (DOMAIN\user) hits when self.domain is an FQDN
             crack = remote_ops.DRSCrackNames(
-                formatOffered=drsuapi.DS_NAME_FORMAT.DS_NT4_ACCOUNT_NAME,
+                formatOffered=drsuapi.DS_NT4_ACCOUNT_NAME_SANS_DOMAIN,
                 formatDesired=drsuapi.DS_NAME_FORMAT.DS_UNIQUE_ID_NAME,
-                name=f"{self.domain}\\{self.username}",
+                name=self.username,
             )
             result = crack["pmsgOut"]["V1"]["pResult"]
             if result["cItems"] < 1 or result["rItems"][0]["status"] != 0:
-                self.logger.debug("Could not resolve own account GUID over DRSUAPI")
+                status = result["rItems"][0]["status"] if result["cItems"] else "no items"
+                self.logger.debug(f"Could not resolve own account GUID over DRSUAPI (status={status})")
                 return
             own_guid = result["rItems"][0]["pName"][:-1]  # {GUID} with trailing null
             remote_ops.DRSGetNCChangesGuid(own_guid)  # raises 0x2105 (access denied) if we can't replicate

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -733,11 +733,12 @@ class smb(connection):
         if self.dcsync_privs or not self.username:
             return
 
-        # DCSync-capable accounts (e.g. DC machine accounts) aren't local admins, so check_if_admin misses them.
-        # A DC's own machine account (HOSTNAME$) always has replication rights - flagged with no replication traffic.
-        # Match the account name first (cheap) so is_host_dc() only fires for a machine-account-looking login.
+        # Two DCSync-capable cases are free to infer on a DC (no replication traffic):
+        #   - the DC's own machine account (HOSTNAME$), which isn't a local admin so check_if_admin misses it
+        #   - any local admin, i.e. BUILTIN\Administrators, which holds Replicating Directory Changes[-All] by default
+        # These signals are cheap; only resolve isdc (one RPC) once a login actually matches one of them.
         name_match = self.hostname and self.username.rstrip("$").upper() == self.hostname.upper()
-        if not (name_match or self.args.dcsync_check):
+        if not (name_match or self.admin_privs or self.args.dcsync_check):
             return
 
         # isdc is resolved lazily - it isn't set in the default login flow (only with --generate-hosts/krb5-file or over LDAP)
@@ -749,8 +750,12 @@ class smb(connection):
         if name_match:
             self.logger.debug(f"{self.username} is the DC machine account, has DCSync rights")
             self.dcsync_privs = True
+        elif self.admin_privs:
+            self.logger.debug(f"{self.username} is a local admin on a DC, has DCSync rights")
+            self.dcsync_privs = True
 
-        # --dcsync-check confirms replication rights over DRSUAPI (also catches delegated users / other DCs)
+        # --dcsync-check confirms replication rights over DRSUAPI for the remaining case:
+        # a non-admin user who's been delegated replication rights (also catches other DCs)
         if not self.dcsync_privs and self.args.dcsync_check:
             self.probe_dcsync_rights()
 

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -318,16 +318,19 @@ class smb(connection):
             self.logger.info(f"Resolved domain: {self.domain} with dns, kdcHost: {self.kdcHost}")
 
     def print_host_info(self):
+        # Resolve DC status up front so the banner can flag it (is_host_dc caches into self.isdc,
+        # so check_if_dcsync later reuses it). Only a promoted DC registers the Netlogon RPC endpoint.
+        if self.isdc is None:
+            self.is_host_dc()
+        dc_prefix = "DC:" if self.isdc else ""
         signing = colored(f"signing:{self.signing}", host_info_colors[0], attrs=["bold"]) if self.signing else colored(f"signing:{self.signing}", host_info_colors[1], attrs=["bold"])
         smbv1 = colored(f"SMBv1:{self.smbv1}", host_info_colors[2], attrs=["bold"]) if self.smbv1 else colored(f"SMBv1:{self.smbv1}", host_info_colors[3], attrs=["bold"])
         ntlm = colored(f" (NTLM:{not self.no_ntlm})", host_info_colors[2], attrs=["bold"]) if self.no_ntlm else ""
         null_auth = colored(f" (Null Auth:{self.null_auth})", host_info_colors[2], attrs=["bold"]) if self.null_auth else ""
         guest = colored(f" (Guest Auth:{self.is_guest})", host_info_colors[1], attrs=["bold"]) if self.is_guest else ""
-        self.logger.display(f"{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.targetDomain}) ({signing}) ({smbv1}){ntlm}{null_auth}{guest}")
+        self.logger.display(f"{dc_prefix}{self.server_os}{f' x{self.os_arch}' if self.os_arch else ''} (name:{self.hostname}) (domain:{self.targetDomain}) ({signing}) ({smbv1}){ntlm}{null_auth}{guest}")
 
         if self.args.generate_hosts_file or self.args.generate_krb5_file:
-            if self.isdc is None:
-                self.is_host_dc()
             if self.args.generate_hosts_file:
                 with open(self.args.generate_hosts_file, "a+") as host_file:
                     dc_part = f" {self.targetDomain}" if self.isdc else ""

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -21,6 +21,7 @@ def proto_args(parser, parents):
     smb_parser.add_argument("--smb-server-port", default="445", help="specify a server port for SMB", type=int)
     smb_parser.add_argument("--no-smbv1", action="store_true", help="Force to disable SMBv1 in connection")
     smb_parser.add_argument("--no-admin-check", action="store_true", help="Avoid checking admin which queries the Service Control Manager")
+    smb_parser.add_argument("--dcsync-check", action="store_true", help="Confirm DCSync/replication rights over DRSUAPI (generates replication traffic)")
     smb_parser.add_argument("--gen-relay-list", metavar="OUTPUT_FILE", help="outputs all hosts that don't require SMB signing to the specified file")
     smb_parser.add_argument("--smb-timeout", help="SMB connection timeout", type=int, default=2)
     smb_parser.add_argument("--laps", dest="laps", metavar="LAPS", type=str, help="LAPS authentification", nargs="?", const="administrator")

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -45,6 +45,7 @@ netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --put-file 
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file.txt --put-file TEST_NORMAL_FILE \\Windows\\Temp\\test_file2.txt
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --get-file \\Windows\\Temp\\test_file.txt /tmp/test_file.txt
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --no-admin-check
+netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --dcsync-check
 ##### SMB PowerShell
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec smb TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig --exec-method atexec


### PR DESCRIPTION
## Description

Adds a `(DCSync!)` marker to the SMB and LDAP login lines for accounts that can perform **DCSync** but aren't necessarily local admins — most notably a DC's own machine account, which held no marker at all before. It's shown alongside `(Pwn3d!)` when both apply, and is configurable via `dcsync_label` in `nxc.conf` (default `DCSync!`).

Detection is **passive by default** (no replication traffic):

- **SMB:** flag the DC's own machine account (`HOSTNAME$`), and any local admin on a DC — `BUILTIN\Administrators` holds `Replicating Directory Changes[-All]` on the domain NC by default. Resolved for free from `admin_privs` + `isdc`.
- **LDAP:** flag the replication-capable principals — nested membership in Domain Admins (512), Enterprise Admins (519), Administrators (`S-1-5-32-544`), plus Domain Controllers (516) via `primaryGroupID` (covers DC machine accounts). Server/Backup Operators are admin-equivalent (`Pwn3d!`) but excluded, since they can't replicate.
- **Opt-in `--dcsync-check` (SMB):** for the remaining case — a non-admin user *delegated* replication rights — confirm over DRSUAPI with a single-object `GetNCChanges` probe on our own account. This generates the same replication traffic as a real DCSync (event 4662), so it's gated behind the flag.

Resolving DC status also lets the SMB host banner flag DCs: `[*] DC:Windows Server 2022 ...` (a real DC registers the Netlogon RPC endpoint; member/standalone servers are unaffected).

Also removes two dead `opsec_safe` class attributes (`enum_interfaces`, `ntlm_reflection`), unused since #788.

Resolves #1322 .

No new dependencies — the DRSUAPI probe reuses the already-vendored Impacket `drsuapi` / `RemoteOperations`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (Claude Opus)

## Setup guide for the review

Tested from Kali Linux, Python 3.13 (project supports 3.10+). Target: a Windows Server AD Domain Controller 2022.

**SMB**
1. **Machine account (passive):** `netexec smb DC_IP -u 'DC01$' -H <machine_nt_hash>` → `(DCSync!)` only (not a local admin, so no `(Pwn3d!)`); no replication request sent. Banner shows `DC:...`.
2. **Domain Admin (passive):** `netexec smb DC_IP -u administrator -p <pass>` → `(Pwn3d!) (DCSync!)`, no flag needed.
3. **Delegated non-admin (opt-in):** a user granted GetChanges/GetChangesAll but not admin — `netexec smb DC_IP -u repluser -p <pass> --dcsync-check` → `(DCSync!)`.
4. **Negatives:** unprivileged user (with and without `--dcsync-check`) → no marker; any account against a non-DC → no marker and no `DC:` banner prefix.

**LDAP**
5. `netexec ldap DC_IP -u 'DC01$' -H <machine_nt_hash>` → `(DCSync!)`. `-u administrator` → `(Pwn3d!) (DCSync!)`. A Backup/Server Operator → `(Pwn3d!)` only. Unprivileged → none.

**Config:** change `dcsync_label` in `~/.nxc/nxc.conf` and confirm the label updates.

Note: `--dcsync-check` generates real replication traffic (event 4662) on the target DC; every other path above is passive.

## Screenshots (if appropriate):

Before:
<img width="1757" height="487" alt="paste (3)" src="https://github.com/user-attachments/assets/2c44f3de-e63c-4916-a0c4-ad710d093aeb" />


After:
<img width="1793" height="498" alt="paste (2)" src="https://github.com/user-attachments/assets/c94bb2b5-c772-419e-8052-2ffda15c423a" />


## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (added a `--dcsync-check` line)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects  <!-- N/A: no third-party dependency changes -->
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: <WIKI_PR_LINK>)

**Sources**
- DCSync — The Hacker Recipes: https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync
- MITRE ATT&CK T1003.006 (OS Credential Dumping: DCSync): https://attack.mitre.org/techniques/T1003/006/
- Default replication rights on the domain object (Get-Changes / Get-Changes-All): https://learn.microsoft.com/en-us/windows/win32/adschema/r-ds-replication-get-changes
