### PR TITLE
Fix check isdc is not ntlm 

### DIFF
--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -955,12 +955,6 @@ class smb(connection):
         """
         Unauthenticated Netlogon endpoint-mapper lookup on 135. NTLM-agnostic
         and needs no session;
-        Only a positive result (Netlogon registered -> True) or a definitive
-        negative from the endpoint mapper (it answered but Netlogon is absent, so
-        a live RPC host that is not a DC -> False) are conclusive. Anything that
-        just means "couldn't reach/finish the lookup" (135 filtered, timeout,
-        transport error) returns None so the Kerberos tier still gets a turn -
-        a DC can be reachable on 88 even when 135 is not.
         """
         from impacket.dcerpc.v5 import nrpc, epm
 

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -870,17 +870,24 @@ class smb(connection):
         if self.isdc is not None:
             return self.isdc
 
+        # Tier 1 (SMB) always runs. Tier 2 (Kerberos) is added whenever the SMB
+        # tier cannot decide on its own (NTLM disabled), so the default path can
+        # still identify a DC without the flags. Tier 3 (RPC) is noisier (port
+        # 135) and stays behind the aggressive flags. Kerberos must precede RPC:
+        # RPC never returns None, so ordering it first would shadow Kerberos.
         probes = [self._is_dc_via_smb]
+        if self.no_ntlm or aggressive_check:
+            probes.append(self._is_dc_via_kerberos)
         if aggressive_check:
-            probes += [self._is_dc_via_rpc, self._is_dc_via_kerberos]
+            probes.append(self._is_dc_via_rpc)
 
         for probe in probes:
             result = probe()
             if result is not None:
                 self.isdc = result
                 return self.isdc
-        # inconclusive if all probes return None
-        if aggressive_check:
+
+        if self.no_ntlm or aggressive_check:
             self.isdc = False
         return self.isdc
 
@@ -893,13 +900,13 @@ class smb(connection):
         session, the reason is decisive: a DC with NTLM enabled always accepts
         the null bind, so "NTLM on + no null session" means this is NOT a DC.
         Only "NTLM disabled" is inconclusive here (a real DC can refuse the null
-        bind then), so we hand that case off to the Kerberos/RPC tiers.
+        bind then), so we hand that case off to the Kerberos tier.
         """
         if not self.null_auth:
             if not self.no_ntlm:
                 self.logger.debug("NTLM enabled but no null session: host is not a DC")
                 return False
-            self.logger.debug("No null session (NTLM disabled): deferring to Kerberos/RPC")
+            self.logger.debug("No null session (NTLM disabled): deferring to Kerberos")
             return None
         try:
             tid = self.conn.connectTree("SYSVOL")
@@ -930,6 +937,9 @@ class smb(connection):
         one (a PRINCIPAL_UNKNOWN reply is marginally quieter) and otherwise a
         placeholder - we never need to actually know the domain.
         """
+        if not self._is_port_open(88):
+            self.logger.debug("Port 88 closed/filtered: no KDC reachable, deferring")
+            return None
         # targetDomain is not set yet when this runs on the no-NTLM path (it is
         # produced later by the isdc-dependent LDAP resolution), so read it
         # defensively and fall back to a placeholder - the realm need not be real.

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -922,7 +922,10 @@ class smb(connection):
             return None
 
     def _is_dc_via_kerberos(self):
-        """
+        """Tier 2: only a KDC answers a Kerberos AS-REQ, and in AD the KDC runs
+        only on DCs. Pre-auth, no credentials - the fallback for NTLM-disabled
+        hosts where no SMB session exists.
+
         The realm need not be correct: a live KDC answers a wrong realm with
         KDC_ERR_WRONG_REALM, which proves it is a KDC just as well as
         PRINCIPAL_UNKNOWN would. So we use the known domain if we happen to have

--- a/nxc/protocols/smb.py
+++ b/nxc/protocols/smb.py
@@ -870,16 +870,11 @@ class smb(connection):
         if self.isdc is not None:
             return self.isdc
 
-        # Tier 1 (SMB) always runs. Tier 2 (Kerberos) is added whenever the SMB
-        # tier cannot decide on its own (NTLM disabled), so the default path can
-        # still identify a DC without the flags. Tier 3 (RPC) is noisier (port
-        # 135) and stays behind the aggressive flags. Kerberos must precede RPC:
-        # RPC never returns None, so ordering it first would shadow Kerberos.
         probes = [self._is_dc_via_smb]
-        if self.no_ntlm or aggressive_check:
-            probes.append(self._is_dc_via_kerberos)
         if aggressive_check:
             probes.append(self._is_dc_via_rpc)
+        if self.no_ntlm or aggressive_check:
+            probes.append(self._is_dc_via_kerberos)
 
         for probe in probes:
             result = probe()
@@ -927,10 +922,7 @@ class smb(connection):
             return None
 
     def _is_dc_via_kerberos(self):
-        """Tier 2: only a KDC answers a Kerberos AS-REQ, and in AD the KDC runs
-        only on DCs. Pre-auth, no credentials - the fallback for NTLM-disabled
-        hosts where no SMB session exists.
-
+        """
         The realm need not be correct: a live KDC answers a wrong realm with
         KDC_ERR_WRONG_REALM, which proves it is a KDC just as well as
         PRINCIPAL_UNKNOWN would. So we use the known domain if we happen to have
@@ -960,27 +952,36 @@ class smb(connection):
         return True
 
     def _is_dc_via_rpc(self):
-        """Tier 3: unauthenticated Netlogon endpoint lookup on 135. NTLM-agnostic
-        and needs no session, but heavier and noisier than the SMB/Kerberos
-        probes above, so it only runs when both of those were inconclusive.
+        """
+        Unauthenticated Netlogon endpoint-mapper lookup on 135. NTLM-agnostic
+        and needs no session;
+        Only a positive result (Netlogon registered -> True) or a definitive
+        negative from the endpoint mapper (it answered but Netlogon is absent, so
+        a live RPC host that is not a DC -> False) are conclusive. Anything that
+        just means "couldn't reach/finish the lookup" (135 filtered, timeout,
+        transport error) returns None so the Kerberos tier still gets a turn -
+        a DC can be reachable on 88 even when 135 is not.
         """
         from impacket.dcerpc.v5 import nrpc, epm
 
         if not self._is_port_open(135):
-            self.logger.debug("Port 135 closed and no higher-tier signal: treating as not a DC")
-            return False
+            self.logger.debug("Port 135 closed/filtered: RPC inconclusive, deferring to Kerberos")
+            return None
 
         self.logger.debug("Port 135 is open, attempting Netlogon MSRPC lookup...")
         try:
             epm.hept_map(self.host, nrpc.MSRPC_UUID_NRPC, protocol="ncacn_ip_tcp")
+            self.logger.debug("Netlogon endpoint registered: host is a DC")
             return True
         except DCERPCException:
-            self.logger.debug("DCERPCException on Netlogon lookup: probably not a DC")
+            self.logger.debug("Endpoint mapper answered but Netlogon not registered: host is not a DC")
+            return False
         except TimeoutError:
-            self.logger.debug("Timeout on Netlogon lookup: likely not a DC or unreachable")
+            self.logger.debug("Timeout on Netlogon lookup: inconclusive, deferring to Kerberos")
+            return None
         except Exception as e:
-            self.logger.debug(f"Error on Netlogon lookup: {e}")
-        return False
+            self.logger.debug(f"Error on Netlogon lookup ({e}): inconclusive, deferring to Kerberos")
+            return None
 
     def _is_port_open(self, port, timeout=1):
         """Check if a specific port is open on the target host."""


### PR DESCRIPTION
## Description
Fix DC detection for NTLM-disabled hosts (RPC probe swallowed the Kerberos fallback) thanks to @XedSama report

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
run goad lab with ntlm disabled

## Screenshots (if appropriate):


## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [x] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
