### PR TITLE
Update rdp.py to add additional error for failed user authentication 

### DIFF
--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -448,7 +448,12 @@ class rdp(connection):
             self.conn = RDPConnection(iosettings=self.iosettings, target=self.target, credentials=self.auth)
             await self.connect_rdp()
         except Exception as e:
-            self.logger.debug(f"Error connecting to RDP: {e!s}")
+            err_msg = str(e)
+            if "Authentication failed! (early user auth)" in err_msg:
+                  self.logger.error("Authentication failed! (early user auth)")
+                  self.logger.error("Verify RDP user privileges, NLA settings, or credential format.")
+            else:
+                  self.logger.debug(f"Error connecting to RDP: {err_msg}")
             return None
 
         try:

--- a/nxc/protocols/rdp.py
+++ b/nxc/protocols/rdp.py
@@ -450,10 +450,10 @@ class rdp(connection):
         except Exception as e:
             err_msg = str(e)
             if "Authentication failed! (early user auth)" in err_msg:
-                  self.logger.error("Authentication failed! (early user auth)")
-                  self.logger.error("Verify RDP user privileges, NLA settings, or credential format.")
+                self.logger.error("Authentication failed! (early user auth)")
+                self.logger.error("Verify RDP user privileges, NLA settings, or credential format.")
             else:
-                  self.logger.debug(f"Error connecting to RDP: {err_msg}")
+                self.logger.debug(f"Error connecting to RDP: {err_msg}")
             return None
 
         try:


### PR DESCRIPTION
## Description
Added a visible error outside of debugging for RDP to help identify authentication errors. RDP will authenticate to the host/domain to see if the user creds are valid, but the RDP session auth could still fail for multiple reasons such as NLA issues, RDP privs for the attempted user, etc. This default visible error just makes it more obvious. I can also see the argument that this is what --debug is for and 100% okay if this gets rejected for that reason :)

Currently there is no followup error for auth issues and appears okay. 
<img width="630" height="57" alt="image" src="https://github.com/user-attachments/assets/6d7aca2b-7f73-4547-b869-72264ce14ae2" />

After this change an error appears after the successful domain/host authentication.
<img width="711" height="121" alt="image" src="https://github.com/user-attachments/assets/817d858d-1d92-43a2-9a5a-7ede1b17180a" />


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
1. Create a new user on a Windows host that does not have RDP privs to the host. 
2. Use NetExec with the RDP protocol against that windows host with the user creds.


## Checklist:
- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
