### PR TITLE
fix: use target domain for bloodhound collection

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1692,7 +1692,7 @@ class ldap(connection):
             )
             ad = AD(
                 auth=auth,
-                domain=self.domain,
+                domain=self.targetDomain,
                 nameserver=self.args.dns_server,
                 dns_tcp=self.args.dns_tcp,
                 dns_timeout=self.args.dns_timeout,
@@ -1700,7 +1700,7 @@ class ldap(connection):
 
             self.logger.debug("Using DNS to retrieve domain information")
             try:
-                ad.dns_resolve(domain=self.domain)
+                ad.dns_resolve(domain=self.targetDomain)
             except (resolver.LifetimeTimeout, resolver.NoNameservers):
                 self.logger.fail("Bloodhound-python failed to resolve domain information, try specifying the DNS server.")
                 return
@@ -1763,13 +1763,13 @@ class ldap(connection):
             # Create CertiHound adapter and collector
             adapter = ImpacketLDAPAdapter(
                 search_func=self.search,
-                domain=self.domain,
+                domain=self.targetDomain,
                 domain_sid=self.sid_domain,
             )
 
             collector = ADCSCollector.from_external(
                 ldap_connection=adapter,
-                domain=self.domain,
+                domain=self.targetDomain,
                 domain_sid=self.sid_domain,
             )
             data = collector.collect_all()


### PR DESCRIPTION
## Description
Fixes #1364 

When using `--bloodhound` against a domain while authenticating with credentials from a trusted domain, NetExec was using the authentication domain as the BloodHound enumeration domain.

This change makes the BloodHound collection use the target domain detected from the LDAP target while keeping the supplied domain for authentication.

AI disclosure: ChatGPT (GPT-5.5) was used to help with the wording of the issue/PR description. The code change itself was not generated by AI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Test environment:

- OS: NixOS
- Python: 3.14.6
- NetExec: 1.5.1 - Yippie-Ki-Yay - af9bb875 - 644
- `DOMAIN2.local` has an inbound trust from `DOMAIN1.local`, allowing users from `DOMAIN1.local` to authenticate against and query `DOMAIN2.local`.
- `USER` belongs to `DOMAIN1.local`
- LDAP target is `DOMAIN2.local`

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)

## Trace with the correction applied

```bash
$ nxc --debug ldap 'dc01.DOMAIN2.local' --dns-server 10.42.0.5 --dns-tcp -u 'USER' -p 'PASSWORD' -d 'DOMAIN1.local' --bloodhound
[13:34:54] DEBUG    NXC VERSION: 1.5.1 - Yippie-Ki-Yay - af9bb875 - 644                                                                                        netexec.py:96
           DEBUG    PYTHON VERSION: 3.14.6 (main, Jun 10 2026, 10:03:53) [GCC 15.3.0]                                                                          netexec.py:97
           DEBUG    RUNNING ON: Linux Release: 6.18.44                                                                                                         netexec.py:98
           DEBUG    Passed args: Namespace(version=False, threads=256, timeout=None, jitter=None, no_progress=False, log=None, verbose=False, debug=False,     netexec.py:99
                    force_ipv6=False, dns_server='10.42.0.5', dns_tcp=True, dns_timeout=3, protocol='ldap', target=['dc01.DOMAIN2.local'],
                    username=['USER'], password=['PASSWORD'], cred_id=[], ignore_pw_decoding=False, no_bruteforce=False, continue_on_success=False,
                    gfail_limit=None, ufail_limit=None, fail_limit=None, kerberos=False, use_kcache=False, aesKey=None, kdcHost=None, pfx_cert=None,
                    pfx_base64=None, pfx_pass=None, pem_cert=None, pem_key=None, module=None, module_options=[], list_modules=None, show_module_options=False,
                    hash=[], simple_bind=False, port=389, ldap_timeout=3, domain='DOMAIN1.local', asreproast=None, kerberoasting=None, kerberoast_account=None,
                    targeted_kerberoast=None, no_preauth_targets=None, base_dn=None, query=None, find_delegation=False, trusted_for_delegation=False,
                    password_not_required=False, admin_count=False, users=None, users_export=None, groups=None, ous=None, computers=False, dc_list=False,
                    get_sid=False, active_users=None, pso=False, pass_pol=False, gmsa=False, gmsa_convert_id=None, gmsa_decrypt_lsa=None, bloodhound=True,
                    collection='Default')
           DEBUG    Protocol: ldap                                                                                                                            netexec.py:155
           DEBUG    Protocol Path: /root/.local/share/pipx/venvs/netexec/lib/python3.14/site-packages/nxc/protocols/ldap.py                                   netexec.py:158
           DEBUG    Protocol DB Path: /root/.local/share/pipx/venvs/netexec/lib/python3.14/site-packages/nxc/protocols/ldap/database.py                       netexec.py:160
           DEBUG    Protocol Object: <class 'protocol.ldap'>, type: <class 'type'>                                                                            netexec.py:163
           DEBUG    Protocol DB Object: <class 'protocol.database'>                                                                                           netexec.py:165
           DEBUG    DB Path: /root/.nxc/workspaces/default/ldap.db                                                                                            netexec.py:168
           DEBUG    Creating ThreadPoolExecutor                                                                                                                netexec.py:47
           DEBUG    Creating thread for <class 'protocol.ldap'>                                                                                                netexec.py:50
[13:34:55] INFO     Socket info: host=10.11.0.10, hostname=dc01.DOMAIN2.local, kerberos=False, ipv6=False, link-local ipv6=False                              connection.py:178
           DEBUG    Kicking off proto_flow                                                                                                                 connection.py:242
           INFO     Connecting to ldap://10.11.0.10 with no baseDN                                                                                               ldap.py:109
           DEBUG    ldap_connection: <impacket.ldap.ldap.LDAPConnection object at 0x7933b4477e00>                                                                ldap.py:113
           DEBUG    Created connection object                                                                                                              connection.py:247
           DEBUG    Target: dc01.DOMAIN2.local; target_domain: DOMAIN2.local; base_dn: DC=DOMAIN2,DC=local                                                     ldap.py:225
           DEBUG    LDAP signing is not enforced on 10.11.0.10                                                                                                   ldap.py:155
[13:34:57] DEBUG    Update Hosts: [{'id': 4, 'ip': '10.11.0.10', 'hostname': 'DC01', 'domain': 'DOMAIN1.local', 'os': 'Windows 10 / Server 2019 Build 17763',     database.py:95
                    'signing_required': False, 'channel_binding': 'Never'}]
           DEBUG    add_host() - Host IDs Updated: [4]                                                                                                       database.py:105
           DEBUG    Printing host info for LDAP                                                                                                                  ldap.py:285
[13:34:57] INFO     LDAP        10.11.0.10      389    DC01             Windows 10 / Server 2019 Build 17763 (name:DC01) (domain:DOMAIN1.local) (signing:None)       ldap.py:293
                    (channel binding:Never)
           DEBUG    Trying to authenticate using plaintext with domain                                                                                     connection.py:510
           INFO     Connecting to ldap://dc01.DOMAIN2.local - DC=DOMAIN2,DC=local - 10.11.0.10 [3]                                                         ldap.py:460
           DEBUG    Search Filter=(userAccountControl:1.2.840.113556.1.4.803:=8192)                                                                              ldap.py:674
           DEBUG    Search                                                                                                                                       ldap.py:674
                    Filter=(|(objectSid=S-1-5-21-1019428679-532804500-936572585-512)(objectSid=S-1-5-21-1019428679-532804500-936572585-519)(objectSid=S-1-5-21-1
                    019428679-532804500-936572585-544)(objectSid=S-1-5-32-544)(objectSid=S-1-5-32-549)(objectSid=S-1-5-32-551))
           DEBUG    Search                                                                                                                                       ldap.py:674
                    Filter=(&(objectCategory=user)(sAMAccountName=USER)(|(memberOf:1.2.840.113556.1.4.1941:=CN=Administrators,CN=Builtin,DC=DOMAIN2,DC=loca
                    l)(memberOf:1.2.840.113556.1.4.1941:=CN=Server Operators,CN=Builtin,DC=DOMAIN2,DC=local)(memberOf:1.2.840.113556.1.4.1941:=CN=Backup
                    Operators,CN=Builtin,DC=DOMAIN2,DC=local)(memberOf:1.2.840.113556.1.4.1941:=CN=Domain
                    Admins,CN=Users,DC=DOMAIN2,DC=local)(memberOf:1.2.840.113556.1.4.1941:=CN=Enterprise
                    Admins,CN=Users,DC=DOMAIN2,DC=local)(primaryGroupID=512)(primaryGroupID=519)(primaryGroupID=544)(primaryGroupID=549)(primaryGroupID=551)))
           DEBUG    Adding credential: DOMAIN1.local/USER:PASSWORD                                                                                         ldap.py:464
           DEBUG    Adding credentials: [{'id': 6, 'domain': 'DOMAIN1.local', 'username': 'USER', 'password': 'PASSWORD', 'credtype': 'plaintext',     database.py:158
                    'pillaged_from_hostid': None}]
[13:34:57] INFO     LDAP        10.11.0.10      389    DC01             DOMAIN1.local\USER:PASSWORD                                                        ldap.py:468
           DEBUG    Calling command arguments                                                                                                              connection.py:259
           DEBUG    Calling bloodhound()                                                                                                                   connection.py:285
[13:34:57] INFO     LDAP        10.11.0.10      389    DC01             Resolved collection methods: adcs, group, localadmin, session, trusts                   ldap.py:1635
[13:34:57] INFO     LDAP        10.11.0.10      389    DC01             Excluded collection methods: acl, container, dcom, loggedon, objectprops, psremote, rdp ldap.py:1636
           DEBUG    Using DNS to retrieve domain information                                                                                                    ldap.py:1701
           DEBUG    Querying domain controller information from DNS                                                                                            domain.py:734
           DEBUG    Using domain hint: DOMAIN2.local                                                                                                           domain.py:740
           INFO     Found AD domain: DOMAIN2.local                                                                                                             domain.py:753
           DEBUG    Found primary DC: dc01.DOMAIN2.local                                                                                                       domain.py:762
[13:34:58] DEBUG    Found Global Catalog server: dc01.DOMAIN2.local                                                                                            domain.py:773
           DEBUG    Found KDC for enumeration domain: dc01.DOMAIN2.local                                                                                       domain.py:793
           DEBUG    Found KDC for user: dc02.DOMAIN1.local                                                                                                    domain.py:813
           DEBUG    Using LDAP server: dc01.DOMAIN2.local                                                                                                     bloodhound.py:34
           DEBUG    Using base DN: DC=DOMAIN2,DC=local                                                                                                        bloodhound.py:35
           DEBUG    Using kerberos KDC: dc01.DOMAIN2.local                                                                                                    bloodhound.py:39
           DEBUG    Using kerberos realm: DOMAIN2.local                                                                                                       bloodhound.py:40
           INFO     Connecting to LDAP server: dc01.DOMAIN2.local                                                                                             domain.py:63
           DEBUG    Using protocol ldap                                                                                                                         domain.py:64
[13:34:59] DEBUG    LDAP server IPv4: 10.11.0.10                                                                                                                domain.py:73
           DEBUG    Testing resolved hostname connectivity 10.11.0.10                                                                                           domain.py:74
           DEBUG    Successful connection to LDAP server on IP: 10.11.0.10                                                                                      domain.py:83
           DEBUG    No AAAA records found                                                                                                                      domain.py:108
           DEBUG    Authenticating to LDAP server with NTLM                                                                                            authentication.py:155
[13:35:01] DEBUG    No LAPS attributes found in schema                                                                                                         domain.py:320
           DEBUG    Found KeyCredentialLink attributes in schema                                                                                               domain.py:323
[13:35:02] INFO     Found 1 domains                                                                                                                            domain.py:359
           INFO     Found 1 domains in the forest                                                                                                              domain.py:398
           INFO     Found 11 computers                                                                                                                         domain.py:587
           DEBUG    Writing users to file: DC01_10.11.0.10_2026-08-15_133457_2026-08-15_133457_users.json                                                 memberships.py:133
           INFO     Found 22 users                                                                                                                       outputworker.py:147
           DEBUG    Finished writing users                                                                                                                memberships.py:244
           DEBUG    Writing groups to file: DC01_10.11.0.10_2026-08-15_133457_2026-08-15_133457_groups.json                                               memberships.py:266
           INFO     Connecting to LDAP server: dc01.DOMAIN2.local                                                                                             domain.py:63
           DEBUG    Using protocol ldap                                                                                                                         domain.py:64
           DEBUG    LDAP server IPv4: 10.11.0.10                                                                                                                domain.py:73
           DEBUG    Testing resolved hostname connectivity 10.11.0.10                                                                                           domain.py:74
           DEBUG    Successful connection to LDAP server on IP: 10.11.0.10                                                                                      domain.py:83
           DEBUG    No AAAA records found                                                                                                                      domain.py:108
           DEBUG    Authenticating to LDAP server with NTLM                                                                                            authentication.py:155
[13:35:03] DEBUG    Querying resolver LDAP for DN CN=Domain Users,CN=Users,DC=DOMAIN2,DC=local                                                             objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=Group Policy Creator Owners,CN=Users,DC=DOMAIN2,DC=local                                              objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=Domain Admins,CN=Users,DC=DOMAIN2,DC=local                                                            objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=Cert Publishers,CN=Users,DC=DOMAIN2,DC=local                                                          objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=Enterprise Admins,CN=Users,DC=DOMAIN2,DC=local                                                        objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=Schema Admins,CN=Users,DC=DOMAIN2,DC=local                                                            objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=Domain Controllers,CN=Users,DC=DOMAIN2,DC=local                                                       objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=S-1-5-9,CN=ForeignSecurityPrincipals,DC=DOMAIN2,DC=local                                              objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=S-1-5-11,CN=ForeignSecurityPrincipals,DC=DOMAIN2,DC=local                                             objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=S-1-5-17,CN=ForeignSecurityPrincipals,DC=DOMAIN2,DC=local                                             objectresolver.py:56
           DEBUG    Querying resolver LDAP for DN CN=S-1-5-4,CN=ForeignSecurityPrincipals,DC=DOMAIN2,DC=local                                              objectresolver.py:56
[13:35:04] INFO     Found 65 groups                                                                                                                      outputworker.py:147
           DEBUG    Finished writing groups                                                                                                               memberships.py:353
           DEBUG    Opening file for writing: DC01_10.11.0.10_2026-08-15_133457_2026-08-15_133457_domains.json                                                 domains.py:62
           INFO     Found 1 trusts                                                                                                                            domains.py:156
           DEBUG    Finished writing domain info                                                                                                              domains.py:175
           INFO     Starting computer enumeration with 10 workers                                                                                            computers.py:78
           DEBUG    Start working                                                                                                                           computers.py:283
           DEBUG    Start working                                                                                                                           computers.py:283
           DEBUG    Start working                                                                                                                           computers.py:283
           DEBUG    Start working                                                                                                                           computers.py:283
           DEBUG    Start working                                                                                                                           computers.py:283
           DEBUG    Start working                                                                                                                           computers.py:283
           DEBUG    Start working                                                                                                                           computers.py:283
           DEBUG    Start working                                                                                                                           computers.py:283
           DEBUG    Start working                                                                                                                           computers.py:283
           DEBUG    Start working                                                                                                                           computers.py:283
           INFO     Querying computer: wks74.DOMAIN2.local                                                                                                     computers.py:288
           DEBUG    Querying computer: wks74.DOMAIN2.local                                                                                                     computers.py:116
           INFO     Querying computer: wks89.DOMAIN2.local                                                                                                     computers.py:288
           INFO     Querying computer: wks90.DOMAIN2.local                                                                                                     computers.py:288
           INFO     Querying computer: sccmdb.DOMAIN2.local                                                                                                    computers.py:288
           INFO     Querying computer: sccm1.DOMAIN2.local                                                                                                     computers.py:288
           INFO     Querying computer: pki2.DOMAIN2.local                                                                                                      computers.py:288
           INFO     Querying computer: rds.DOMAIN2.local                                                                                                       computers.py:288
           INFO     Querying computer: srv24.DOMAIN2.local                                                                                                     computers.py:288
           INFO     Querying computer: srv56.DOMAIN2.local                                                                                                     computers.py:288
           INFO     Querying computer: wks14.DOMAIN2.local                                                                                                     computers.py:288
           DEBUG    Querying computer: wks89.DOMAIN2.local                                                                                                     computers.py:116
           DEBUG    Querying computer: wks90.DOMAIN2.local                                                                                                     computers.py:116
           DEBUG    Querying computer: sccmdb.DOMAIN2.local                                                                                                    computers.py:116
           DEBUG    Querying computer: sccm1.DOMAIN2.local                                                                                                     computers.py:116
           DEBUG    Querying computer: pki2.DOMAIN2.local                                                                                                      computers.py:116
           DEBUG    Querying computer: rds.DOMAIN2.local                                                                                                       computers.py:116
           DEBUG    Querying computer: srv24.DOMAIN2.local                                                                                                     computers.py:116
           DEBUG    Querying computer: srv56.DOMAIN2.local                                                                                                     computers.py:116
           DEBUG    Querying computer: wks14.DOMAIN2.local                                                                                                     computers.py:116
           DEBUG    Resolved: 10.0.3.42                                                                                                                      computer.py:313
           DEBUG    Trying connecting to computer: wks14.DOMAIN2.local                                                                                          computer.py:319
           DEBUG    Resolved: 192.168.4.67                                                                                                                   computer.py:313
           DEBUG    Trying connecting to computer: pki2.DOMAIN2.local                                                                                           computer.py:319
           DEBUG    Resolved: 10.0.3.74                                                                                                                      computer.py:313
           DEBUG    Resolved: 10.21.0.98                                                                                                                     computer.py:313
           DEBUG    Resolved: 192.168.4.156                                                                                                                  computer.py:313
           DEBUG    Resolved: 192.168.4.157                                                                                                                  computer.py:313
           DEBUG    Trying connecting to computer: wks74.DOMAIN2.local                                                                                          computer.py:319
           DEBUG    Resolved: 10.0.2.246                                                                                                                     computer.py:313
           DEBUG    Resolved: 10.21.0.32                                                                                                                     computer.py:313
           DEBUG    Trying connecting to computer: rds.DOMAIN2.local                                                                                            computer.py:319
           DEBUG    Resolved: 10.0.2.67                                                                                                                      computer.py:313
           DEBUG    Resolved: 10.21.0.41                                                                                                                     computer.py:313
           DEBUG    Trying connecting to computer: sccm1.DOMAIN2.local                                                                                          computer.py:319
           DEBUG    Trying connecting to computer: sccmdb.DOMAIN2.local                                                                                         computer.py:319
           DEBUG    Trying connecting to computer: wks89.DOMAIN2.local                                                                                          computer.py:319
           DEBUG    Trying connecting to computer: srv56.DOMAIN2.local                                                                                          computer.py:319
           DEBUG    Trying connecting to computer: wks90.DOMAIN2.local                                                                                          computer.py:319
           DEBUG    Trying connecting to computer: srv24.DOMAIN2.local                                                                                          computer.py:319
           DEBUG    DCE/RPC binding: ncacn_np:10.0.3.42[\PIPE\srvsvc]                                                                                        computer.py:330
           DEBUG    DCE/RPC binding: ncacn_np:10.0.2.246[\PIPE\srvsvc]                                                                                       computer.py:330
           DEBUG    DCE/RPC binding: ncacn_np:10.21.0.98[\PIPE\srvsvc]                                                                                       computer.py:330
           DEBUG    DCE/RPC binding: ncacn_np:10.0.3.74[\PIPE\srvsvc]                                                                                        computer.py:330
           DEBUG    DCE/RPC binding: ncacn_np:10.21.0.32[\PIPE\srvsvc]                                                                                       computer.py:330
           DEBUG    DCE/RPC binding: ncacn_np:10.0.2.67[\PIPE\srvsvc]                                                                                        computer.py:330
           DEBUG    DCE/RPC binding: ncacn_np:10.21.0.41[\PIPE\srvsvc]                                                                                       computer.py:330
[13:35:05] DEBUG    Access denied while enumerating Sessions on wks89.DOMAIN2.local, likely a patched OS                                                        computer.py:516
           DEBUG    DCE/RPC binding: ncacn_np:10.0.2.246[\PIPE\samr]                                                                                         computer.py:330
           DEBUG    Access denied while enumerating Sessions on srv24.DOMAIN2.local, likely a patched OS                                                        computer.py:516
           DEBUG    DCE/RPC binding: ncacn_np:10.21.0.41[\PIPE\samr]                                                                                         computer.py:330
           DEBUG    Access denied while enumerating Sessions on srv56.DOMAIN2.local, likely a patched OS                                                        computer.py:516
           DEBUG    DCE/RPC binding: ncacn_np:10.21.0.32[\PIPE\samr]                                                                                         computer.py:330
           DEBUG    Access denied while enumerating Sessions on wks14.DOMAIN2.local, likely a patched OS                                                        computer.py:516
           DEBUG    DCE/RPC binding: ncacn_np:10.0.3.42[\PIPE\samr]                                                                                          computer.py:330
           DEBUG    Access denied while enumerating Sessions on rds.DOMAIN2.local, likely a patched OS                                                          computer.py:516
           DEBUG    DCE/RPC binding: ncacn_np:10.21.0.98[\PIPE\samr]                                                                                         computer.py:330
           DEBUG    Access denied while enumerating Sessions on wks90.DOMAIN2.local, likely a patched OS                                                        computer.py:516
           DEBUG    DCE/RPC binding: ncacn_np:10.0.2.67[\PIPE\samr]                                                                                          computer.py:330
           DEBUG    Access denied while enumerating Sessions on wks74.DOMAIN2.local, likely a patched OS                                                        computer.py:516
           DEBUG    DCE/RPC binding: ncacn_np:10.0.3.74[\PIPE\samr]                                                                                          computer.py:330
           DEBUG    Access denied while enumerating groups on srv24.DOMAIN2.local, likely a patched OS                                                          computer.py:841
           DEBUG    Access denied while enumerating groups on wks89.DOMAIN2.local, likely a patched OS                                                          computer.py:841
           DEBUG    Access denied while enumerating groups on srv56.DOMAIN2.local, likely a patched OS                                                          computer.py:841
           DEBUG    Access denied while enumerating groups on wks14.DOMAIN2.local, likely a patched OS                                                          computer.py:841
           DEBUG    Access denied while enumerating groups on rds.DOMAIN2.local, likely a patched OS                                                            computer.py:841
           DEBUG    Access denied while enumerating groups on wks90.DOMAIN2.local, likely a patched OS                                                          computer.py:841
           INFO     Querying computer: dc01.DOMAIN2.local                                                                                                      computers.py:288
           DEBUG    Querying computer: dc01.DOMAIN2.local                                                                                                      computers.py:116
           DEBUG    Resolved: 10.11.0.10                                                                                                                     computer.py:313
           DEBUG    Trying connecting to computer: dc01.DOMAIN2.local                                                                                           computer.py:319
[13:35:06] DEBUG    Access denied while enumerating groups on wks74.DOMAIN2.local, likely a patched OS                                                          computer.py:841
           DEBUG    DCE/RPC binding: ncacn_np:10.11.0.10[\PIPE\srvsvc]                                                                                       computer.py:330
           DEBUG    Access denied while enumerating Sessions on dc01.DOMAIN2.local, likely a patched OS                                                         computer.py:516
           DEBUG    DCE/RPC binding: ncacn_np:10.11.0.10[\PIPE\samr]                                                                                         computer.py:330
[13:35:07] DEBUG    Opening domain handle                                                                                                                    computer.py:792
           DEBUG    Found 544 SID: S-1-5-21-1019428679-532804500-936572585-500                                                                               computer.py:823
           DEBUG    Found 544 SID: S-1-5-21-1019428679-532804500-936572585-519                                                                               computer.py:823
           DEBUG    Found 544 SID: S-1-5-21-1019428679-532804500-936572585-512                                                                               computer.py:823
           DEBUG    DCE/RPC binding: ncacn_np:10.11.0.10[\PIPE\lsarpc]                                                                                       computer.py:330
           DEBUG    Resolved SID to name: ADMINISTRATOR@DOMAIN2.local                                                                                           computer.py:912
           DEBUG    Resolved SID to name: ENTERPRISE ADMINS@DOMAIN2.local                                                                                       computer.py:912
           DEBUG    Resolved SID to name: DOMAIN ADMINS@DOMAIN2.local                                                                                           computer.py:912
[13:35:09] DEBUG    Write worker obtained a None value, exiting                                                                                           outputworker.py:57
           DEBUG    Write worker is done, closing files                                                                                                   outputworker.py:88
[13:35:09] INFO     LDAP        10.11.0.10      389    DC01             Bloodhound data collection completed in 0M 11S                                     bloodhound.py:110
[13:35:09] INFO     LDAP        10.11.0.10      389    DC01             Collecting ADCS data (CertiHound)...                                                    ldap.py:1760
           DEBUG    Search Filter=(objectClass=pKICertificateTemplate)                                                                                           ldap.py:674
[13:35:10] DEBUG    Search Filter=(objectClass=pKIEnrollmentService)                                                                                             ldap.py:674
           DEBUG    Search Filter=(objectClass=certificationAuthority)                                                                                           ldap.py:674
           DEBUG    Search Filter=(cn=NTAuthCertificates)                                                                                                        ldap.py:674
           DEBUG    Search Filter=(objectClass=certificationAuthority)                                                                                           ldap.py:674
[13:35:10] INFO     LDAP        10.11.0.10      389    DC01             Found 32 certificate templates                                                          ldap.py:1777
[13:35:10] INFO     LDAP        10.11.0.10      389    DC01             Found 1 Enterprise CAs                                                                  ldap.py:1778
           INFO     Detection complete: 0 attack path edges, 0 vulnerable templates                                                                          exporter.py:369
           DEBUG    Wrote ADCS file: 2026-08-15_133457_certtemplates.json                                                                                       ldap.py:1791
           DEBUG    Wrote ADCS file: 2026-08-15_133457_enterprisecas.json                                                                                       ldap.py:1791
           DEBUG    Wrote ADCS file: 2026-08-15_133457_rootcas.json                                                                                             ldap.py:1791
           DEBUG    Wrote ADCS file: 2026-08-15_133457_ntauthstores.json                                                                                        ldap.py:1791
           DEBUG    Wrote ADCS file: 2026-08-15_133457_aiacas.json                                                                                              ldap.py:1791
[13:35:10] INFO     LDAP        10.11.0.10      389    DC01             Compressing output into                                                                 ldap.py:1738
                    /root/.nxc/logs/DC01_10.11.0.10_2026-08-15_133457_bloodhound.zip
           DEBUG    Closing connection to: dc01.DOMAIN2.local                                                                                                 connection.py:193
```