### PR TITLE
Only mark RDP hosts Pwn3d when a real session actually opens

### DIFF
--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -13,7 +13,7 @@ from nxc.logger import NXCAdapter
 from nxc.config import host_info_colors, process_secret
 from nxc.paths import NXC_PATH
 
-from aardwolf.connection import RDPConnection
+from aardwolf.connection import RDPConnection, AUTHZ_ACCESS_DENIED
 from aardwolf.commons.queuedata.constants import VIDEO_FORMAT
 from aardwolf.commons.queuedata.keyboard import RDP_KEYBOARD_UNICODE
 from aardwolf.commons.iosettings import RDPIOSettings
@@ -168,6 +168,9 @@ class rdp(connection):
             timeout=self.args.rdp_timeout,
         )
 
+        # Reset so aardwolf negotiates on its own (restricted admin + HYBRID_EX), the loop above pinned it
+        self.iosettings.supported_protocols = None
+
         return True
 
     async def check_nla(self):
@@ -202,6 +205,7 @@ class rdp(connection):
         _, err = await asyncio.wait_for(self.conn.connect(), timeout=self.args.rdp_timeout)
         if err is not None:
             raise err
+        self.logger.debug(f"RDP negotiated protocol: {self.conn.x224_protocol}, authz_result: {self.conn.authz_result}")
 
     async def terminate_conn(self):
         """Terminate the RDP connection with a timeout so cleanup doesn't hang."""
@@ -215,6 +219,30 @@ class rdp(connection):
             await self.connect_rdp()
         finally:
             await self.terminate_conn()
+
+    async def login_and_confirm(self):
+        """Connect and return whether a real session opened (Save Session Info PDU), always cleaning up.
+
+        That PDU never comes when access is authorized but the logon is refused (restricted admin).
+        """
+        try:
+            await self.connect_rdp()
+            try:
+                await asyncio.wait_for(self.conn.logon_info_received.wait(), timeout=self.args.rdp_timeout)
+                return True
+            except asyncio.TimeoutError:
+                self.logger.debug("No Save Session Info PDU: RDP access is granted but the interactive logon was refused (restricted admin)")
+                return False
+        finally:
+            await self.terminate_conn()
+
+    def rdp_access_denied(self):
+        """Whether the Early User Authorization Result PDU says the account has no RDP access right at all.
+
+        Distinct from a valid right whose logon is later refused (restricted admin), which yields no such PDU.
+        """
+        self.logger.debug(f"authz_result from Early User Authorization Result PDU: {self.conn.authz_result}")
+        return self.conn.authz_result == AUTHZ_ACCESS_DENIED
 
     def kerberos_login(self, domain, username, password="", ntlm_hash="", aesKey="", kdcHost="", useCache=False):
         try:
@@ -269,9 +297,8 @@ class rdp(connection):
                 stype=stype,
             )
             self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
-            asyncio.run(self.connect_rdp_with_cleanup())
+            self.admin_privs = asyncio.run(self.login_and_confirm())
 
-            self.admin_privs = True
             self.logger.success(
                 "{}\\{}{} {}".format(
                     domain,
@@ -299,8 +326,11 @@ class rdp(connection):
                     (f"{domain}\\{username}{' from ccache' if useCache else f':{process_secret(kerb_pass)}'} ({reason if reason else str(e)})"),
                     color=("magenta" if ((reason or "CredSSP" in str(e)) and reason != "KDC_ERR_C_PRINCIPAL_UNKNOWN") else "red"),
                 )
-            elif "Authentication failed!" in str(e):
-                self.logger.success(f"{domain}\\{username}:{(process_secret(password))} {self.mark_pwned()}")
+            elif self.rdp_access_denied():
+                self.logger.success(f"{domain}\\{username}{' from ccache' if useCache else f':{process_secret(kerb_pass)}'}")
+                if not self.args.local_auth and self.username != "":
+                    add_user_bh(username, domain, self.logger, self.config)
+                return True
             elif "No such file" in str(e):
                 self.logger.fail(e)
             else:
@@ -325,9 +355,8 @@ class rdp(connection):
                 stype=asyauthSecret.PASS,
             )
             self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
-            asyncio.run(self.connect_rdp_with_cleanup())
+            self.admin_privs = asyncio.run(self.login_and_confirm())
 
-            self.admin_privs = True
             self.logger.success(f"{domain}\\{username}:{process_secret(password)} {self.mark_pwned()}")
             if not self.args.local_auth and self.username != "":
                 add_user_bh(username, domain, self.logger, self.config)
@@ -335,8 +364,11 @@ class rdp(connection):
                 add_user_bh(f"{self.hostname}$", domain, self.logger, self.config)
             return True
         except Exception as e:
-            if "Authentication failed!" in str(e):
-                self.logger.success(f"{domain}\\{username}:{process_secret(password)} {self.mark_pwned()}")
+            if self.rdp_access_denied():
+                self.logger.success(f"{domain}\\{username}:{process_secret(password)}")
+                if not self.args.local_auth and self.username != "":
+                    add_user_bh(username, domain, self.logger, self.config)
+                return True
             else:
                 reason = None
                 for word in self.rdp_error_status:
@@ -359,9 +391,8 @@ class rdp(connection):
                 stype=asyauthSecret.NT,
             )
             self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
-            asyncio.run(self.connect_rdp_with_cleanup())
+            self.admin_privs = asyncio.run(self.login_and_confirm())
 
-            self.admin_privs = True
             self.logger.success(f"{self.domain}\\{username}:{process_secret(ntlm_hash)} {self.mark_pwned()}")
             if not self.args.local_auth and self.username != "":
                 add_user_bh(username, domain, self.logger, self.config)
@@ -369,8 +400,11 @@ class rdp(connection):
                 add_user_bh(f"{self.hostname}$", domain, self.logger, self.config)
             return True
         except Exception as e:
-            if "Authentication failed!" in str(e):
-                self.logger.success(f"{domain}\\{username}:{process_secret(ntlm_hash)} {self.mark_pwned()}")
+            if self.rdp_access_denied():
+                self.logger.success(f"{self.domain}\\{username}:{process_secret(ntlm_hash)}")
+                if not self.args.local_auth and self.username != "":
+                    add_user_bh(username, domain, self.logger, self.config)
+                return True
             else:
                 reason = None
                 for word in self.rdp_error_status:


### PR DESCRIPTION
## Description

RDP hosts were marked `Pwn3d!` on any successful auth, even with no real session. This produced false positives for accounts with no RDP access right, and for `pass-the-hash` logons when restricted admin is disabled (auth succeeds but the interactive logon is refused).

`Pwn3d!` now relies on what the server reports,  no marker when RDP access is denied or when no Save Session Info PDU confirms the logon, and `Pwn3d!` only once a real session is confirmed.

Must be merged first: https://github.com/skelsec/aardwolf/pull/49


## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Disable restricted admin if it isn't already (disabled by default) : 

```
Set-ItemProperty 'HKLM:\System\CurrentControlSet\Control\Lsa' -Name DisableRestrictedAdmin -Value 1
```

Try logging in as an admin using your password and via pth 

## Screenshots (if appropriate):

Before : 

<img width="1917" height="394" alt="image" src="https://github.com/user-attachments/assets/c958f14b-7271-4e3c-b981-861a7c44dbb6" />

After : 

<img width="1908" height="369" alt="image" src="https://github.com/user-attachments/assets/8cb40c9e-5085-4cd6-8619-2a5ed2bd7ba4" />


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [X] I have performed a self-review of my own code (_not_ an AI review)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
