### PR TITLE
fix ldap resolution failure in GPP_Privileges module

### DIFF
--- a/nxc/modules/gpp_privileges.py
+++ b/nxc/modules/gpp_privileges.py
@@ -1,6 +1,7 @@
 import re
 from io import BytesIO
 from impacket.ldap import ldap as ldap_impacket
+from impacket.ldap import ldapasn1 as ldapasn1_impacket
 from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
 
@@ -130,12 +131,19 @@ class NXCModule:
             privileges = self.extract_privileges(content)
             if privileges:
                 ldap_connection = None
+                base_dn = None
                 if not self.no_ldap:
                     ldap_connection = self.initialize_ldap_connection(connection)
+                    root = ldap_connection.search(
+                        scope=ldapasn1_impacket.Scope("baseObject"),
+                        attributes=["defaultNamingContext"],
+                        sizeLimit=0,
+                    )
+                    base_dn = parse_result_attributes(root)[0]["defaultNamingContext"]
 
                 self.context.log.success(f"Privileges extracted from {path}:")
                 for privilege, sids in privileges.items():
-                    resolved_sids = [self.resolve_sid(sid, ldap_connection) for sid in sids]
+                    resolved_sids = [self.resolve_sid(sid, ldap_connection, base_dn) for sid in sids]
                     self.context.log.highlight(f"{privilege}: {', '.join(resolved_sids)}")
 
                 if ldap_connection:
@@ -193,7 +201,7 @@ class NXCModule:
             return None
         return ldap_connection
 
-    def resolve_sid(self, sid, ldap_connection):
+    def resolve_sid(self, sid, ldap_connection, base_dn):
         """Resolves a SID to a human-readable name using well-known mappings or LDAP queries."""
         if sid in self.WELL_KNOWN_SIDS:
             return self.WELL_KNOWN_SIDS[sid]
@@ -201,11 +209,11 @@ class NXCModule:
         if ldap_connection:
             try:
                 resp = ldap_connection.search(
+                    searchBase=base_dn,
                     searchFilter=f"(objectSid={sid})",
                     attributes=["sAMAccountName"],
                 )
                 parsed_result = parse_result_attributes(resp)
-
                 if parsed_result and "sAMAccountName" in parsed_result[0]:
                     return f"{parsed_result[0]['sAMAccountName']}"
                 else:

--- a/nxc/modules/gpp_privileges.py
+++ b/nxc/modules/gpp_privileges.py
@@ -134,12 +134,7 @@ class NXCModule:
                 base_dn = None
                 if not self.no_ldap:
                     ldap_connection = self.initialize_ldap_connection(connection)
-                    root = ldap_connection.search(
-                        scope=ldapasn1_impacket.Scope("baseObject"),
-                        attributes=["defaultNamingContext"],
-                        sizeLimit=0,
-                    )
-                    base_dn = parse_result_attributes(root)[0]["defaultNamingContext"]
+                    base_dn = self.get_basedn(ldap_connection)
 
                 self.context.log.success(f"Privileges extracted from {path}:")
                 for privilege, sids in privileges.items():
@@ -148,6 +143,14 @@ class NXCModule:
 
                 if ldap_connection:
                     ldap_connection.close()
+
+    def get_basedn(self, ldap_connection):
+        root = ldap_connection.search(
+                        scope=ldapasn1_impacket.Scope("baseObject"),
+                        attributes=["defaultNamingContext"],
+                        sizeLimit=0,
+                    )
+        return parse_result_attributes(root)[0]["defaultNamingContext"]
 
     def extract_privileges(self, content):
         """Parses the content of GptTmpl.inf to extract privilege rights."""


### PR DESCRIPTION
## Description
Hello! just a small fix for the ldap resolution of the gpp_privileges module by adding the base DN. Looking at the commits on the module, the logic was initially present but removed in the last commit https://github.com/Pennyw0rth/NetExec/pull/1286

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

To add a GPO with an SID to resolve I followed this proc:
<img width="806" height="554" alt="image" src="https://github.com/user-attachments/assets/1e42c53c-254b-474e-be83-658f0783a67c" />


## Screenshots (if appropriate):

### Before:
```
nxc smb 192.168.57.11  -u arya.stark -p Needle  -M gpp_privileges --debug
[09:29:37] DEBUG    NXC VERSION: 0.0.0 - Yippie-Ki-Yay - 6fe31fcb - 6649                               netexec.py:96
           DEBUG    PYTHON VERSION: 3.13.14 (main, Jun 10 2026, 18:10:12) [GCC 15.2.0]                 netexec.py:97
           DEBUG    RUNNING ON: Linux Release: 7.0.12+kali-amd64                                       netexec.py:98
           DEBUG    Passed args: Namespace(version=False, threads=256, timeout=None, jitter=None,      netexec.py:99
                    no_progress=False, log=None, verbose=False, debug=True, force_ipv6=False,                       
                    dns_server=None, dns_tcp=False, dns_timeout=3, protocol='smb',                                  
                    target=['192.168.57.11'], username=['arya.stark'], password=['Needle'],                         
                    cred_id=[], ignore_pw_decoding=False, no_bruteforce=False,                                      
                    continue_on_success=False, gfail_limit=None, ufail_limit=None, fail_limit=None,                 
                    kerberos=False, use_kcache=False, aesKey=None, kdcHost=None, pfx_cert=None,                     
                    pfx_base64=None, pfx_pass=None, pem_cert=None, pem_key=None,                                    
                    module=['gpp_privileges'], module_options=[], list_modules=None,                                
                    show_module_options=False, hash=[], delegate=None, spn=None, generate_st=None,                  
                    no_s4u2proxy=False, u2u=False, domain=None, local_auth=False, port=445,                         
                    share='C$', smb_server_port=445, no_smbv1=False, no_admin_check=False,                          
                    gen_relay_list=None, smb_timeout=2, laps=None, generate_hosts_file=None,                        
                    generate_krb5_file=None, generate_tgt=None, sam=None, lsa=None, ntds=None,                      
                    history=False, kerberos_keys=False, enabled=False, userntds=None, dpapi=None,                   
                    sccm=None, mkfile=None, pvk=None, list_snapshots=None, shares=None,                             
                    exclude_shares=None, dir=None, interfaces=False, file_write_check=False,                        
                    filter_shares=None, disks=False, users=None, users_export=None, groups=None,                    
                    local_groups=None, computers=None, pass_pol=False, rid_brute=None,                              
                    smb_sessions=False, reg_sessions=None, loggedon_users=None,                                     
                    loggedon_users_filter=None, qwinsta=None, tasklist=None, taskkill=None,                         
                    wmi_query=None, wmi_namespace='root\\cimv2', spider=None, spider_folder='.',                    
                    content=False, exclude_dirs='', depth=None, only_files=False, silent=False,                     
                    pattern=None, regex=None, put_file=None, get_file=None, append_host=False,                      
                    exec_method='wmiexec', dcom_timeout=5, get_output_tries=100, codec='utf-8',                     
                    no_output=False, execute=None, ps_execute=None, obfs=False, amsi_bypass=None,                   
                    clear_obfscripts=False, force_ps32=False, no_encode=False)                                      
           DEBUG    Protocol: smb                                                                     netexec.py:155
           DEBUG    Protocol Path: /home/kali/tools/dev/NetExec/nxc/protocols/smb.py                  netexec.py:158
           DEBUG    Protocol DB Path: /home/kali/tools/dev/NetExec/nxc/protocols/smb/database.py      netexec.py:160
           DEBUG    Protocol Object: <class 'protocol.smb'>, type: <class 'type'>                     netexec.py:163
           DEBUG    Protocol DB Object: <class 'protocol.database'>                                   netexec.py:165
           DEBUG    DB Path: /home/kali/.nxc/workspaces/default/smb.db                                netexec.py:168
           DEBUG    Modules to be Loaded for sanity check: ['gpp_privileges'], <class 'list'>         netexec.py:202
           DEBUG    Loading module for sanity check gpp_privileges at path                            netexec.py:209
                    /home/kali/tools/dev/NetExec/nxc/modules/gpp_privileges.py                                      
           DEBUG    Supported protocols: ['smb']                                                  moduleloader.py:89
           DEBUG    Protocol: smb                                                                 moduleloader.py:90
           DEBUG    Creating ThreadPoolExecutor                                                        netexec.py:47
           DEBUG    Creating thread for <class 'protocol.smb'>                                         netexec.py:50
           INFO     Socket info: host=192.168.57.11, hostname=192.168.57.11, kerberos=False,       connection.py:178
                    ipv6=False, link-local ipv6=False                                                               
           DEBUG    Kicking off proto_flow                                                         connection.py:242
           INFO     Creating SMBv1 connection to 192.168.57.11                                            smb.py:626
           INFO     SMBv1 disabled on 192.168.57.11                                                       smb.py:650
           INFO     Creating SMBv3 connection to 192.168.57.11                                            smb.py:660
           DEBUG    Created connection object                                                      connection.py:247
[09:29:38] DEBUG    Server OS: Windows 10 / Server 2019 Build 17763 10.0 build 17763                      smb.py:282
           DEBUG    Error logging off system: SMB SessionError: code: 0xc0000203 -                        smb.py:297
                    STATUS_USER_SESSION_DELETED - The remote user session has been deleted.                         
           DEBUG    Update Hosts: [{'id': 1, 'ip': '192.168.57.11', 'hostname': 'WINTERFELL',        database.py:273
                    'domain': 'north.sevenkingdoms.local', 'os': 'Windows 10 / Server 2019 Build                    
                    17763', 'dc': None, 'smbv1': False, 'signing': True, 'spooler': None,                           
                    'zerologon': None, 'petitpotam': None}]                                                         
           DEBUG    add_host() - Host IDs Updated: [1]                                               database.py:283
           INFO     Resolved domain: north.sevenkingdoms.local with dns, kdcHost: 192.168.57.11           smb.py:318
[09:29:38] INFO     SMB         192.168.57.11   445    WINTERFELL       Windows 10 / Server 2019 Build    smb.py:326
                    17763 x64 (name:WINTERFELL) (domain:north.sevenkingdoms.local) (signing:True)                   
                    (SMBv1:False) (Null Auth:True)                                                                  
           DEBUG    Trying to authenticate using plaintext with domain                             connection.py:510
           INFO     Creating SMBv3 connection to 192.168.57.11                                            smb.py:660
           DEBUG    Logged in with password to SMB with north.sevenkingdoms.local/arya.stark              smb.py:493
           DEBUG    self.is_guest=False                                                                   smb.py:495
           DEBUG    Checking if user is admin on 192.168.57.11                                            smb.py:709
           DEBUG    Adding credential: north.sevenkingdoms.local/arya.stark:Needle                        smb.py:502
           DEBUG    Adding credentials: [{'id': 44, 'domain': 'north.sevenkingdoms.local',           database.py:340
                    'username': 'arya.stark', 'password': 'Needle', 'credtype': 'plaintext',                        
                    'pillaged_from_hostid': None}]                                                                  
           DEBUG    Using 'ip' column for filtering                                                  database.py:116
           DEBUG    filter_term is an IP address: 192.168.57.11                                      database.py:127
           DEBUG    smb hosts() - results: [(1, '192.168.57.11', 'WINTERFELL',                       database.py:489
                    'north.sevenkingdoms.local', 'Windows 10 / Server 2019 Build 17763', None,                      
                    False, True, None, None, None)]                                                                 
[09:29:38] INFO     SMB         192.168.57.11   445    WINTERFELL                                         smb.py:514
                    north.sevenkingdoms.local\arya.stark:********                                                   
           DEBUG    Calling command arguments                                                      connection.py:259
           INFO     Loading modules for target: 192.168.57.11                                      connection.py:602
           DEBUG    Supported protocols: ['smb']                                                  moduleloader.py:89
           DEBUG    Protocol: smb                                                                 moduleloader.py:90
           DEBUG    Calling modules                                                                connection.py:263
           DEBUG    Loading module gpp_privileges - <nxc_module_gpp_privileges.NXCModule object at connection.py:295
                    0x7fabce5efc50>                                                                                 
           DEBUG    Loading context for module gpp_privileges -                                    connection.py:305
                    <nxc_module_gpp_privileges.NXCModule object at 0x7fabce5efc50>                                  
           DEBUG    Module gpp_privileges has on_login method                                      connection.py:310
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Searching for          gpp_privileges.py:108
                    GptTmpl.inf files                                                                               
           INFO     Found GptTmpl.inf:                                                         gpp_privileges.py:119
                    north.sevenkingdoms.local/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}/                      
                    MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf                                                
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Found Default Domain   gpp_privileges.py:117
                    Policy GptTmpl.inf:                                                                             
                    north.sevenkingdoms.local/Policies/{6AC1786C-016F-11D2-945F-00C04fB984F9}/                      
                    MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf                                                
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Connected to LDAP.     gpp_privileges.py:190
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Privileges extracted   gpp_privileges.py:136
                    from                                                                                            
                    north.sevenkingdoms.local/Policies/{6AC1786C-016F-11D2-945F-00C04fB984F9}/                      
                    MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf:                                               
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeAssignPrimaryTokenPrivilege: NT Authority, NT Authority                                       
           WARNING  SID S-1-5-80-2246541699-21809830-3603976364-117610243-975697593 not found  gpp_privileges.py:215
                    in LDAP. Returning raw SID.                                                                     
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeAuditPrivilege:      gpp_privileges.py:139
                    S-1-5-80-2246541699-21809830-3603976364-117610243-975697593, NT Authority,                      
                    NT Authority                                                                                    
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeBackupPrivilege:     gpp_privileges.py:139
                    Administrators, Backup Operators, Server Operators                                              
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeBatchLogonRight:     gpp_privileges.py:139
                    Administrators, Backup Operators, BUILTIN\Performance Log Users                                 
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeChangeNotifyPrivilege: Everyone, NT Authority, NT Authority,                                  
                    Administrators, Authenticated Users, BUILTIN\Pre-Windows 2000 Compatible                        
                    Access                                                                                          
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeCreatePagefilePrivilege: Administrators                                                       
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeDebugPrivilege:      gpp_privileges.py:139
                    Administrators                                                                                  
           WARNING  SID S-1-5-90-0 not found in LDAP. Returning raw SID.                       gpp_privileges.py:215
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeIncreaseBasePriorityPrivilege: Administrators, S-1-5-90-0                                     
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeIncreaseQuotaPrivilege: NT Authority, NT Authority, Administrators                            
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeInteractiveLogonRight: Administrators, Backup Operators, Account                              
                    Operators, Server Operators, Print Operators, Enterprise Domain                                 
                    Controllers                                                                                     
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeLoadDriverPrivilege: gpp_privileges.py:139
                    Administrators, Print Operators                                                                 
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeMachineAccountPrivilege: Authenticated Users                                                  
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeNetworkLogonRight:   gpp_privileges.py:139
                    Everyone, Administrators, Authenticated Users, Enterprise Domain                                
                    Controllers, BUILTIN\Pre-Windows 2000 Compatible Access                                         
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeProfileSingleProcessPrivilege: Administrators                                                 
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeRemoteShutdownPrivilege: Administrators, Server Operators                                     
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeRestorePrivilege:    gpp_privileges.py:139
                    Administrators, Backup Operators, Server Operators                                              
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeSecurityPrivilege:   gpp_privileges.py:139
                    Administrators                                                                                  
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeShutdownPrivilege:   gpp_privileges.py:139
                    Administrators, Backup Operators, Server Operators, Print Operators                             
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeSystemEnvironmentPrivilege: Administrators                                                    
           WARNING  SID S-1-5-80-3139157870-2983391045-3678747466-658725712-1809340420 not     gpp_privileges.py:215
                    found in LDAP. Returning raw SID.                                                               
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeSystemProfilePrivilege: Administrators,                                                       
                    S-1-5-80-3139157870-2983391045-3678747466-658725712-1809340420                                  
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeSystemTimePrivilege: gpp_privileges.py:139
                    NT Authority, Administrators, Server Operators                                                  
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeTakeOwnershipPrivilege: Administrators                                                        
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeUndockPrivilege:     gpp_privileges.py:139
                    Administrators                                                                                  
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:139
                    SeEnableDelegationPrivilege: Administrators                                                     
           INFO     Found GptTmpl.inf:                                                         gpp_privileges.py:119
                    north.sevenkingdoms.local/Policies/{C4F0511D-A8F5-4560-B35C-002F3CA1F240}/                      
                    Machine/Microsoft/Windows NT/SecEdit/GptTmpl.inf                                                
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Connected to LDAP.     gpp_privileges.py:190
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Privileges extracted   gpp_privileges.py:136
                    from                                                                                            
                    north.sevenkingdoms.local/Policies/{C4F0511D-A8F5-4560-B35C-002F3CA1F240}/                      
                    Machine/Microsoft/Windows NT/SecEdit/GptTmpl.inf:                                               
           WARNING  SID S-1-5-21-32739672-1006631753-711377108-1110 not found in LDAP.         gpp_privileges.py:215
                    Returning raw SID.                                                                              
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeDebugPrivilege:      gpp_privileges.py:139
                    S-1-5-21-32739672-1006631753-711377108-1110                                                     
           WARNING  SID S-1-5-21-32739672-1006631753-711377108-1110 not found in LDAP.         gpp_privileges.py:215
                    Returning raw SID.                                                                              
[09:29:38] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeBackupPrivilege:     gpp_privileges.py:139
                    S-1-5-21-32739672-1006631753-711377108-1110                                                     
           DEBUG    Closing connection to: 192.168.57.11   
```
<img width="949" height="818" alt="image" src="https://github.com/user-attachments/assets/e57d647e-ca35-4014-a6d1-e940cfd0ce93" />



### After:
```
nxc smb 192.168.57.11  -u arya.stark -p Needle  -M gpp_privileges --debug
[09:42:53] DEBUG    NXC VERSION: 0.0.0 - Yippie-Ki-Yay - 6fe31fcb - 6649                               netexec.py:96
           DEBUG    PYTHON VERSION: 3.13.14 (main, Jun 10 2026, 18:10:12) [GCC 15.2.0]                 netexec.py:97
           DEBUG    RUNNING ON: Linux Release: 7.0.12+kali-amd64                                       netexec.py:98
           DEBUG    Passed args: Namespace(version=False, threads=256, timeout=None, jitter=None,      netexec.py:99
                    no_progress=False, log=None, verbose=False, debug=True, force_ipv6=False,                       
                    dns_server=None, dns_tcp=False, dns_timeout=3, protocol='smb',                                  
                    target=['192.168.57.11'], username=['arya.stark'], password=['Needle'],                         
                    cred_id=[], ignore_pw_decoding=False, no_bruteforce=False,                                      
                    continue_on_success=False, gfail_limit=None, ufail_limit=None, fail_limit=None,                 
                    kerberos=False, use_kcache=False, aesKey=None, kdcHost=None, pfx_cert=None,                     
                    pfx_base64=None, pfx_pass=None, pem_cert=None, pem_key=None,                                    
                    module=['gpp_privileges'], module_options=[], list_modules=None,                                
                    show_module_options=False, hash=[], delegate=None, spn=None, generate_st=None,                  
                    no_s4u2proxy=False, u2u=False, domain=None, local_auth=False, port=445,                         
                    share='C$', smb_server_port=445, no_smbv1=False, no_admin_check=False,                          
                    gen_relay_list=None, smb_timeout=2, laps=None, generate_hosts_file=None,                        
                    generate_krb5_file=None, generate_tgt=None, sam=None, lsa=None, ntds=None,                      
                    history=False, kerberos_keys=False, enabled=False, userntds=None, dpapi=None,                   
                    sccm=None, mkfile=None, pvk=None, list_snapshots=None, shares=None,                             
                    exclude_shares=None, dir=None, interfaces=False, file_write_check=False,                        
                    filter_shares=None, disks=False, users=None, users_export=None, groups=None,                    
                    local_groups=None, computers=None, pass_pol=False, rid_brute=None,                              
                    smb_sessions=False, reg_sessions=None, loggedon_users=None,                                     
                    loggedon_users_filter=None, qwinsta=None, tasklist=None, taskkill=None,                         
                    wmi_query=None, wmi_namespace='root\\cimv2', spider=None, spider_folder='.',                    
                    content=False, exclude_dirs='', depth=None, only_files=False, silent=False,                     
                    pattern=None, regex=None, put_file=None, get_file=None, append_host=False,                      
                    exec_method='wmiexec', dcom_timeout=5, get_output_tries=100, codec='utf-8',                     
                    no_output=False, execute=None, ps_execute=None, obfs=False, amsi_bypass=None,                   
                    clear_obfscripts=False, force_ps32=False, no_encode=False)                                      
           DEBUG    Protocol: smb                                                                     netexec.py:155
           DEBUG    Protocol Path: /home/kali/tools/dev/NetExec/nxc/protocols/smb.py                  netexec.py:158
           DEBUG    Protocol DB Path: /home/kali/tools/dev/NetExec/nxc/protocols/smb/database.py      netexec.py:160
           DEBUG    Protocol Object: <class 'protocol.smb'>, type: <class 'type'>                     netexec.py:163
           DEBUG    Protocol DB Object: <class 'protocol.database'>                                   netexec.py:165
           DEBUG    DB Path: /home/kali/.nxc/workspaces/default/smb.db                                netexec.py:168
[09:42:54] DEBUG    Modules to be Loaded for sanity check: ['gpp_privileges'], <class 'list'>         netexec.py:202
           DEBUG    Loading module for sanity check gpp_privileges at path                            netexec.py:209
                    /home/kali/tools/dev/NetExec/nxc/modules/gpp_privileges.py                                      
           DEBUG    Supported protocols: ['smb']                                                  moduleloader.py:89
           DEBUG    Protocol: smb                                                                 moduleloader.py:90
           DEBUG    Creating ThreadPoolExecutor                                                        netexec.py:47
           DEBUG    Creating thread for <class 'protocol.smb'>                                         netexec.py:50
           INFO     Socket info: host=192.168.57.11, hostname=192.168.57.11, kerberos=False,       connection.py:178
                    ipv6=False, link-local ipv6=False                                                               
           DEBUG    Kicking off proto_flow                                                         connection.py:242
           INFO     Creating SMBv1 connection to 192.168.57.11                                            smb.py:626
           INFO     SMBv1 disabled on 192.168.57.11                                                       smb.py:650
           INFO     Creating SMBv3 connection to 192.168.57.11                                            smb.py:660
           DEBUG    Created connection object                                                      connection.py:247
           DEBUG    Server OS: Windows 10 / Server 2019 Build 17763 10.0 build 17763                      smb.py:282
           DEBUG    Error logging off system: SMB SessionError: code: 0xc0000203 -                        smb.py:297
                    STATUS_USER_SESSION_DELETED - The remote user session has been deleted.                         
           DEBUG    Update Hosts: [{'id': 1, 'ip': '192.168.57.11', 'hostname': 'WINTERFELL',        database.py:273
                    'domain': 'north.sevenkingdoms.local', 'os': 'Windows 10 / Server 2019 Build                    
                    17763', 'dc': None, 'smbv1': False, 'signing': True, 'spooler': None,                           
                    'zerologon': None, 'petitpotam': None}]                                                         
           DEBUG    add_host() - Host IDs Updated: [1]                                               database.py:283
           INFO     Resolved domain: north.sevenkingdoms.local with dns, kdcHost: 192.168.57.11           smb.py:318
[09:42:54] INFO     SMB         192.168.57.11   445    WINTERFELL       Windows 10 / Server 2019 Build    smb.py:326
                    17763 x64 (name:WINTERFELL) (domain:north.sevenkingdoms.local) (signing:True)                   
                    (SMBv1:False) (Null Auth:True)                                                                  
           DEBUG    Trying to authenticate using plaintext with domain                             connection.py:510
           INFO     Creating SMBv3 connection to 192.168.57.11                                            smb.py:660
           DEBUG    Logged in with password to SMB with north.sevenkingdoms.local/arya.stark              smb.py:493
           DEBUG    self.is_guest=False                                                                   smb.py:495
           DEBUG    Checking if user is admin on 192.168.57.11                                            smb.py:709
           DEBUG    Adding credential: north.sevenkingdoms.local/arya.stark:Needle                        smb.py:502
           DEBUG    Adding credentials: [{'id': 44, 'domain': 'north.sevenkingdoms.local',           database.py:340
                    'username': 'arya.stark', 'password': 'Needle', 'credtype': 'plaintext',                        
                    'pillaged_from_hostid': None}]                                                                  
           DEBUG    Using 'ip' column for filtering                                                  database.py:116
           DEBUG    filter_term is an IP address: 192.168.57.11                                      database.py:127
           DEBUG    smb hosts() - results: [(1, '192.168.57.11', 'WINTERFELL',                       database.py:489
                    'north.sevenkingdoms.local', 'Windows 10 / Server 2019 Build 17763', None,                      
                    False, True, None, None, None)]                                                                 
[09:42:54] INFO     SMB         192.168.57.11   445    WINTERFELL                                         smb.py:514
                    north.sevenkingdoms.local\arya.stark:********                                                   
           DEBUG    Calling command arguments                                                      connection.py:259
           INFO     Loading modules for target: 192.168.57.11                                      connection.py:602
           DEBUG    Supported protocols: ['smb']                                                  moduleloader.py:89
           DEBUG    Protocol: smb                                                                 moduleloader.py:90
           DEBUG    Calling modules                                                                connection.py:263
           DEBUG    Loading module gpp_privileges - <nxc_module_gpp_privileges.NXCModule object at connection.py:295
                    0x7f30f7befc50>                                                                                 
           DEBUG    Loading context for module gpp_privileges -                                    connection.py:305
                    <nxc_module_gpp_privileges.NXCModule object at 0x7f30f7befc50>                                  
           DEBUG    Module gpp_privileges has on_login method                                      connection.py:310
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Searching for          gpp_privileges.py:109
                    GptTmpl.inf files                                                                               
           INFO     Found GptTmpl.inf:                                                         gpp_privileges.py:120
                    north.sevenkingdoms.local/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}/                      
                    MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf                                                
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Found Default Domain   gpp_privileges.py:118
                    Policy GptTmpl.inf:                                                                             
                    north.sevenkingdoms.local/Policies/{6AC1786C-016F-11D2-945F-00C04fB984F9}/                      
                    MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf                                                
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Connected to LDAP.     gpp_privileges.py:198
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Privileges extracted   gpp_privileges.py:144
                    from                                                                                            
                    north.sevenkingdoms.local/Policies/{6AC1786C-016F-11D2-945F-00C04fB984F9}/                      
                    MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf:                                               
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeAssignPrimaryTokenPrivilege: NT Authority, NT Authority                                       
           WARNING  SID S-1-5-80-2246541699-21809830-3603976364-117610243-975697593 not found  gpp_privileges.py:220
                    in LDAP. Returning raw SID.                                                                     
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeAuditPrivilege:      gpp_privileges.py:147
                    S-1-5-80-2246541699-21809830-3603976364-117610243-975697593, NT Authority,                      
                    NT Authority                                                                                    
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeBackupPrivilege:     gpp_privileges.py:147
                    Administrators, Backup Operators, Server Operators                                              
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeBatchLogonRight:     gpp_privileges.py:147
                    Administrators, Backup Operators, BUILTIN\Performance Log Users                                 
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeChangeNotifyPrivilege: Everyone, NT Authority, NT Authority,                                  
                    Administrators, Authenticated Users, BUILTIN\Pre-Windows 2000 Compatible                        
                    Access                                                                                          
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeCreatePagefilePrivilege: Administrators                                                       
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeDebugPrivilege:      gpp_privileges.py:147
                    Administrators                                                                                  
           WARNING  SID S-1-5-90-0 not found in LDAP. Returning raw SID.                       gpp_privileges.py:220
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeIncreaseBasePriorityPrivilege: Administrators, S-1-5-90-0                                     
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeIncreaseQuotaPrivilege: NT Authority, NT Authority, Administrators                            
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeInteractiveLogonRight: Administrators, Backup Operators, Account                              
                    Operators, Server Operators, Print Operators, Enterprise Domain                                 
                    Controllers                                                                                     
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeLoadDriverPrivilege: gpp_privileges.py:147
                    Administrators, Print Operators                                                                 
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeMachineAccountPrivilege: Authenticated Users                                                  
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeNetworkLogonRight:   gpp_privileges.py:147
                    Everyone, Administrators, Authenticated Users, Enterprise Domain                                
                    Controllers, BUILTIN\Pre-Windows 2000 Compatible Access                                         
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeProfileSingleProcessPrivilege: Administrators                                                 
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeRemoteShutdownPrivilege: Administrators, Server Operators                                     
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeRestorePrivilege:    gpp_privileges.py:147
                    Administrators, Backup Operators, Server Operators                                              
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeSecurityPrivilege:   gpp_privileges.py:147
                    Administrators                                                                                  
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeShutdownPrivilege:   gpp_privileges.py:147
                    Administrators, Backup Operators, Server Operators, Print Operators                             
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeSystemEnvironmentPrivilege: Administrators                                                    
           WARNING  SID S-1-5-80-3139157870-2983391045-3678747466-658725712-1809340420 not     gpp_privileges.py:220
                    found in LDAP. Returning raw SID.                                                               
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeSystemProfilePrivilege: Administrators,                                                       
                    S-1-5-80-3139157870-2983391045-3678747466-658725712-1809340420                                  
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeSystemTimePrivilege: gpp_privileges.py:147
                    NT Authority, Administrators, Server Operators                                                  
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeTakeOwnershipPrivilege: Administrators                                                        
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeUndockPrivilege:     gpp_privileges.py:147
                    Administrators                                                                                  
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL                              gpp_privileges.py:147
                    SeEnableDelegationPrivilege: Administrators                                                     
           INFO     Found GptTmpl.inf:                                                         gpp_privileges.py:120
                    north.sevenkingdoms.local/Policies/{C4F0511D-A8F5-4560-B35C-002F3CA1F240}/                      
                    Machine/Microsoft/Windows NT/SecEdit/GptTmpl.inf                                                
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Connected to LDAP.     gpp_privileges.py:198
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       Privileges extracted   gpp_privileges.py:144
                    from                                                                                            
                    north.sevenkingdoms.local/Policies/{C4F0511D-A8F5-4560-B35C-002F3CA1F240}/                      
                    Machine/Microsoft/Windows NT/SecEdit/GptTmpl.inf:                                               
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeDebugPrivilege:      gpp_privileges.py:147
                    arya.stark                                                                                      
[09:42:54] INFO     GPP_PRIV... 192.168.57.11   445    WINTERFELL       SeBackupPrivilege:     gpp_privileges.py:147
                    arya.stark                                                                                      
           DEBUG    Closing connection to: 192.168.57.11     
```

<img width="958" height="821" alt="image" src="https://github.com/user-attachments/assets/eb4df3ce-225b-4e7b-80a1-752b340beda8" />



## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
