### PR TITLE
fix: db_execute lock scope to prevent thread-safety race (#1320)

### DIFF
--- a/nxc/database.py
+++ b/nxc/database.py
@@ -204,10 +204,9 @@ class BaseDB:
             self.db_execute(table.delete())
 
     def db_execute(self, *args):
-        self.lock.acquire()
-        res = self.sess.execute(*args)
-        self.lock.release()
-        return res
+        with self.lock:
+            res = self.sess.execute(*args)
+            return res.freeze()() if res.returns_rows else res
 
     def get_keys(self, key_id=None, cred_id=None):
         """Return an empty list by default. Protocols that support keys (e.g. SSH) override this."""


### PR DESCRIPTION
## Description

This PR fixes a thread-safety race condition described in #1320. The issue occurred when `BaseDB.db_execute()` released the lock before the `Result` was consumed, causing `Row._asdict()` to crash with `IndexError: tuple index out of range` under concurrent threads (especially during `SSHDatabase.add_host()`).

The fix holds the lock across both execution and row buffering by using a `with` context manager and freezing the result before returning it to the caller if it returns rows.

Fixes #1320

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
