### PR TITLE
added --ntp-server to kerberos options for time sync

### DIFF
--- a/nxc/cli.py
+++ b/nxc/cli.py
@@ -100,6 +100,7 @@ def gen_cli_args():
     kerberos_group.add_argument("--use-kcache", action="store_true", help="Use Kerberos authentication from ccache file (KRB5CCNAME)")
     kerberos_group.add_argument("--aesKey", metavar="AESKEY", nargs="+", help="AES key to use for Kerberos Authentication (128 or 256 bits)")
     kerberos_group.add_argument("--kdcHost", metavar="KDCHOST", help="FQDN of the domain controller. If omitted it will use the domain part (FQDN) specified in the target parameter")
+    kerberos_group.add_argument("--ntp-server", type=str, help="NTP server to sync the internal clock to")
 
     certificate_group = std_parser.add_argument_group("Certificate Authentication")
     certificate_group.add_argument("--pfx-cert", metavar="PFXCERT", help="Use certificate authentication from pfx file .pfx")

--- a/nxc/helpers/sync_time.py
+++ b/nxc/helpers/sync_time.py
@@ -1,0 +1,55 @@
+from socket import socket, AF_INET, SOCK_DGRAM
+from struct import unpack
+from datetime import datetime, timezone
+from freezegun import freeze_time
+
+from nxc.logger import nxc_logger
+
+
+def sync_and_spoof(ntp_server: str):
+    """
+    Tries to fetch the time from ntp_server and uses
+    freezegun to set this time as the internal clock
+    application wide.
+
+    Just patching impacket.krb5.kerberosv5.sendReceive would be
+    cleaner, however, as we would need to freeze each previous and
+    future import, each import would have its own ticking clock.
+    """
+    try:
+        nxc_logger.debug(f"Trying to fetch time from {ntp_server}")
+        timestamp = get_time_from_ntp_server(server=ntp_server)
+    except Exception as e:
+        nxc_logger.error(f"Got error while fetchting time: {e}")
+        nxc_logger.warning("Could not fetch time, skipping time spoofing")
+        return
+
+    nxc_logger.debug(f"Got time {timestamp} from NTP server, setting fake internal clock")
+    try:
+        freezer = freeze_time(timestamp, tick=True)
+        freezer.start()
+    except Exception as e:
+        nxc_logger.error(f"Got error while setting internal clock using freeze_time: {e}")
+        return
+
+
+def get_time_from_ntp_server(server: str, port=123) -> str:
+    """
+    Fetches the time from server using just socket
+
+    Based on:
+    https://www.mattcrampton.com/blog/query_an_ntp_server_from_python/
+    """
+    buf = 1024
+    address = (server, port)
+    msg = "\x1b" + 47 * "\0"
+
+    TIME1970 = 2208988800  # 1970-01-01 00:00:00
+
+    client = socket(AF_INET, SOCK_DGRAM)
+    client.sendto(msg.encode("utf-8"), address)
+    msg, address = client.recvfrom(buf)
+    t = unpack("!12I", msg)[10]
+    t -= TIME1970
+
+    return datetime.fromtimestamp(t, tz=timezone.utc).isoformat()

--- a/nxc/netexec.py
+++ b/nxc/netexec.py
@@ -3,6 +3,7 @@ import contextlib
 import sys
 from nxc.helpers.logger import highlight
 from nxc.helpers.misc import identify_target_file, display_modules
+from nxc.helpers.sync_time import sync_and_spoof
 from nxc.parsers.ip import parse_targets
 from nxc.parsers.nmap import parse_nmap_xml
 from nxc.parsers.nessus import parse_nessus_file
@@ -220,6 +221,10 @@ def main():
 
     if args.jitter and len(targets) > 1:
         nxc_logger.highlight(highlight("[!] Jitter is only throttling authentications per target!", "red"))
+
+    if args.ntp_server:
+        nxc_logger.info(f"Will attempt to sync and spoof time from {args.ntp_server}")
+        sync_and_spoof(args.ntp_server)
 
     try:
         asyncio.run(start_run(protocol_object, args, db, targets))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "certipy-ad @ git+https://github.com/Pennyw0rth/Certipy",
     "impacket @ git+https://github.com/fortra/impacket",
     "pynfsclient @ git+https://github.com/Pennyw0rth/NfsClient",
+    "freezegun>=1.5.5",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -739,6 +739,18 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1292,6 +1304,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "dploot" },
     { name = "dsinternals" },
+    { name = "freezegun" },
     { name = "impacket" },
     { name = "jwt" },
     { name = "lsassy" },
@@ -1335,6 +1348,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0.8" },
     { name = "dploot", specifier = ">=3.2.2" },
     { name = "dsinternals", specifier = ">=1.2.4" },
+    { name = "freezegun", specifier = ">=1.5.5" },
     { name = "impacket", git = "https://github.com/fortra/impacket" },
     { name = "jwt", specifier = ">=1.3.1" },
     { name = "lsassy", specifier = ">=3.1.11" },


### PR DESCRIPTION
## Description
Added the `--ntp-server` CLI argument to the Kerberos options. 

If a NTP server is specified, a single NTP request is made to the server to fetch its current time. This time is then applied Python-wide using [freezegun](https://github.com/spulec/freezegun). Freezegun "spoofs" the internal clock of the Python VM to be in sync with the NTP server. This is relevant for specific Kerberos exchanges like kerberoasting. 

Currently, if the NetExec host's time is out of sync with the Domain Controller, you get 
```
KerberosError: Kerberos SessionError: KRB_AP_ERR_SKEW(Clock skew too great)
```

Using the new `--ntp-server`, this does not happen anymore.

It is intended as a QoL feature. This was possible in the past by either quickly syncing the time of your host to the DC, or spoofing the time with a tool like `faketime`. It is superior to both as:
- Syncing the time to the DC requires that you then re-sync to a public NTP afterward. Also if you NetExec host is a VM, this requires disabling VM-software specific features, as for example, VirtualBox "hardcodes" the time.
- `faketime` is not available on Windows.

It requires the new 3rd-party library [freezegun](https://github.com/spulec/freezegun). The code was added without AI. A specific snippet was copied from the internet with the original source linked as a comment.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

To test this feature, try to kerberoast against a DC which has as clock set to a future time. (To set the clock manually, use `timedate.cpl`)

## Screenshots (if appropriate):
<img width="776" height="567" alt="2026-08-13_09-48" src="https://github.com/user-attachments/assets/cbab2bbd-c057-45a4-8fa2-eb338f17dc61" />

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
