### PR TITLE
fix(dns): resolve each address family separately when AF_UNSPEC fails

### DIFF
--- a/nxc/connection.py
+++ b/nxc/connection.py
@@ -10,7 +10,7 @@ from functools import wraps
 from time import sleep
 from ipaddress import ip_address
 from dns import resolver, rdatatype
-from socket import AF_UNSPEC, SOCK_DGRAM, IPPROTO_IP, AI_CANONNAME, getaddrinfo
+from socket import AF_INET, AF_INET6, AF_UNSPEC, SOCK_DGRAM, IPPROTO_IP, AI_CANONNAME, getaddrinfo
 
 from nxc.config import pwned_label
 from nxc.helpers.logger import highlight
@@ -30,6 +30,26 @@ global_failed_logins = 0
 user_failed_logins = {}
 
 
+def getaddrinfo_by_family(target, families):
+    """Resolve target with getaddrinfo, keeping the first address of each family."""
+    addresses = {"AF_INET": "", "AF_INET6": ""}
+    canonname = ""
+
+    for family in families:
+        try:
+            results = getaddrinfo(target, None, family, SOCK_DGRAM, IPPROTO_IP, AI_CANONNAME)
+        except OSError:
+            continue
+
+        for af, _, _, name, sa in results:
+            if not canonname:
+                canonname = name
+            if not addresses[af.name]:
+                addresses[af.name] = sa[0]
+
+    return addresses, canonname
+
+
 def get_host_addr_info(target, force_ipv6, dns_server, dns_tcp, dns_timeout):
     result = {
         "host": "",
@@ -46,9 +66,12 @@ def get_host_addr_info(target, force_ipv6, dns_server, dns_tcp, dns_timeout):
     except Exception:
         # If the target is not an IP address, we need to resolve it
         if not (dns_server or dns_tcp):
-            for res in getaddrinfo(target, None, AF_UNSPEC, SOCK_DGRAM, IPPROTO_IP, AI_CANONNAME):
-                af, _, _, canonname, sa = res
-                address_info[af.name] = sa[0]
+            # glibc fails an AF_UNSPEC lookup outright when one family's UDP answer is
+            # truncated, so retry each family on its own before giving up.
+            addresses, canonname = getaddrinfo_by_family(target, (AF_UNSPEC,))
+            if not (addresses["AF_INET"] or addresses["AF_INET6"]):
+                addresses, canonname = getaddrinfo_by_family(target, (AF_INET, AF_INET6))
+            address_info.update(addresses)
 
             if address_info["AF_INET6"] and ip_address(address_info["AF_INET6"]).is_link_local:
                 address_info["AF_INET6"] = canonname

--- a/tests/test_dns_resolution.py
+++ b/tests/test_dns_resolution.py
@@ -1,0 +1,130 @@
+"""Regression tests for hostname resolution (nxc/connection.py).
+
+Background: the system-resolver branch of ``get_host_addr_info`` made a single
+``AF_UNSPEC`` ``getaddrinfo`` call with no fallback. glibc fails an ``AF_UNSPEC``
+lookup with ``EAI_AGAIN`` when one family's UDP answer is truncated, even though
+querying each family on its own succeeds. NetExec then reported the name as
+unresolvable, which left ``self.kdcHost`` unset and broke Kerberos operations.
+
+The dnspython branch already queried A and AAAA separately; the fix makes the
+system-resolver branch behave the same way.
+"""
+from socket import AF_INET, AF_INET6, AF_UNSPEC, EAI_AGAIN, gaierror
+
+import pytest
+
+from nxc.connection import get_host_addr_info
+
+HOST = "dc.example.com"
+
+
+def addrinfo(family, address, canonname=""):
+    return (family, 2, 17, canonname, (address, 0) if family == AF_INET else (address, 0, 0, 0))
+
+
+def fake_getaddrinfo(responses):
+    """Build a getaddrinfo stub driven by a {family: result-or-exception} map."""
+    def stub(target, port, family, *args, **kwargs):
+        outcome = responses[family]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+    return stub
+
+
+def resolve(monkeypatch, responses, force_ipv6=False):
+    monkeypatch.setattr("nxc.connection.getaddrinfo", fake_getaddrinfo(responses))
+    return get_host_addr_info(HOST, force_ipv6, None, False, 3)
+
+
+TRUNCATED_AF_UNSPEC = {
+    AF_UNSPEC: gaierror(EAI_AGAIN, "Temporary failure in name resolution"),
+    AF_INET: [addrinfo(AF_INET, "10.0.0.1", HOST)],
+    AF_INET6: [addrinfo(AF_INET6, "2001:db8::1", HOST)],
+}
+
+
+def test_af_unspec_failure_falls_back_to_per_family(monkeypatch):
+    """The regression: AF_UNSPEC fails but both families resolve on their own."""
+    result = resolve(monkeypatch, TRUNCATED_AF_UNSPEC)
+    assert result["host"] == "10.0.0.1"
+    assert result["is_ipv6"] is False
+
+
+def test_af_unspec_failure_falls_back_for_ipv6(monkeypatch):
+    result = resolve(monkeypatch, TRUNCATED_AF_UNSPEC, force_ipv6=True)
+    assert result["host"] == "2001:db8::1"
+    assert result["is_ipv6"] is True
+
+
+def test_af_unspec_success_is_not_retried(monkeypatch):
+    """A working AF_UNSPEC lookup must not trigger the per-family fallback."""
+    calls = []
+    responses = {AF_UNSPEC: [addrinfo(AF_INET, "10.0.0.1", HOST)]}
+
+    def stub(target, port, family, *args, **kwargs):
+        calls.append(family)
+        return responses[family]
+
+    monkeypatch.setattr("nxc.connection.getaddrinfo", stub)
+    result = get_host_addr_info(HOST, False, None, False, 3)
+    assert result["host"] == "10.0.0.1"
+    assert calls == [AF_UNSPEC]
+
+
+def test_first_address_of_each_family_is_kept(monkeypatch):
+    """Matches the dnspython branch, which keeps answers[0] per family."""
+    responses = {
+        AF_UNSPEC: [
+            addrinfo(AF_INET, "10.0.0.1", HOST),
+            addrinfo(AF_INET, "10.0.0.2"),
+            addrinfo(AF_INET6, "2001:db8::1"),
+            addrinfo(AF_INET6, "2001:db8::2"),
+        ]
+    }
+    assert resolve(monkeypatch, responses)["host"] == "10.0.0.1"
+    assert resolve(monkeypatch, responses, force_ipv6=True)["host"] == "2001:db8::1"
+
+
+def test_link_local_ipv6_uses_canonical_name(monkeypatch):
+    """The canonical name comes from the first record, the only one glibc fills."""
+    responses = {
+        AF_UNSPEC: [
+            addrinfo(AF_INET6, "fe80::1", HOST),
+            addrinfo(AF_INET6, "fe80::2"),
+        ]
+    }
+    result = resolve(monkeypatch, responses, force_ipv6=True)
+    assert result["host"] == HOST
+    assert result["is_link_local_ipv6"] is True
+
+
+def test_every_family_failing_raises(monkeypatch):
+    responses = dict.fromkeys(
+        (AF_UNSPEC, AF_INET, AF_INET6),
+        gaierror(EAI_AGAIN, "Temporary failure in name resolution"),
+    )
+    with pytest.raises(Exception, match="The DNS query name does not exist"):
+        resolve(monkeypatch, responses)
+
+
+def test_ip_targets_skip_resolution(monkeypatch):
+    def stub(*args, **kwargs):
+        raise AssertionError("getaddrinfo must not be called for an IP target")
+
+    monkeypatch.setattr("nxc.connection.getaddrinfo", stub)
+    assert get_host_addr_info("10.0.0.1", False, None, False, 3)["host"] == "10.0.0.1"
+    assert get_host_addr_info("2001:db8::1", False, None, False, 3)["host"] == "2001:db8::1"
+
+
+def test_getaddrinfo_by_family_skips_failing_family(monkeypatch):
+    from nxc.connection import getaddrinfo_by_family
+
+    responses = {
+        AF_INET: gaierror(EAI_AGAIN, "Temporary failure in name resolution"),
+        AF_INET6: [addrinfo(AF_INET6, "2001:db8::1", HOST)],
+    }
+    monkeypatch.setattr("nxc.connection.getaddrinfo", fake_getaddrinfo(responses))
+    addresses, canonname = getaddrinfo_by_family(HOST, (AF_INET, AF_INET6))
+    assert addresses == {"AF_INET": "", "AF_INET6": "2001:db8::1"}
+    assert canonname == HOST

--- a/tests/test_smb_signing.py
+++ b/tests/test_smb_signing.py
@@ -60,7 +60,7 @@ def test_smb311_signing_enabled_not_required_reports_false(smb_module):
         server_security_mode=SMB2_NEGOTIATE_SIGNING_ENABLED,
         require_signing=True,
     )
-    assert smb_module.smb._is_signing_required(None, conn, smbv1=False) is False
+    assert smb_module.smb._is_signing_required(SimpleNamespace(smbv1=False, conn=conn)) is False
 
 
 def test_smb311_signing_required_reports_true(smb_module):
@@ -69,7 +69,7 @@ def test_smb311_signing_required_reports_true(smb_module):
         server_security_mode=SMB2_NEGOTIATE_SIGNING_ENABLED | SMB2_NEGOTIATE_SIGNING_REQUIRED,
         require_signing=True,
     )
-    assert smb_module.smb._is_signing_required(None, conn, smbv1=False) is True
+    assert smb_module.smb._is_signing_required(SimpleNamespace(smbv1=False, conn=conn)) is True
 
 
 def test_smb30_signing_not_required_reports_false(smb_module):
@@ -78,7 +78,7 @@ def test_smb30_signing_not_required_reports_false(smb_module):
         server_security_mode=SMB2_NEGOTIATE_SIGNING_ENABLED,
         require_signing=False,
     )
-    assert smb_module.smb._is_signing_required(None, conn, smbv1=False) is False
+    assert smb_module.smb._is_signing_required(SimpleNamespace(smbv1=False, conn=conn)) is False
 
 
 def test_smb21_falls_back_to_require_signing(smb_module):
@@ -89,9 +89,9 @@ def test_smb21_falls_back_to_require_signing(smb_module):
         server_security_mode=0,
         require_signing=True,
     )
-    assert smb_module.smb._is_signing_required(None, conn, smbv1=False) is True
+    assert smb_module.smb._is_signing_required(SimpleNamespace(smbv1=False, conn=conn)) is True
 
 
 def test_smbv1_uses_session_signing_flag(smb_module):
-    assert smb_module.smb._is_signing_required(None, make_smbv1_conn(True), smbv1=True) is True
-    assert smb_module.smb._is_signing_required(None, make_smbv1_conn(False), smbv1=True) is False
+    assert smb_module.smb._is_signing_required(SimpleNamespace(smbv1=True, conn=make_smbv1_conn(True))) is True
+    assert smb_module.smb._is_signing_required(SimpleNamespace(smbv1=True, conn=make_smbv1_conn(False))) is False


### PR DESCRIPTION
## Description

`get_host_addr_info()` resolved hostnames two different ways, and only one of them was resilient.

The dnspython branch (used with `--dns-server` / `--dns-tcp`) queries A and AAAA as two separate lookups, each in its own `try/except`, so one family failing still yields a usable address. The system-resolver branch made a **single** `AF_UNSPEC` `getaddrinfo()` call with no `try/except` and no per-family fallback.

That asymmetry matters because glibc fails an `AF_UNSPEC` lookup outright with `EAI_AGAIN` when one family's UDP answer is truncated, even when each family resolves fine on its own. Against a domain with many A and AAAA records:

```
AF_INET    OK   21 results   <dc ip>
AF_INET6   OK   25 results   <dc ipv6>
AF_UNSPEC  FAIL [Errno -3] Temporary failure in name resolution
```

NetExec then treated the domain as unresolvable, `Connection.resolver()` returned `None`, and `ldap.py` left `self.kdcHost = None`. Every Kerberos operation broke, reporting the confusing:

```
Error retrieving TGT for domain.tld\user from None
```

`--dns-server` does not help, because impacket opens its Kerberos socket through the OS resolver, not through NetExec's dnspython resolver.

This makes the system-resolver branch behave like the dnspython branch: try `AF_UNSPEC`, and only if that yields nothing, retry `AF_INET` and `AF_INET6` separately. Two smaller issues in the same loop are fixed along the way — the first address of each family is now kept rather than the last (matching `answers[0]` in the dnspython branch), and `canonname` is taken from the first record rather than whatever the last loop iteration happened to hold, which could be empty and silently blanked a link-local IPv6 target.

No new dependencies. No linked issue; this was found in the field rather than reported.

**Second commit, unrelated to the DNS fix:** `tests/test_smb_signing.py` currently fails on `main` with 5 × `TypeError: _is_signing_required() got an unexpected keyword argument 'smbv1'`. 2536442a changed `_is_signing_required` from `(self, conn, smbv1)` to a method reading `self.conn` / `self.smbv1`, but the tests were not updated. Included so this branch's suite is green; happy to split it out if you'd rather take it separately.

`tests/e2e_commands.txt` is unchanged — this fixes existing resolution behaviour and adds no module or flag.

**AI disclosure:** Claude Code (Opus 5). The diagnosis, the patch, the unit tests, and the first draft of this description were produced by the model, working from a live failure I hit during an engagement. I directed the work, reviewed the diff, and verified the fix by hand against a real DC (see the setup section below). Stating the extent plainly rather than understating it, per the project AI policy.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Tested on Kali Linux 6.12.25-amd64, Python 3.12, against a live Windows Server 2022 (Build 20348) DC in a large AD forest.

**Reproducing the bug.** You need a domain whose apex has enough A + AAAA records that the combined answer exceeds the 512-byte non-EDNS UDP limit, and a resolver config without `options edns0`. The forest I hit this on publishes 21 A and 25 AAAA records for the domain name (AAAA answer = 764 bytes).

1. Confirm the resolver state — the bug needs `AF_UNSPEC` to fail while each family succeeds:

```bash
python3 -c "
import socket
for fam,name in ((socket.AF_INET,'A'),(socket.AF_INET6,'AAAA'),(socket.AF_UNSPEC,'UNSPEC')):
    try: print(name,'OK',len(socket.getaddrinfo('<domain>',None,fam,socket.SOCK_DGRAM)))
    except Exception as e: print(name,'FAIL',e)
"
```

2. On `main`, run any Kerberos operation without `--kdcHost`:

```bash
nxc ldap <dc-ip> -u <user> -p <pass> --kerberoast out.txt --debug
```

Before the fix it ends with `DEBUG TGT: None` and `Error retrieving TGT for <domain>\<user> from None`. After the fix the same command resolves the KDC and roasts normally.

If you cannot reproduce the DNS conditions, `tests/test_dns_resolution.py` simulates them with a stubbed `getaddrinfo`; 6 of its 8 tests fail on `main` and all 8 pass with this change.

## Screenshots (if appropriate)

Before, on `main` (no `--kdcHost`, no `--dns-server`):

```
[20:56:22] INFO  LDAP  <dc-ip>  389  <DC>  Some other OSError occured: [Errno Connection error
                  (DOMAIN.TLD:88)] [Errno -3] Temporary failure in name resolution   kerberos.py:170
           DEBUG TGT: None                                                              ldap.py:1093
[20:56:22] INFO  LDAP  <dc-ip>  389  <DC>  Error retrieving TGT for domain.tld\user from None
                                                                                        ldap.py:1128
```

After, same host, same command, glibc `AF_UNSPEC` still failing:

```
AF_UNSPEC FAIL [Errno -3] Temporary failure in name resolution
INFO  Resolved domain: domain.tld with dns, kdcHost: <dc-ip>     ldap.py:270
      $krb5tgs$18$<account>$DOMAIN.TLD$*domain.tld\<account>*...
```

Test suite:

```
$ python -m pytest tests/ -q --ignore=tests/e2e_tests.py
53 passed

$ python -m ruff check .
All checks passed!
```

## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [ ] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)

Sources for the resolver behaviour: [`resolv.conf(5)`](https://man7.org/linux/man-pages/man5/resolv.conf.5.html) — see the `edns0` and `single-request` options, which exist precisely because of the parallel A/AAAA truncation problem — and [`getaddrinfo(3)`](https://man7.org/linux/man-pages/man3/getaddrinfo.3.html) for `EAI_AGAIN`.
