### PR TITLE
fix(vnc): bound the connection so an unresponsive server cannot hang the scan

### DIFF
--- a/nxc/protocols/vnc.py
+++ b/nxc/protocols/vnc.py
@@ -96,10 +96,15 @@ class vnc(connection):
 
     def create_conn_obj(self):
         try:
-            self.target = RDPTarget(ip=self.host, port=self.port)
+            self.target = RDPTarget(ip=self.host, port=self.port, timeout=self.args.vnc_timeout)
             credential = UniCredential(protocol=asyauthProtocol.PLAIN, stype=asyauthSecret.PASS)
             self.conn = VNCConnection(target=self.target, credentials=credential, iosettings=self.iosettings)
             asyncio.run(self.connect_vnc(True))
+        except asyncio.TimeoutError:
+            # asyncio.TimeoutError is only an alias of the builtin from 3.11 on,
+            # and the project supports 3.10, so catch it by its asyncio name.
+            self.logger.debug(f"Timed out after {self.args.vnc_timeout}s connecting to {self.host}:{self.port}")
+            return False
         except Exception as e:
             self.logger.debug(str(e))
             if "Connect call failed" in str(e):
@@ -107,7 +112,10 @@ class vnc(connection):
         return True
 
     async def connect_vnc(self, discover=False):
-        _, err = await self.conn.connect()
+        # Bounded like connect_rdp(): the target timeout alone does not cover a
+        # server that completes the TCP connect and then stops responding during
+        # the RFB handshake, which leaves the await outstanding indefinitely.
+        _, err = await asyncio.wait_for(self.conn.connect(), timeout=self.args.vnc_timeout)
         if err is not None:
             if not discover:
                 await asyncio.sleep(self.args.vnc_sleep)
@@ -136,6 +144,11 @@ class vnc(connection):
             )
             return True
 
+        except asyncio.TimeoutError:
+            # Reporting an unresponsive server as a rejected password would be wrong:
+            # nothing was authenticated, so say what actually happened.
+            self.logger.fail(f"{password} - Connection timed out after {self.args.vnc_timeout}s")
+            return False
         except Exception as e:
             self.logger.debug(str(e))
             self.logger.fail(f"{password} - Authentication failed")

--- a/nxc/protocols/vnc/proto_args.py
+++ b/nxc/protocols/vnc/proto_args.py
@@ -4,6 +4,7 @@ from nxc.helpers.args import DisplayDefaultsNotNone
 def proto_args(parser, parents):
     vnc_parser = parser.add_parser("vnc", help="own stuff using VNC", parents=parents, formatter_class=DisplayDefaultsNotNone)
     vnc_parser.add_argument("--port", type=int, default=5900, help="VNC port")
+    vnc_parser.add_argument("--vnc-timeout", type=int, default=5, help="VNC timeout on socket connection")
     vnc_parser.add_argument("--vnc-sleep", type=int, default=5, help="VNC Sleep on socket connection to avoid rate limit")
 
     egroup = vnc_parser.add_argument_group("Screenshot", "VNC Server")


### PR DESCRIPTION
## Description
A VNC server that completes the TCP connect and then stops responding during the RFB handshake leaves `await self.conn.connect()` outstanding forever. `nxc vnc` produces no output and no error, and the run never ends.

This was hit on a live engagement: a target file with a **single host**, and the run sat for a full hour producing nothing but the `--log` header, until an external timeout killed it.

Passing `timeout=` to `RDPTarget` alone does not fix it. The TCP connect *succeeds* — the hang is in the handshake that follows, which the target timeout does not cover. Reproduced against a local listener that accepts the connection and then stays silent:

```
unbounded await: still hanging after 8.0s (killed by the harness, not by nxc)
bounded await:   asyncio.TimeoutError raised after 5.0s
```

RDP already handles exactly this: `connect_rdp()` wraps the call in `asyncio.wait_for` and exposes `--rdp-timeout`. This change gives VNC the same treatment:

- adds `--vnc-timeout` (default 5, matching `--rdp-timeout`)
- passes it to `RDPTarget`
- wraps `self.conn.connect()` in `asyncio.wait_for`
- reports a timeout as a timeout rather than as a rejected password, since nothing was authenticated

Caught as `asyncio.TimeoutError` rather than the builtin, because the two are only unified from Python 3.11 and `pyproject.toml` declares `requires-python = ">=3.10,<4.0"`.

This may also be relevant to #655 (Nonresponsive RDP), which describes the same "freezes, no error messages" behaviour on the other aardwolf-based protocol, though this PR does not change RDP.

No dependency changes.

**AI assistance:** written with Claude Code (Claude Opus 5). The tool located the hang, wrote the patch, and built the local reproduction above. A human reviewed the diff and the reasoning before submission.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review
Tested on Linux (kernel 6.12), Python 3.10–3.13, against NetExec on `main` at 09342c19.

**Triggering the bug** — you need a listener that accepts TCP on the VNC port and then sends nothing, which is what an unresponsive or filtered VNC service looks like on the wire:

```bash
# terminal 1 — accept and stay silent
python3 -c "
import socket
s = socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
s.bind(('127.0.0.1', 5900)); s.listen(8)
held = []
while True:
    c, _ = s.accept(); held.append(c)   # never speak
"

# terminal 2
netexec vnc 127.0.0.1                   # before: hangs indefinitely
netexec vnc 127.0.0.1                   # after: fails the host after ~5s
netexec vnc 127.0.0.1 --vnc-timeout 1   # after: fails after ~1s
```

Before the change the second terminal never returns. After it, the host is failed cleanly and the run continues. A reachable VNC server is unaffected — the handshake completes well inside the default.

## Screenshots (if appropriate):
Not applicable; the behavioural difference is the terminal output shown above.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)

Notes on the unchecked boxes:
- `tests/e2e_commands.txt`: the e2e targets are live services, and this path only triggers against a host that accepts TCP and then stops responding, which the e2e environment does not provide. Happy to add a line if you would like one.
- Wiki: `--vnc-timeout` mirrors the existing `--rdp-timeout`. I will open a wiki PR if you want the VNC flag documented alongside it.
