### PR TITLE
Fixing KDC_ERR_S_UNKNOWN_PRINCIPAL in case of NTLM restriction for WS2025

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -144,6 +144,7 @@ class smb(connection):
         self.no_da = None
         self.no_ntlm = False
         self.null_auth = False
+        self.ntlm_probe_failed = False
         self.protocol = "SMB"
         self.is_guest = None
         self.isdc = None
@@ -193,6 +194,9 @@ class smb(connection):
             self.null_auth = True
         except BrokenPipeError:
             self.logger.fail("Broken Pipe Error while attempting to login")
+        except (NetBIOSTimeout, NetBIOSError, OSError) as e:
+            self.logger.debug(f"Null Auth Probe failed : {e!s}")
+            self.ntlm_probe_failed = True
         except Exception as e:
             self.null_auth = False
             if "STATUS_NOT_SUPPORTED" in str(e):
@@ -200,7 +204,7 @@ class smb(connection):
                 self.no_ntlm = True
                 self.logger.debug("NTLM not supported")
 
-        aggressive_check = bool(self.args.generate_hosts_file or self.args.generate_krb5_file)
+        aggressive_check = bool(self.args.generate_hosts_file or self.args.generate_krb5_file or self.kerberos)
         self.is_host_dc(aggressive_check=aggressive_check)
 
         # self.domain is the attribute we authenticate with
@@ -896,10 +900,11 @@ class smb(connection):
         bind then), so we hand that case off to the Kerberos/RPC tiers.
         """
         if not self.null_auth:
-            if not self.no_ntlm:
+            if not self.no_ntlm and not self.ntlm_probe_failed:
                 self.logger.debug("NTLM enabled but no null session: host is not a DC")
                 return False
             self.logger.debug("No null session (NTLM disabled): deferring to Kerberos/RPC")
+            self.no_ntlm = True
             return None
         try:
             tid = self.conn.connectTree("SYSVOL")

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -904,7 +904,8 @@ class smb(connection):
                 self.logger.debug("NTLM enabled but no null session: host is not a DC")
                 return False
             self.logger.debug("No null session (NTLM disabled): deferring to Kerberos/RPC")
-            self.no_ntlm = True
+            if self.ntlm_probe_failed:
+                self.no_ntlm = True
             return None
         try:
             tid = self.conn.connectTree("SYSVOL")


### PR DESCRIPTION
## Description
This PR resolves issue #1312 by adding support for the rate-limiting introduced by WS2025 to the `enum_host_info` and `_is_dc_via_smb` functions.

During the null auth at the start of the `enum_host_info` function, the `NetBIOSTimeout` exception is not handled correctly. Whilst the `null_auth` variable is correctly set to `False`, this is not the case for `no_ntlm`, which distorts the detection later in the function.

The `ntlm_probe_failed` variable effectively detects whether rate limiting is in place; it also reroutes the `_is_dc_via_smb` function and sets `no_ntlm` to `true`.

Finally, the aggressive check conditions for DC detection have been extended to include the use of the Kerberos flag (-k), which, in the case of rate-limiting and the NTLM protocol being disabled, still ensures accurate detection. 

The quality of the PR is somewhat questionable in my opinion, but after testing, it seems to work quite well and does not introduce any regressions.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Server : Windows Server 2025
Additional : `reg add "HKLM\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0" /v RestrictReceivingNTLMTraffic /t REG_DWORD /d 2 /f` to disable NTLM traffic

## Screenshots (if appropriate):
<img width="1887" height="445" alt="image" src="https://github.com/user-attachments/assets/9e62a36d-7ee3-490e-a2a7-98a7ceb41370" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
