### PR TITLE
[Draft] Fix RDP command execution reliability

### DIFF
--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -538,6 +538,7 @@ Add-Type -AssemblyName System.Windows.Forms
     async def _submit_run_command(self, command):
         await self._send_win_r()
         await self.conn.set_current_clipboard_text(command)
+        # server must acknowledge our clipboard data before we trigger the read
         response = await self._wait_for_event(
             {"CLIPBOARD_FORMAT_LIST_RESPONSE"}, self.args.clipboard_delay
         )
@@ -545,6 +546,8 @@ Add-Type -AssemblyName System.Windows.Forms
             raise RuntimeError(
                 "Remote session rejected the clipboard command data"
             )
+        # type a one-liner that reads and executes the clipboard we just set
+        # uses .NET WinForms API instead of Get-Clipboard (which requires PS5+)
         await self._send_keystrokes(
             "powershell.exe -NoLogo -NoProfile -NonInteractive -STA "
             '-WindowStyle Hidden -Command "Add-Type -AssemblyName '

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -612,15 +612,17 @@ Add-Type -AssemblyName System.Windows.Forms
 
             await self._wait_for_desktop()
 
-            # Prime the .NET/PowerShell runtime on Windows 10/11 single-session
-            # hosts where first execution after logon can take 30-60s due to
-            # JIT compilation of System.Windows.Forms. This hidden warmup command
-            # loads the assembly without producing any visible output.
-            await self._submit_typed_run_command(
-                "powershell.exe -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden "
-                '-Command "Add-Type -AssemblyName System.Windows.Forms"'
-            )
-            await asyncio.sleep(3)
+            if get_output:
+                # On first RDP logon after boot, Explorer may not be ready to
+                # process Win+R immediately after the desktop appears. This
+                # no-op warmup command absorbs the race: if the shell isn't
+                # ready it silently fails, and the 3-second pause gives Explorer
+                # time to finish initialization before the real command.
+                await self._submit_typed_run_command(
+                    "powershell.exe -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden "
+                    '-Command "Add-Type -AssemblyName System.Windows.Forms"'
+                )
+                await asyncio.sleep(3)
 
             if get_output:
                 try:

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -200,15 +200,14 @@ class rdp(connection):
         except Exception:
             pass
 
-    async def connect_rdp(self):
+    async def connect_rdp(self, auth_only=False):
         """Connect to the RDP server. Does NOT clean up on exit.
 
-        Use this when the caller needs the connection alive after connecting
-        (screen, nla_screen, execute_shell). For sync callers that only need to
-        know whether authentication succeeded and want guaranteed cleanup, use
-        connect_rdp_with_cleanup() instead.
+        When auth_only is True, performs only CredSSP/NLA authentication
+        without establishing a full RDP session. This verifies credentials
+        without creating a disconnected session on single-session hosts.
         """
-        _, err = await asyncio.wait_for(self.conn.connect(), timeout=self.args.rdp_timeout)
+        _, err = await asyncio.wait_for(self.conn.connect(auth_only=auth_only), timeout=self.args.rdp_timeout)
         if err is not None:
             raise err
 
@@ -218,10 +217,10 @@ class rdp(connection):
             with contextlib.suppress(Exception):
                 await asyncio.wait_for(self.conn.terminate(), timeout=self.args.rdp_timeout)
 
-    async def connect_rdp_with_cleanup(self):
+    async def connect_rdp_with_cleanup(self, auth_only=False):
         """Connect to the RDP server and always terminate the connection on exit"""
         try:
-            await self.connect_rdp()
+            await self.connect_rdp(auth_only=auth_only)
         finally:
             await self.terminate_conn()
 
@@ -282,7 +281,7 @@ class rdp(connection):
                 stype=stype,
             )
             self.conn = self._create_rdp_connection(self.auth)
-            asyncio.run(self.connect_rdp_with_cleanup())
+            asyncio.run(self.connect_rdp_with_cleanup(auth_only=self._execution_pending()))
 
             self.admin_privs = True
             self.logger.success(
@@ -329,6 +328,10 @@ class rdp(connection):
                 )
             return False
 
+    def _execution_pending(self):
+        """Check if command execution will follow authentication."""
+        return bool(self.args.execute or self.args.ps_execute)
+
     def plaintext_login(self, domain, username, password):
         try:
             self.auth = NTLMCredential(
@@ -338,7 +341,9 @@ class rdp(connection):
                 stype=asyauthSecret.PASS,
             )
             self.conn = self._create_rdp_connection(self.auth)
-            asyncio.run(self.connect_rdp_with_cleanup())
+            # When execution follows, use auth_only to verify credentials
+            # without creating a full session (avoids Win11 clipboard issues).
+            asyncio.run(self.connect_rdp_with_cleanup(auth_only=self._execution_pending()))
 
             self.admin_privs = True
             self.logger.success(f"{domain}\\{username}:{process_secret(password)} {self.mark_pwned()}")
@@ -372,7 +377,7 @@ class rdp(connection):
                 stype=asyauthSecret.NT,
             )
             self.conn = self._create_rdp_connection(self.auth)
-            asyncio.run(self.connect_rdp_with_cleanup())
+            asyncio.run(self.connect_rdp_with_cleanup(auth_only=self._execution_pending()))
 
             self.admin_privs = True
             self.logger.success(f"{self.domain}\\{username}:{process_secret(ntlm_hash)} {self.mark_pwned()}")
@@ -591,6 +596,8 @@ Add-Type -AssemblyName System.Windows.Forms
             await self.connect_rdp()
         except Exception as e:
             self.logger.debug(f"Error connecting to RDP: {e!s}")
+            if "CredSSP" in str(e) or "STATUS_LOGON" in str(e):
+                self.logger.fail(f"Authentication failed: {e!s}")
             await self.terminate_conn()
             return None
 

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -120,6 +120,9 @@ class rdp(connection):
     def _create_rdp_connection(self, credentials):
         iosettings = self.iosettings.clone_for_connection()
         if credentials is not None:
+            # clear the protocol override left by the NLA probe so aardwolf
+            # picks the right X224 flags for this credential type (e.g.
+            # RESTRICTED_ADMIN for hashes, HYBRID_EX for passwords)
             iosettings.supported_protocols = None
         return RDPConnection(
             iosettings=iosettings,

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -1,7 +1,10 @@
 import asyncio
+import base64
+import copy
 import contextlib
 from datetime import datetime
 from os import getenv
+from uuid import uuid4
 from anyio import Path
 from termcolor import colored
 
@@ -114,6 +117,16 @@ class rdp(connection):
             except Exception as e:
                 self.logger.debug(f"Error adding host {self.host} into db: {e!s}")
 
+    def _create_rdp_connection(self, credentials):
+        iosettings = self.iosettings.clone_for_connection()
+        if credentials is not None:
+            iosettings.supported_protocols = None
+        return RDPConnection(
+            iosettings=iosettings,
+            target=copy.deepcopy(self.target),
+            credentials=copy.deepcopy(credentials),
+        )
+
     def create_conn_obj(self):
         self.target = RDPTarget(ip=self.host, domain="FAKE", port=self.port, timeout=self.args.rdp_timeout)
         self.auth = NTLMCredential(secret="pass", username="user", domain="FAKE", stype=asyauthSecret.PASS)
@@ -123,11 +136,7 @@ class rdp(connection):
         for proto in reversed(self.protoflags):
             try:
                 self.iosettings.supported_protocols = proto
-                self.conn = RDPConnection(
-                    iosettings=self.iosettings,
-                    target=self.target,
-                    credentials=self.auth,
-                )
+                self.conn = self._create_rdp_connection(self.auth)
                 asyncio.run(self.connect_rdp_with_cleanup())
             except OSError as e:
                 if "Errno 104" not in str(e):
@@ -174,11 +183,7 @@ class rdp(connection):
         self.logger.debug(f"Checking NLA for {self.host}")
         try:
             self.iosettings.supported_protocols = SUPP_PROTOCOLS.SSL
-            self.conn = RDPConnection(
-                iosettings=self.iosettings,
-                target=self.target,
-                credentials=None,
-            )
+            self.conn = self._create_rdp_connection(None)
             packetizer = TPKTPacketizer()
             client = UniClient(self.target, packetizer)
             self.conn._connection = await asyncio.wait_for(client.connect(), timeout=self.args.rdp_timeout)
@@ -247,8 +252,12 @@ class rdp(connection):
                     ccache = CCache.loadFile(getenv("KRB5CCNAME"))
                     ticketCreds = ccache.credentials[0]
                     username = ticketCreds["client"].prettyPrint().decode().split("@")[0]
+            elif aesKey:
+                stype = asyauthSecret.AES
+                password = aesKey
             else:
                 stype = asyauthSecret.PASS if not nthash else asyauthSecret.NT
+                password = password if password else nthash
 
             kerberos_target = UniTarget(
                 self.kdcHost,
@@ -268,7 +277,7 @@ class rdp(connection):
                 domain=domain,
                 stype=stype,
             )
-            self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
+            self.conn = self._create_rdp_connection(self.auth)
             asyncio.run(self.connect_rdp_with_cleanup())
 
             self.admin_privs = True
@@ -324,7 +333,7 @@ class rdp(connection):
                 domain=domain,
                 stype=asyauthSecret.PASS,
             )
-            self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
+            self.conn = self._create_rdp_connection(self.auth)
             asyncio.run(self.connect_rdp_with_cleanup())
 
             self.admin_privs = True
@@ -358,7 +367,7 @@ class rdp(connection):
                 domain=domain,
                 stype=asyauthSecret.NT,
             )
-            self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
+            self.conn = self._create_rdp_connection(self.auth)
             asyncio.run(self.connect_rdp_with_cleanup())
 
             self.admin_privs = True
@@ -388,10 +397,11 @@ class rdp(connection):
     async def _send_keystrokes(self, text, delay=0.02):
         """Helper method to send keystrokes to the RDP session"""
         for char in text:
-            key_event = RDP_KEYBOARD_UNICODE()
-            key_event.char = char
-            key_event.is_pressed = True
-            await self.conn.ext_in_queue.put(key_event)
+            for is_pressed in (True, False):
+                key_event = RDP_KEYBOARD_UNICODE()
+                key_event.char = char
+                key_event.is_pressed = is_pressed
+                await self.conn.ext_in_queue.put(key_event)
             await asyncio.sleep(delay)
 
     async def _send_enter(self):
@@ -400,52 +410,171 @@ class rdp(connection):
         await asyncio.sleep(0.05)
         await self.conn.send_key_virtualkey("VK_RETURN", False, False)
 
+    async def _send_shortcut(self, modifier, key):
+        layout = KeyboardLayoutManager().get_layout_by_shortname("enus")
+        modifier_scancode = layout.vk_to_scancode(modifier)
+        key_scancode = layout.char_to_scancode(key)[0]
+
+        await self.conn.send_key_scancode(modifier_scancode, True, False)
+        await asyncio.sleep(0.05)
+        await self.conn.send_key_scancode(key_scancode, True, False)
+        await asyncio.sleep(0.05)
+        await self.conn.send_key_scancode(key_scancode, False, False)
+        await asyncio.sleep(0.05)
+        await self.conn.send_key_scancode(modifier_scancode, False, False)
+
     async def _send_win_r(self):
         """Helper method to send Windows+R key combination to open Run dialog"""
+        self.logger.debug("Sending Win+R using scancode method")
+        for _ in range(2):
+            _, err = await self.conn.send_focus_in()
+            if err is not None:
+                raise err
+        await self._send_shortcut("VK_LWIN", "r")
+        await asyncio.sleep(0.5)
+
+    @staticmethod
+    def _build_execution_command(payload, shell_type, marker, get_output):
+        if not get_output:
+            if shell_type == "cmd":
+                return f"cmd.exe /d /s /c {payload}"
+            if shell_type == "powershell":
+                return (
+                    "powershell.exe -NoLogo -NoProfile -NonInteractive "
+                    f"-WindowStyle Hidden -Command {payload}"
+                )
+            raise ValueError(f"Unsupported shell type: {shell_type}")
+
+        payload_encoded = base64.b64encode(payload.encode("utf-16-le")).decode("ascii")
+        decode_payload = f"$command = [Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('{payload_encoded}'))"
+
+        if shell_type == "cmd":
+            invoke_command = "$output = & $env:ComSpec /d /s /c $command 2>&1"
+        elif shell_type == "powershell":
+            invoke_command = "$output = & ([ScriptBlock]::Create($command)) 2>&1"
+        else:
+            raise ValueError(f"Unsupported shell type: {shell_type}")
+
+        start_marker = f"__NXC_RDP_START_{marker}__"
+        end_marker = f"__NXC_RDP_END_{marker}__"
+        script = f"""
+$ErrorActionPreference = 'Continue'
+{decode_payload}
+try {{
+    {invoke_command}
+    $succeeded = $?
+    $nativeExitCode = $LASTEXITCODE
+}} catch {{
+    $output = $_
+    $succeeded = $false
+    $nativeExitCode = $null
+}}
+$exitCode = if ($null -ne $nativeExitCode) {{ [int]$nativeExitCode }} elseif (-not $succeeded) {{ 1 }} else {{ 0 }}
+$outputText = ($output | Out-String -Width 4096).TrimEnd()
+$result = @('{start_marker}', [string]$exitCode, $outputText, '{end_marker}') -join [Environment]::NewLine
+Set-Clipboard -Value $result
+"""
+
+        encoded_script = base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+        return f"powershell.exe -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -EncodedCommand {encoded_script}"
+
+    @staticmethod
+    def _parse_execution_result(clipboard_text, marker):
+        start_marker = f"__NXC_RDP_START_{marker}__"
+        end_marker = f"__NXC_RDP_END_{marker}__"
+        normalized = clipboard_text.replace("\r\n", "\n").rstrip("\x00")
+
+        start_index = normalized.find(start_marker)
+        end_index = normalized.find(end_marker, start_index + len(start_marker))
+        if start_index == -1 or end_index == -1:
+            return None
+
+        body = normalized[start_index + len(start_marker):end_index].lstrip("\n")
+        exit_code_text, separator, output = body.partition("\n")
+        if not separator:
+            return None
+
         try:
-            self.logger.debug("Sending Win+R using scancode method")
+            exit_code = int(exit_code_text.strip())
+        except ValueError:
+            return None
+        return exit_code, output.rstrip("\n")
 
-            layout = KeyboardLayoutManager().get_layout_by_shortname("enus")
+    async def _wait_for_event(self, event_names, max_wait):
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + max_wait
 
-            win_scancode = layout.vk_to_scancode("VK_LWIN")
-            await self.conn.send_key_scancode(win_scancode, True, False)
-            await asyncio.sleep(0.1)
+        while True:
+            if self.conn.disconnected_evt.is_set():
+                raise ConnectionError("RDP connection was terminated")
 
-            r_scancode = layout.char_to_scancode("r")[0]
-            await self.conn.send_key_scancode(r_scancode, True, False)
-            await asyncio.sleep(0.1)
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise asyncio.TimeoutError
 
-            await self.conn.send_key_scancode(r_scancode, False, False)
-            await asyncio.sleep(0.1)
+            data = await asyncio.wait_for(self.conn.ext_out_queue.get(), timeout=remaining)
+            if data is None:
+                raise ConnectionError("RDP connection was terminated")
 
-            await self.conn.send_key_scancode(win_scancode, False, False)
+            event_name = getattr(getattr(data, "type", None), "name", None)
+            if event_name in event_names:
+                return data
 
-            await asyncio.sleep(0.5)
+    async def _wait_for_desktop(self):
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
 
-            self.logger.debug("Win+R sent successfully")
-            return True
-        except (ConnectionResetError, ConnectionError, OSError) as e:
-            self.logger.debug(f"Connection error while waiting for clipboard: {e!s}")
-            self.logger.fail("Connection was reset by the remote host")
-            return False
-        except Exception as e:
-            self.logger.debug(f"Error sending Win+R: {e!s}")
-            self.logger.debug("Using fallback approach for opening command prompt")
-            return False
+        if not self.conn.desktop_buffer_has_data:
+            try:
+                await self._wait_for_event({"VIDEO"}, self.args.cmd_delay)
+            except asyncio.TimeoutError:
+                self.logger.debug("No desktop update received before command execution; continuing")
+
+        remaining_delay = self.args.cmd_delay - (loop.time() - started_at)
+        if remaining_delay > 0:
+            await asyncio.sleep(remaining_delay)
+
+    async def _submit_run_command(self, command):
+        await self._send_win_r()
+        await self.conn.set_current_clipboard_text(command)
+        response = await self._wait_for_event(
+            {"CLIPBOARD_FORMAT_LIST_RESPONSE"}, self.args.clipboard_delay
+        )
+        if not response.accepted:
+            raise RuntimeError(
+                "Remote session rejected the clipboard command data"
+            )
+        await self._send_keystrokes('powershell.exe -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -Command "Invoke-Expression (Get-Clipboard -Raw)"')
+        await self._send_enter()
+
+    async def _submit_typed_run_command(self, command):
+        await self._send_win_r()
+        await self._send_keystrokes(command, delay=0.005)
+        await self._send_enter()
+
+    async def _wait_for_command_result(self, marker):
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.args.clipboard_delay
+
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise asyncio.TimeoutError
+
+            data = await self._wait_for_event({"CLIPBOARD_DATA_TXT"}, remaining)
+            result = self._parse_execution_result(data.data, marker)
+            if result is not None:
+                return result
 
     async def execute_shell(self, payload, get_output, shell_type):
-        # Append | clip to send output to clipboard
-        if shell_type == "cmd":
-            payload_with_clip = f"{payload} | clip & exit"
-        elif shell_type == "powershell":
-            payload_with_clip = f"try {{ {payload} 2>&1 | clip}} catch {{ $_ | clip}}; exit"
-        else:
-            self.logger.fail(f"Unsupported shell type: {shell_type}")
-            return None
-        self.logger.debug(f"Executing command: {payload_with_clip}")
+        marker = uuid4().hex if get_output else None
+        command = self._build_execution_command(
+            payload, shell_type, marker, get_output
+        )
+        self.logger.debug(f"Executing {shell_type} command through {'an encoded PowerShell launcher' if get_output else 'interactive keyboard input'}")
 
         try:
-            self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
+            self.conn = self._create_rdp_connection(self.auth)
             await self.connect_rdp()
         except Exception as e:
             self.logger.debug(f"Error connecting to RDP: {e!s}")
@@ -454,90 +583,43 @@ class rdp(connection):
         try:
             if get_output:
                 self.logger.success("Waiting for clipboard to be ready...")
-                clipboard_ready = False
-                await asyncio.sleep(self.args.cmd_delay)
-
-                timeout_counter = 0
-                while not clipboard_ready and timeout_counter < (self.args.clipboard_delay * 10):  # Convert seconds to deciseconds
-                    try:
-                        data = await asyncio.wait_for(self.conn.ext_out_queue.get(), timeout=0.1)
-                        if hasattr(data, "type") and data.type.name == "CLIPBOARD_READY":
-                            clipboard_ready = True
-                            self.logger.debug("Clipboard is ready!")
-                            break
-                    except asyncio.TimeoutError:
-                        timeout_counter += 1
-                        continue
-                    except (ConnectionResetError, ConnectionError, OSError) as e:
-                        self.logger.debug(f"Connection error while waiting for clipboard: {e!s}")
-                        self.logger.fail("Connection was reset by the remote host")
-                        return ""
-                    except Exception as e:
-                        self.logger.debug(f"Error waiting for clipboard: {e!s}")
-                        self.logger.fail("Warning: Clipboard may not be fully initialized, no output can be retrieved")
-                        return ""
-
-                if not clipboard_ready:
+                try:
+                    await self._wait_for_event({"CLIPBOARD_READY"}, self.args.clipboard_delay)
+                except asyncio.TimeoutError:
                     self.logger.fail("Clipboard cannot be initialized, no output can be retrieved")
                     return ""
 
-            # Wait for desktop to be available
-            await asyncio.sleep(self.args.cmd_delay)
+            await self._wait_for_desktop()
+            if get_output:
+                try:
+                    await self._submit_run_command(command)
+                except asyncio.TimeoutError:
+                    self.logger.fail(
+                        "Remote session did not acknowledge the clipboard command data"
+                    )
+                    return None
+            else:
+                await self._submit_typed_run_command(command)
+
+            if not get_output:
+                await asyncio.sleep(self.args.cmd_delay)
+                self.logger.success("Executed command without retrieving output")
+                return None
 
             try:
-                # Try to open Run dialog using Windows+R
-                self.logger.debug("Attempting to open Run dialog")
-                win_r_success = await self._send_win_r()
-
-                if win_r_success:
-                    self.logger.debug(f"Launching {shell_type} via Run dialog")
-                    await self._send_keystrokes(f"{shell_type}.exe")
-                    await self._send_enter()
-                    await asyncio.sleep(self.args.cmd_delay)  # Wait for cmd window to open
-                else:
-                    # Fallback: Try direct command typing (assumes cmd may already be open)
-                    self.logger.debug(f"Sending {shell_type} command directly")
-                    await self._send_keystrokes(f"{shell_type}.exe")
-                    await self._send_enter()
-                    await asyncio.sleep(self.args.cmd_delay)
-
-                # Type the command with | clip
-                self.logger.debug(f"Typing command: {payload_with_clip}")
-                await self._send_keystrokes(payload_with_clip)
-                await self._send_enter()
-
-                # Wait for command to execute
-                await asyncio.sleep(self.args.cmd_delay)
-
-                if get_output:
-                    # Get the current clipboard text
-                    self.logger.debug("Getting clipboard content...")
-                    clipboard_text = await self.conn.get_current_clipboard_text()
-
-                    if clipboard_text:
-                        self.logger.debug("Command output retrieved from clipboard:")
-                        for line in clipboard_text.lstrip().strip("\n").splitlines():
-                            self.logger.highlight(line)
-                    else:
-                        self.logger.fail("Clipboard is empty or contains non-text data")
-                    return clipboard_text
-                else:
-                    self.logger.success("Executed command without retrieving output")
-
-                self.logger.debug("Command execution completed")
+                exit_code, output = await self._wait_for_command_result(marker)
+            except asyncio.TimeoutError:
+                self.logger.fail("Timed out waiting for command output on the RDP clipboard")
                 return None
 
-            except (ConnectionResetError, ConnectionError, OSError) as e:
-                self.logger.debug(f"Connection error during command execution: {e!s}")
-                self.logger.fail("Connection was reset by the remote host during command execution")
-                return None
-            except Exception as e:
-                self.logger.debug(f"Error during command execution: {e!s}")
-                if "cannot unpack non-iterable NoneType object" in str(e):
-                    self.logger.fail("RDP connection was terminated unexpectedly")
-                else:
-                    self.logger.fail(f"Command execution failed: {e!s}")
-                return None
+            if exit_code != 0:
+                self.logger.fail(f"Command completed with exit code {exit_code}")
+            if output:
+                for line in output.splitlines():
+                    self.logger.highlight(line)
+            else:
+                self.logger.debug("Command completed without output")
+            return output
 
         except (ConnectionResetError, ConnectionError, OSError) as e:
             self.logger.debug(f"Connection error: {e!s}")
@@ -559,31 +641,24 @@ class rdp(connection):
 
         get_output = bool(not self.args.no_output)
 
-        self.logger.success(f"Executing command: {payload} with delay {self.args.cmd_delay} seconds")
+        self.logger.success(f"Executing command: {payload}")
 
         try:
             result = asyncio.run(self.execute_shell(payload, get_output, shell_type))
 
-            if result:
+            if result is not None:
                 self.logger.debug("Command execution completed")
             return result
         except Exception as e:
             self.logger.error(f"Command execution error: {e!s}")
-            if shell_type == "cmd":
-                self.logger.info("Cannot execute command via cmd - now switching to PowerShell to attempt execution")
-                try:
-                    return self.execute(payload, shell_type="powershell")
-                except Exception as e2:
-                    self.logger.fail(f"Execute command failed, error: {e2!s}")
-            else:
-                self.logger.fail(f"Execute command failed, error: {e!s}")
+            self.logger.fail(f"Execute command failed, error: {e!s}")
 
     def ps_execute(self):
         self.execute(payload=self.args.ps_execute, shell_type="powershell")
 
     async def screen(self):
         try:
-            self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
+            self.conn = self._create_rdp_connection(self.auth)
             await self.connect_rdp()
 
             await asyncio.sleep(5)
@@ -606,7 +681,7 @@ class rdp(connection):
         for proto in self.protoflags_nla:
             try:
                 self.iosettings.supported_protocols = proto
-                self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
+                self.conn = self._create_rdp_connection(self.auth)
                 await self.connect_rdp()
             except Exception as e:
                 self.logger.debug(f"Failed to connect for nla_screenshot with {proto} {e}")

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -117,13 +117,12 @@ class rdp(connection):
             except Exception as e:
                 self.logger.debug(f"Error adding host {self.host} into db: {e!s}")
 
-    def _create_rdp_connection(self, credentials):
+    def _create_rdp_connection(self, credentials, supported_protocols=None):
         iosettings = self.iosettings.clone_for_connection()
-        if credentials is not None:
-            # clear the protocol override left by the NLA probe so aardwolf
-            # picks the right X224 flags for this credential type (e.g.
-            # RESTRICTED_ADMIN for hashes, HYBRID_EX for passwords)
-            iosettings.supported_protocols = None
+        # Explicit protocols are used by discovery and screenshot fallbacks.
+        # Authenticated connections leave this unset so aardwolf selects the
+        # X224 flags appropriate for the credential type.
+        iosettings.supported_protocols = supported_protocols
         return RDPConnection(
             iosettings=iosettings,
             target=copy.deepcopy(self.target),
@@ -138,8 +137,9 @@ class rdp(connection):
 
         for proto in reversed(self.protoflags):
             try:
-                self.iosettings.supported_protocols = proto
-                self.conn = self._create_rdp_connection(self.auth)
+                self.conn = self._create_rdp_connection(
+                    self.auth, supported_protocols=proto
+                )
                 asyncio.run(self.connect_rdp_with_cleanup())
             except OSError as e:
                 if "Errno 104" not in str(e):
@@ -185,8 +185,9 @@ class rdp(connection):
     async def check_nla(self):
         self.logger.debug(f"Checking NLA for {self.host}")
         try:
-            self.iosettings.supported_protocols = SUPP_PROTOCOLS.SSL
-            self.conn = self._create_rdp_connection(None)
+            self.conn = self._create_rdp_connection(
+                None, supported_protocols=SUPP_PROTOCOLS.SSL
+            )
             packetizer = TPKTPacketizer()
             client = UniClient(self.target, packetizer)
             self.conn._connection = await asyncio.wait_for(client.connect(), timeout=self.args.rdp_timeout)
@@ -240,8 +241,6 @@ class rdp(connection):
             if nthash:
                 self.nthash = nthash
 
-            kerb_pass = next(s for s in [nthash, password, aesKey] if s) if not all(s == "" for s in [nthash, password, aesKey]) else ""
-
             self.hostname + "." + self.domain
             password = password if password else nthash
 
@@ -261,6 +260,8 @@ class rdp(connection):
             else:
                 stype = asyauthSecret.PASS if not nthash else asyauthSecret.NT
                 password = password if password else nthash
+
+            kerb_pass = password
 
             kerberos_target = UniTarget(
                 self.kdcHost,
@@ -693,8 +694,9 @@ Add-Type -AssemblyName System.Windows.Forms
 
         for proto in self.protoflags_nla:
             try:
-                self.iosettings.supported_protocols = proto
-                self.conn = self._create_rdp_connection(self.auth)
+                self.conn = self._create_rdp_connection(
+                    self.auth, supported_protocols=proto
+                )
                 await self.connect_rdp()
             except Exception as e:
                 self.logger.debug(f"Failed to connect for nla_screenshot with {proto} {e}")

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -611,6 +611,17 @@ Add-Type -AssemblyName System.Windows.Forms
                     return None
 
             await self._wait_for_desktop()
+
+            # Prime the .NET/PowerShell runtime on Windows 10/11 single-session
+            # hosts where first execution after logon can take 30-60s due to
+            # JIT compilation of System.Windows.Forms. This hidden warmup command
+            # loads the assembly without producing any visible output.
+            await self._submit_typed_run_command(
+                "powershell.exe -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden "
+                '-Command "Add-Type -AssemblyName System.Windows.Forms"'
+            )
+            await asyncio.sleep(3)
+
             if get_output:
                 try:
                     await self._submit_run_command(command)

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -472,11 +472,12 @@ try {{
 $exitCode = if ($null -ne $nativeExitCode) {{ [int]$nativeExitCode }} elseif (-not $succeeded) {{ 1 }} else {{ 0 }}
 $outputText = ($output | Out-String -Width 4096).TrimEnd()
 $result = @('{start_marker}', [string]$exitCode, $outputText, '{end_marker}') -join [Environment]::NewLine
-Set-Clipboard -Value $result
+Add-Type -AssemblyName System.Windows.Forms
+[System.Windows.Forms.Clipboard]::SetText($result)
 """
 
         encoded_script = base64.b64encode(script.encode("utf-16-le")).decode("ascii")
-        return f"powershell.exe -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -EncodedCommand {encoded_script}"
+        return f"powershell.exe -NoLogo -NoProfile -NonInteractive -STA -WindowStyle Hidden -EncodedCommand {encoded_script}"
 
     @staticmethod
     def _parse_execution_result(clipboard_text, marker):
@@ -544,7 +545,12 @@ Set-Clipboard -Value $result
             raise RuntimeError(
                 "Remote session rejected the clipboard command data"
             )
-        await self._send_keystrokes('powershell.exe -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -Command "Invoke-Expression (Get-Clipboard -Raw)"')
+        await self._send_keystrokes(
+            "powershell.exe -NoLogo -NoProfile -NonInteractive -STA "
+            '-WindowStyle Hidden -Command "Add-Type -AssemblyName '
+            "System.Windows.Forms; Invoke-Expression "
+            '([System.Windows.Forms.Clipboard]::GetText())"'
+        )
         await self._send_enter()
 
     async def _submit_typed_run_command(self, command):

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -590,6 +590,7 @@ Add-Type -AssemblyName System.Windows.Forms
             await self.connect_rdp()
         except Exception as e:
             self.logger.debug(f"Error connecting to RDP: {e!s}")
+            await self.terminate_conn()
             return None
 
         try:

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -608,7 +608,7 @@ Add-Type -AssemblyName System.Windows.Forms
                     await self._wait_for_event({"CLIPBOARD_READY"}, self.args.clipboard_delay)
                 except asyncio.TimeoutError:
                     self.logger.fail("Clipboard cannot be initialized, no output can be retrieved")
-                    return ""
+                    return None
 
             await self._wait_for_desktop()
             if get_output:

--- a/nxc/protocols/rdp/proto_args.py
+++ b/nxc/protocols/rdp/proto_args.py
@@ -20,8 +20,8 @@ def proto_args(parser, parents):
     cgroup = rdp_parser.add_argument_group("Command Execution")
     cgroup.add_argument("-x", metavar="COMMAND", dest="execute", help="execute the specified command")
     cgroup.add_argument("-X", metavar="PS_COMMAND", dest="ps_execute", help="execute the specified PowerShell command")
-    cgroup.add_argument("--cmd-delay", type=int, default=5, help="Sleep time before executing command")
-    cgroup.add_argument("--clipboard-delay", type=int, default=30, help="Maximum time to wait for clipboard initialization (seconds)")
+    cgroup.add_argument("--cmd-delay", type=int, default=5, help="Delay before executing the command and before disconnecting with --no-output")
+    cgroup.add_argument("--clipboard-delay", type=int, default=30, help="Maximum time to wait for clipboard initialization and command output")
     cgroup.add_argument("--no-output", action="store_true", help="do not retrieve command output")
 
     return parser

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -311,6 +311,10 @@ netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --nla-scree
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --screenshot
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
 netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x ipconfig
+netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x "echo nxc-rdp-exec"
+netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x "echo alpha^&beta"
+netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X "Write-Output 'nxc-rdp-exec'"
+netexec rdp TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -x "echo nxc-rdp-no-output" --no-output
 ##### SSH - Default test passwords and random key; switch these out if you want correct authentication
 netexec ssh TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD
 netexec ssh TARGET_HOST -u TEST_USER_FILE -p TEST_PASSWORD_FILE --no-bruteforce


### PR DESCRIPTION
## Description

This PR rewrites the RDP command execution path introduced in #676 for better reliability. The current implementation has several failures, including Win+R failing occasionally, clipboard sync races, and auth issues. 

Requires aardwolf with reliability fixes: https://github.com/skelsec/aardwolf/pull/47 (I can commit an update to dependencies here once aardwolf merges this)

<img width="4586" height="1168" alt="image" src="https://github.com/user-attachments/assets/40e017a3-2476-45d1-bd91-281a4efe7949" />

Unfortunately, execution is still sometimes unreliable - but in my testing, this branch is ~35% more reliable than the main branch. Issues usually seem to happen on cold start of the box and rerunning once more fixes it. As far as I can tell, this issue just has to do with waiting for explorer to start up before we open the Run dialog. Could add a retry in the code if yall think that would be appropriate.

<img width="1898" height="452" alt="image" src="https://github.com/user-attachments/assets/b2882d5b-d0af-4e13-9b68-90a67e0bedbc" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [x] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

## Setup guide for the review

Local machine: Python 3.13, Ubuntu Linux
Targets tested: Windows Server 2022 (Azure, Build 20348), Windows Server 2025 AD (Azure, Build 26100), Windows 11 (Azure, Build 26100)

How to test:
```bash
pipx install "git+https://github.com/Adamkadaban/NetExec@rdp-exec-reliability-final"
pipx inject netexec "git+https://github.com/Adamkadaban/aardwolf@rdp-reliability-final" -f 

nxc rdp <target> -u admin -p pass -x 'echo hello'
nxc rdp <target> -u admin -p pass -X 'Write-Output "hello"'
nxc rdp <target> -u admin -p pass -x 'echo alpha^&beta'
nxc rdp <target> -u admin -p pass -x 'cmd /c exit /b 7'
nxc rdp <target> -u admin -p pass -X 'Write-Output "cafe"'
nxc rdp <target> -u admin -p pass -x 'echo hi' --no-output
nxc rdp <target> -u admin -p pass -k -x 'whoami'
```

## Sources

MS-RDPBCGR

- Synchronize Event, `toggleFlags` (4 bytes):
  https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/6c5d0ef9-4653-4d69-9ba9-09ba3acd660f
- Keyboard Event, `keyboardFlags` EXTENDED bit:
  https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/08eaaed5-f143-4bfa-a1e2-5414ca0ec67e

FreeRDP

- Focus initialization sequence:
  https://github.com/FreeRDP/FreeRDP/blob/0aa3589/libfreerdp/core/input.c#L344-L356
- `toggleFlags` as UINT32:
  https://github.com/FreeRDP/FreeRDP/blob/0aa3589/libfreerdp/core/input.c#L125-L131
- Extended scancode normalization:
  https://github.com/FreeRDP/FreeRDP/blob/0aa3589/libfreerdp/core/input.c#L720-L726
- Clipboard format list response:
  https://github.com/FreeRDP/FreeRDP/blob/0aa3589/channels/cliprdr/client/cliprdr_format.c#L191-L206

Other

- `System.Windows.Forms.Clipboard` requires STA threading:
  https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.clipboard

## Testing

- Tested e2e on Windows Server 2022, Windows 11, and Server 2025 AD with NTLM, Kerberos password, ccache, NT hash, and AES.
- Tested against NetExec E2E suite (9/9 passing).
- Stress tested 50 sequential+parallel command executions on Server 2022: 50/50 passed (10 per batch).
- Stress tested 50 sequential+parallel Kerberos password executions on Server 2025 DC: 50/50 passed (10 per batch).


## Checklist:

- [x] I have ran Ruff against my changes (`poetry run python -m ruff check . --preview`)
- [x] I have added or updated the `tests/e2e_commands.txt` file
- [x] New and existing e2e tests pass locally with my changes
- [x] If reliant on changes of third party dependencies, I have linked the relevant PRs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Details (AI)

1. Connection isolation: Each connection gets cloned IO settings, target, and credential objects. No shared state between sequential connections.

2. Protocol negotiation fix: Authenticated connections no longer inherit the NLA fingerprinting probe's `supported_protocols` override. This fixes Kerberos, ccache, and NT hash execution on Server 2025.

3. AES credential type: Uses `asyauthSecret.AES` for AES keys (was incorrectly using password type).

4. Keyboard focus initialization: Sends the focus initialization sequence before Win+R to ensure keyboard reaches the desktop (see https://github.com/skelsec/aardwolf/pull/47).

5. Unicode input: Uses `send_key_char` (Unicode keyboard events) for Run dialog text.

6. Output capture rewrite:
   - Payload base64-encoded as UTF-16LE (handles all characters including &, |, Unicode).
   - Unique `__NXC_RDP_START_<uuid>__` / `__NXC_RDP_END_<uuid>__` markers (ignores stale clipboard).
   - Captures native `$LASTEXITCODE`.
   - Uses `[System.Windows.Forms.Clipboard]::SetText()` / `::GetText()` (.NET API, works PowerShell 2+) instead of PS5-only `Set-Clipboard`/`Get-Clipboard`.
   - `-STA` flag for WinForms clipboard STA threading requirement.

7. Clipboard synchronization: Waits for `CLIPBOARD_FORMAT_LIST_RESPONSE` before triggering remote clipboard read. Eliminates the race where the remote reads before the client has written.

8. No-output mode: Direct compact launchers (`cmd.exe /d /s /c` or `powershell.exe -Command`) instead of large encoded scripts typed character-by-character.

---
(Developed with assistance from Copilot CLI with GPT 5.6 and Opus 5, but all reviewed and tested on live targets by a human)
