### PR TITLE
Sync uv lock with fortra

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10, <4.0"
 
 [options]
-exclude-newer = "2026-07-14T14:10:39.438350905Z"
+exclude-newer = "2026-08-01T20:37:47.701901443Z"
 exclude-newer-span = "P1D"
 
 [[package]]
@@ -856,8 +856,8 @@ wheels = [
 
 [[package]]
 name = "impacket"
-version = "0.14.0.dev0+20260317.95020.1049826e"
-source = { git = "https://github.com/Pennyw0rth/impacket#1049826efbc556221cca17f94e9fd0b944b8c600" }
+version = "0.14.0.dev0+20260731.125001.141be7ac"
+source = { git = "https://github.com/fortra/impacket#141be7ac577d5165adf2a70b677091ed3557eb36" }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "flask" },
@@ -1334,13 +1334,13 @@ requires-dist = [
     { name = "certipy-ad", git = "https://github.com/Pennyw0rth/Certipy" },
     { name = "dploot", specifier = ">=3.2.2" },
     { name = "dsinternals", specifier = ">=1.2.4" },
-    { name = "impacket", git = "https://github.com/Pennyw0rth/impacket" },
+    { name = "impacket", git = "https://github.com/fortra/impacket" },
     { name = "jwt", specifier = ">=1.3.1" },
     { name = "lsassy", specifier = ">=3.1.11" },
     { name = "masky", specifier = ">=0.2.1" },
     { name = "minikerberos", specifier = ">=0.4.1" },
     { name = "neo4j", specifier = ">=5.0.0" },
-    { name = "oscrypto", git = "https://github.com/wbond/oscrypto?rev=1547f535001ba568b239b8797465536759c742a3" },
+    { name = "oscrypto", git = "https://github.com/wbond/oscrypto" },
     { name = "paramiko", specifier = ">=3.3.1" },
     { name = "pefile", specifier = ">=2024.8.26,<2025.0.0" },
     { name = "pyasn1-modules", specifier = ">=0.3.0" },
@@ -1362,14 +1362,14 @@ requires-dist = [
 dev = [
     { name = "flake8" },
     { name = "pytest", specifier = ">=7.2.2,<8" },
-    { name = "ruff", specifier = "==0.11.0" },
+    { name = "ruff" },
     { name = "shiv" },
 ]
 
 [[package]]
 name = "oscrypto"
 version = "1.3.0"
-source = { git = "https://github.com/wbond/oscrypto?rev=1547f535001ba568b239b8797465536759c742a3#1547f535001ba568b239b8797465536759c742a3" }
+source = { git = "https://github.com/wbond/oscrypto#76bfdcb7285d856c44f8d0fbafe0ecca1c6d2f8b" }
 dependencies = [
     { name = "asn1crypto" },
 ]


### PR DESCRIPTION
## Description
uv.lock recorded impacket from Pennyw0rth/impacket @1049826e (2026-03-17) which is wrong, now it point to fortra

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

## Screenshots (if appropriate):
Screenshots are always nice to have and can give a visual representation of the change.
If appropriate, include before and after screenshot(s) to show which results are to be expected.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [ ] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
