### PR TITLE
Removing oscrypto lib direct dependency 

### DIFF
--- a/nxc/helpers/pfx.py
+++ b/nxc/helpers/pfx.py
@@ -35,15 +35,18 @@ import base64
 
 from binascii import unhexlify, hexlify
 
-from oscrypto.keys import parse_pkcs12, parse_certificate, parse_private
-from oscrypto.asymmetric import rsa_pkcs1v15_sign, load_private_key
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
 
 from asn1crypto import cms
 from asn1crypto import algos
 from asn1crypto import core
 from asn1crypto import keys
+from asn1crypto import pem
+from asn1crypto import x509
 
-from minikerberos.pkinit import PKINIT, DirtyDH
+from minikerberos.protocol.dirtydh import DirtyDH
 from minikerberos.protocol.constants import NAME_TYPE, PaDataType
 from minikerberos.protocol.encryption import Enctype, _enctype_table, Key
 from minikerberos.protocol.asn1_structs import KDC_REQ_BODY, PrincipalName, KDCOptions, EncASRepPart, AS_REQ, PADATA_TYPE, PA_PAC_REQUEST
@@ -71,11 +74,36 @@ from nxc.paths import NXC_PATH
 from nxc.logger import nxc_logger
 
 
-class myPKINIT(PKINIT):
+def _load_asn1_certificate(data):
+    """Load a certificate as an asn1crypto object, accepting both PEM and DER input"""
+    if pem.detect(data):
+        _, _, data = pem.unarmor(data)
+    return x509.Certificate.load(data)
+
+
+def _check_rsa_privkey(privkey):
+    """PKINIT signing here is RSA PKCS#1 v1.5 only, so reject anything else early"""
+    if not isinstance(privkey, rsa.RSAPrivateKey):
+        raise Exception(f"PKINIT requires an RSA private key, got {type(privkey).__name__}")
+    return privkey
+
+
+class myPKINIT:
     """
     Copy of minikerberos PKINIT
     With some changes where it differs from PKINIT used in NegoEx
     """
+
+    def __init__(self):
+        self.privkeyinfo = None
+        self.privkey = None
+        self.certificate = None
+        self.extra_certs = None
+        self.user_sid = None
+        self.user_name = None
+        self.issuer = None
+        self.cname = None
+        self.diffie = None
 
     @staticmethod
     def from_pfx(pfxfile, pfxpass, dh_params=None, b64=False):
@@ -90,26 +118,15 @@ class myPKINIT(PKINIT):
     @staticmethod
     def from_pfx_data(pfxdata, pfxpass, dh_params=None):
         pkinit = myPKINIT()
-        # oscrypto does not seem to support pfx without password, so convert it to PEM using cryptography instead
-        if not pfxpass:
-            from cryptography.hazmat.primitives.serialization import pkcs12
-            from cryptography.hazmat.primitives import serialization
-            privkey, cert, extra_certs = pkcs12.load_key_and_certificates(pfxdata, None)
-            pem_key = privkey.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=serialization.NoEncryption(),
-            )
-            pkinit.privkey = load_private_key(parse_private(pem_key))
-            pem_cert = cert.public_bytes(
-                encoding=serialization.Encoding.PEM
-            )
-            pkinit.certificate = parse_certificate(pem_cert)
-        else:
-            if isinstance(pfxpass, str):
-                pfxpass = pfxpass.encode()
-            pkinit.privkeyinfo, pkinit.certificate, pkinit.extra_certs = parse_pkcs12(pfxdata, password=pfxpass)
-            pkinit.privkey = load_private_key(pkinit.privkeyinfo)
+        if isinstance(pfxpass, str):
+            pfxpass = pfxpass.encode()
+        # cryptography requires None (not an empty password) for a pfx without password
+        privkey, cert, extra_certs = pkcs12.load_key_and_certificates(pfxdata, pfxpass if pfxpass else None)
+        if cert is None:
+            raise Exception("No certificate found in the PFX file")
+        pkinit.privkey = _check_rsa_privkey(privkey)
+        pkinit.certificate = x509.Certificate.load(cert.public_bytes(serialization.Encoding.DER))
+        pkinit.extra_certs = [x509.Certificate.load(extra.public_bytes(serialization.Encoding.DER)) for extra in extra_certs or []]
         pkinit.setup(dh_params=dh_params)
         return pkinit
 
@@ -117,9 +134,16 @@ class myPKINIT(PKINIT):
     def from_pem(certfile, privkeyfile, dh_params=None):
         pkinit = myPKINIT()
         with open(certfile, "rb") as f:
-            pkinit.certificate = parse_certificate(f.read())
+            pkinit.certificate = _load_asn1_certificate(f.read())
         with open(privkeyfile, "rb") as f:
-            pkinit.privkey = load_private_key(parse_private(f.read()))
+            keydata = f.read()
+        try:
+            privkey = serialization.load_pem_private_key(keydata, password=None)
+        except TypeError as e:
+            raise Exception(f"Private key {privkeyfile} is password protected, which is not supported. Decrypt it first with: openssl rsa -in {privkeyfile} -out decrypted.pem") from e
+        except ValueError:
+            privkey = serialization.load_der_private_key(keydata, password=None)
+        pkinit.privkey = _check_rsa_privkey(privkey)
         pkinit.setup(dh_params=dh_params)
         return pkinit
 
@@ -237,7 +261,7 @@ class myPKINIT(PKINIT):
             cms.CMSAttribute({"type": "message_digest", "values": [hashlib.sha1(data).digest()]}),  # hash of the data, the data itself will not be signed, but this block of data will be.
         ]
         si["signature_algorithm"] = algos.SignedDigestAlgorithm({"algorithm": "1.2.840.113549.1.1.1"})
-        si["signature"] = rsa_pkcs1v15_sign(self.privkey, cms.CMSAttributes(si["signed_attrs"]).dump(), "sha1")
+        si["signature"] = self.privkey.sign(cms.CMSAttributes(si["signed_attrs"]).dump(), padding.PKCS1v15(), hashes.SHA1())
 
         ec = {}
         ec["content_type"] = "1.3.6.1.5.2.3.1"

--- a/nxc/helpers/pfx.py
+++ b/nxc/helpers/pfx.py
@@ -38,12 +38,12 @@ from binascii import unhexlify, hexlify
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509 import load_pem_x509_certificate, load_der_x509_certificate
 
 from asn1crypto import cms
 from asn1crypto import algos
 from asn1crypto import core
 from asn1crypto import keys
-from asn1crypto import pem
 from asn1crypto import x509
 
 from minikerberos.protocol.dirtydh import DirtyDH
@@ -75,10 +75,18 @@ from nxc.logger import nxc_logger
 
 
 def _load_asn1_certificate(data):
-    """Load a certificate as an asn1crypto object, accepting both PEM and DER input"""
-    if pem.detect(data):
-        _, _, data = pem.unarmor(data)
-    return x509.Certificate.load(data)
+    """Load a certificate as an asn1crypto object, accepting both PEM and DER input
+
+    The certificate is parsed by cryptography and re-encoded, so that malformed input is
+    rejected here instead of failing later inside asn1crypto, which parses lazily
+    """
+    cert = load_pem_x509_certificate(data) if b"-----BEGIN" in data else load_der_x509_certificate(data)
+    return _to_asn1_certificate(cert)
+
+
+def _to_asn1_certificate(cert):
+    """Convert a cryptography certificate to the asn1crypto object the CMS structures need"""
+    return x509.Certificate.load(cert.public_bytes(serialization.Encoding.DER))
 
 
 def _check_rsa_privkey(privkey):
@@ -92,15 +100,14 @@ class myPKINIT:
     """
     Copy of minikerberos PKINIT
     With some changes where it differs from PKINIT used in NegoEx
+
+    This does not subclass minikerberos.pkinit.PKINIT on purpose: that module imports oscrypto,
+    which fails at import time on any OpenSSL whose version has a two digit component
     """
 
     def __init__(self):
-        self.privkeyinfo = None
         self.privkey = None
         self.certificate = None
-        self.extra_certs = None
-        self.user_sid = None
-        self.user_name = None
         self.issuer = None
         self.cname = None
         self.diffie = None
@@ -121,12 +128,14 @@ class myPKINIT:
         if isinstance(pfxpass, str):
             pfxpass = pfxpass.encode()
         # cryptography requires None (not an empty password) for a pfx without password
-        privkey, cert, extra_certs = pkcs12.load_key_and_certificates(pfxdata, pfxpass if pfxpass else None)
+        privkey, cert, _ = pkcs12.load_key_and_certificates(pfxdata, pfxpass if pfxpass else None)
+        # a pfx holding only a certificate parses fine, so check the key before the certificate
+        if privkey is None:
+            raise Exception("No private key found in the PFX file")
         if cert is None:
             raise Exception("No certificate found in the PFX file")
         pkinit.privkey = _check_rsa_privkey(privkey)
-        pkinit.certificate = x509.Certificate.load(cert.public_bytes(serialization.Encoding.DER))
-        pkinit.extra_certs = [x509.Certificate.load(extra.public_bytes(serialization.Encoding.DER)) for extra in extra_certs or []]
+        pkinit.certificate = _to_asn1_certificate(cert)
         pkinit.setup(dh_params=dh_params)
         return pkinit
 
@@ -138,11 +147,13 @@ class myPKINIT:
         with open(privkeyfile, "rb") as f:
             keydata = f.read()
         try:
-            privkey = serialization.load_pem_private_key(keydata, password=None)
+            try:
+                privkey = serialization.load_pem_private_key(keydata, password=None)
+            except ValueError:
+                privkey = serialization.load_der_private_key(keydata, password=None)
         except TypeError as e:
+            # raised by both loaders when the key is encrypted and no password was given
             raise Exception(f"Private key {privkeyfile} is password protected, which is not supported. Decrypt it first with: openssl rsa -in {privkeyfile} -out decrypted.pem") from e
-        except ValueError:
-            privkey = serialization.load_der_private_key(keydata, password=None)
         pkinit.privkey = _check_rsa_privkey(privkey)
         pkinit.setup(dh_params=dh_params)
         return pkinit

--- a/poetry.lock
+++ b/poetry.lock
@@ -1694,17 +1694,13 @@ description = "TLS (SSL) sockets, key generation, encryption, decryption, signin
 optional = false
 python-versions = "*"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "oscrypto-1.3.0-py2.py3-none-any.whl", hash = "sha256:2b2f1d2d42ec152ca90ccb5682f3e051fb55986e1b170ebde472b133713e7085"},
+    {file = "oscrypto-1.3.0.tar.gz", hash = "sha256:6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4"},
+]
 
 [package.dependencies]
 asn1crypto = ">=1.5.1"
-
-[package.source]
-type = "git"
-url = "https://github.com/wbond/oscrypto"
-reference = "HEAD"
-resolved_reference = "1547f535001ba568b239b8797465536759c742a3"
 
 [[package]]
 name = "packaging"
@@ -2990,4 +2986,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "06b6bb8d03df489bbccc835c0650c83407c4d5d7961e171df7a5144386d8ea56"
+content-hash = "c0aa9e4d6e98e01f9e0a43b122439ccc0f01709afcea3bf645ed830ee35c54a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "beautifulsoup4>=4.11,<5",
     "bloodhound-ce>=1.8.0",
     "certihound>=0.1.1",
+    "cryptography>=42.0.8",
     "dploot>=3.2.2",
     "dsinternals>=1.2.4",
     "jwt>=1.3.1",
@@ -47,7 +48,6 @@ dependencies = [
     # Git Dependencies
     "certipy-ad @ git+https://github.com/Pennyw0rth/Certipy",
     "impacket @ git+https://github.com/fortra/impacket",
-    "oscrypto @ git+https://github.com/wbond/oscrypto",
     "pynfsclient @ git+https://github.com/Pennyw0rth/NfsClient",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10, <4.0"
 
 [options]
-exclude-newer = "2026-08-01T20:37:47.701901443Z"
+exclude-newer = "2026-08-01T20:50:46.878646981Z"
 exclude-newer-span = "P1D"
 
 [[package]]
@@ -1289,6 +1289,7 @@ dependencies = [
     { name = "bloodhound-ce" },
     { name = "certihound" },
     { name = "certipy-ad" },
+    { name = "cryptography" },
     { name = "dploot" },
     { name = "dsinternals" },
     { name = "impacket" },
@@ -1297,7 +1298,6 @@ dependencies = [
     { name = "masky" },
     { name = "minikerberos" },
     { name = "neo4j" },
-    { name = "oscrypto" },
     { name = "paramiko" },
     { name = "pefile" },
     { name = "pyasn1-modules" },
@@ -1332,6 +1332,7 @@ requires-dist = [
     { name = "bloodhound-ce", specifier = ">=1.8.0" },
     { name = "certihound", specifier = ">=0.1.1" },
     { name = "certipy-ad", git = "https://github.com/Pennyw0rth/Certipy" },
+    { name = "cryptography", specifier = ">=42.0.8" },
     { name = "dploot", specifier = ">=3.2.2" },
     { name = "dsinternals", specifier = ">=1.2.4" },
     { name = "impacket", git = "https://github.com/fortra/impacket" },
@@ -1340,7 +1341,6 @@ requires-dist = [
     { name = "masky", specifier = ">=0.2.1" },
     { name = "minikerberos", specifier = ">=0.4.1" },
     { name = "neo4j", specifier = ">=5.0.0" },
-    { name = "oscrypto", git = "https://github.com/wbond/oscrypto" },
     { name = "paramiko", specifier = ">=3.3.1" },
     { name = "pefile", specifier = ">=2024.8.26,<2025.0.0" },
     { name = "pyasn1-modules", specifier = ">=0.3.0" },
@@ -1369,9 +1369,13 @@ dev = [
 [[package]]
 name = "oscrypto"
 version = "1.3.0"
-source = { git = "https://github.com/wbond/oscrypto#76bfdcb7285d856c44f8d0fbafe0ecca1c6d2f8b" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asn1crypto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/81/a7654e654a4b30eda06ef9ad8c1b45d1534bfd10b5c045d0c0f6b16fecd2/oscrypto-1.3.0.tar.gz", hash = "sha256:6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4", size = 184590, upload-time = "2022-03-18T01:53:26.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/7c/fa07d3da2b6253eb8474be16eab2eadf670460e364ccc895ca7ff388ee30/oscrypto-1.3.0-py2.py3-none-any.whl", hash = "sha256:2b2f1d2d42ec152ca90ccb5682f3e051fb55986e1b170ebde472b133713e7085", size = 194553, upload-time = "2022-03-18T01:53:24.559Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Removing the oscrypto lib that depend on a fork and use cryptography lib (thanks @azoxlpf for the idea)

Helped with claude max to avoid any regression

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Tested against GOAD lab

## Screenshots (if appropriate):
<img width="1879" height="809" alt="image" src="https://github.com/user-attachments/assets/742e827f-66dd-4a47-87cf-629fb2e5d34a" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
