### PR TITLE
Allow modules to abort the run by returning False from options()

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -14,7 +14,7 @@ from socket import AF_UNSPEC, SOCK_DGRAM, IPPROTO_IP, AI_CANONNAME, getaddrinfo
 
 from nxc.config import pwned_label
 from nxc.helpers.logger import highlight
-from nxc.loaders.moduleloader import ModuleLoader
+from nxc.loaders.moduleloader import ModuleLoader, ModuleOptionsError
 from nxc.logger import nxc_logger, NXCAdapter
 from nxc.context import Context
 from nxc.paths import NXC_PATH
@@ -604,5 +604,9 @@ class connection:
         self.modules = []
 
         for module_path in self.module_paths:
-            module = loader.init_module(module_path)
+            try:
+                module = loader.init_module(module_path)
+            except ModuleOptionsError as e:
+                self.logger.debug(f"Skipping module: {e}")
+                continue
             self.modules.append(module)

--- a/nxc/loaders/moduleloader.py
+++ b/nxc/loaders/moduleloader.py
@@ -100,7 +100,8 @@ class ModuleLoader:
                     key, value = option.split("=", 1)
                     module_options[str(key).upper()] = value
 
-                module.options(context, module_options)
+                if module.options(context, module_options) is False:
+                    return None
                 return module
             else:
                 self.logger.fail(f"Module {module.name.upper()} is not supported for protocol {self.args.protocol}")

--- a/nxc/loaders/moduleloader.py
+++ b/nxc/loaders/moduleloader.py
@@ -13,6 +13,10 @@ from nxc.logger import NXCAdapter
 from nxc.paths import NXC_PATH
 
 
+class ModuleOptionsError(Exception):
+    """Raised when a module aborts the run from options() (returned False)."""
+
+
 class ModuleLoader:
     def __init__(self, args, db, logger):
         self.args = args
@@ -101,7 +105,7 @@ class ModuleLoader:
                     module_options[str(key).upper()] = value
 
                 if module.options(context, module_options) is False:
-                    return None
+                    raise ModuleOptionsError(f"Module {module.name} aborted the run from options()")
                 return module
             else:
                 self.logger.fail(f"Module {module.name.upper()} is not supported for protocol {self.args.protocol}")

--- a/nxc/modules/example_module.py
+++ b/nxc/modules/example_module.py
@@ -22,6 +22,7 @@ class NXCModule:
         Module options get parsed here. Additionally, put the modules usage here as well
         """
         # Put "No options available" in the docstring if there are no options for the module
+        # Return False to abort the run if options are invalid (log with context.log.fail first).
 
     def on_login(self, context, connection):
         """Concurrent.

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -8,7 +8,7 @@ from nxc.parsers.nmap import parse_nmap_xml
 from nxc.parsers.nessus import parse_nessus_file
 from nxc.cli import gen_cli_args
 from nxc.loaders.protocolloader import ProtocolLoader
-from nxc.loaders.moduleloader import ModuleLoader
+from nxc.loaders.moduleloader import ModuleLoader, ModuleOptionsError
 from nxc.first_run import first_run_setup
 from nxc.paths import NXC_PATH, WORKSPACE_DIR
 from nxc.console import nxc_console
@@ -207,8 +207,10 @@ def main():
                 exit(1)
 
             nxc_logger.debug(f"Loading module for sanity check {m} at path {modules[m]['path']}")
-            module = loader.init_module(modules[m]["path"])
-            if module is None:
+            try:
+                loader.init_module(modules[m]["path"])
+            except ModuleOptionsError as e:
+                nxc_logger.debug(f"Aborting run: {e}")
                 exit(1)
 
             # Add modules paths to the protocol object so it can load them itself

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -208,6 +208,8 @@ def main():
 
             nxc_logger.debug(f"Loading module for sanity check {m} at path {modules[m]['path']}")
             module = loader.init_module(modules[m]["path"])
+            if module is None:
+                exit(1)
 
             # Add modules paths to the protocol object so it can load them itself
             proto_module_paths.append(modules[m]["path"])


### PR DESCRIPTION
## Description

Modules currently have no clean way to reject invalid options and fall back to `sys.exit()`, which kills the entire multi-host scan. This adds an opt-in contract: `options()` may `return False` to abort the run, the loader turns that into a `None` module and the sanity pass exits with a single error message.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

You can use this module: 

```python
from nxc.helpers.misc import CATEGORY


class NXCModule:
    name = "test_contract"
    description = "throwaway module to prove the options() return False contract"
    supported_protocols = ["smb"]
    category = CATEGORY.ENUMERATION

    def options(self, context, module_options):
        if "FOO" not in module_options:
            context.log.fail("FOO is required!")
            return False

    def on_login(self, context, connection):
        context.log.success("on_login reached: options were valid")

```

## Screenshots (if appropriate):

Before & After : 

<img width="1906" height="900" alt="image" src="https://github.com/user-attachments/assets/056518a2-87b7-40b3-9090-f9480d79ac74" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [X] I have performed a self-review of my own code (_not_ an AI review)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
