### PR TITLE
Allow using proto to switch protocole without calling back

### DIFF
--- a/nxc/nxcdb.py
+++ b/nxc/nxcdb.py
@@ -101,7 +101,6 @@ class DatabaseNavigator(cmd.Cmd):
     def do_proto(self, line):
         if not line:
             self.main_menu.help_proto()
-            return
 
         self.db.shutdown_db()
         self.main_menu.do_proto(line)

--- a/nxc/nxcdb.py
+++ b/nxc/nxcdb.py
@@ -16,10 +16,6 @@ from nxc.paths import CONFIG_PATH, WORKSPACE_DIR
 from nxc.database import create_db_engine, open_config, get_workspace, get_db, write_configfile, create_workspace, set_workspace
 
 
-class UserExitedProto(Exception):
-    pass
-
-
 def print_table(data, title=None):
     print()
     table = AsciiTable(data)
@@ -99,7 +95,17 @@ class DatabaseNavigator(cmd.Cmd):
         print_help(help_string)
 
     def do_back(self, line):
-        raise UserExitedProto
+        self.db.shutdown_db()
+        return True
+
+    def do_proto(self, line):
+        if not line:
+            self.main_menu.help_proto()
+            return
+
+        self.db.shutdown_db()
+        self.main_menu.do_proto(line)
+        return True
 
     def do_export(self, line):
         if not line:
@@ -467,17 +473,13 @@ class NXCDBMenu(cmd.Cmd):
             db_object = self.p_loader.load_protocol(self.protocols[proto]["dbpath"])
             self.config.set("nxc", "last_used_db", proto)
             write_configfile(self.config, self.config_path)
-            try:
-                proto_menu = db_nav_object.navigator(self, db_object.database(self.conn), proto)
-                proto_menu.cmdloop()
-            except UserExitedProto:
-                pass
+            proto_menu = db_nav_object.navigator(self, db_object.database(self.conn), proto)
+            proto_menu.cmdloop()
 
     @staticmethod
     def help_proto():
         help_string = """
-        proto [smb|mssql|winrm]
-            *unimplemented protocols: ftp, rdp, ldap, ssh
+        proto [smb|mssql|winrm|ftp|rdp|ldap|ssh]
         Changes nxcdb to the specified protocol
         """
         print_help(help_string)


### PR DESCRIPTION
## Description
This PR allows switching proto databases without having to call the back command:

<img width="1165" height="353" alt="image" src="https://github.com/user-attachments/assets/24194663-3ae1-415a-a726-c5d09eb3db55" />

I also updated the help proto command so that it includes ldap, ssh, ftp and rdp protos because we now support them! :)

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Nothing new.

## Screenshots (if appropriate):

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
