### PR TITLE
ssh: distinguish 'key type rejected by server' from invalid passphrase (issue #1356)

### DIFF
--- a/nxc/protocols/ssh.py
+++ b/nxc/protocols/ssh.py
@@ -15,6 +15,22 @@ from paramiko.ssh_exception import (
 )
 
 
+# Substrings raised by Paramiko when the server refuses a public key because
+# its algorithm is not in the server's accepted list (e.g. sshd
+# "PubkeyAcceptedAlgorithms ssh-ed25519" while the key is RSA). These must be
+# distinguished from a wrong passphrase so the user gets an actionable error.
+_KEY_TYPE_REJECTED_SUBSTRINGS = (
+    "unsupported or disabled",
+    "no RSA pubkey algorithms are configured",
+    "Unable to agree on a pubkey algorithm",
+)
+
+
+def _is_key_type_rejected(exc):
+    """Return True if *exc* indicates the server rejected the key's algorithm."""
+    return any(sub in str(exc) for sub in _KEY_TYPE_REJECTED_SUBSTRINGS)
+
+
 class ssh(connection):
     def __init__(self, args, db, host):
         self.protocol = "SSH"
@@ -125,6 +141,8 @@ class ssh(connection):
         except AuthenticationException as e:
             if "Private key file is encrypted" in str(e):
                 self.logger.fail(f"{username}:{process_secret(password)} Could not load private key, error: {e}")
+            elif _is_key_type_rejected(e):
+                self.logger.fail(f"{username}:{process_secret(password)} Key type rejected by server (pubkey algorithm not allowed)")
             else:
                 self.logger.fail(f"{username}:{process_secret(password)}")
         except SSHException as e:
@@ -132,6 +150,8 @@ class ssh(connection):
                 self.logger.fail(f"{username}:{process_secret(password)} Could not decrypt private key, invalid password")
             elif "Error reading SSH protocol banner" in str(e):
                 self.logger.error(f"Internal Paramiko error for {username}:{process_secret(password)}, {e}")
+            elif _is_key_type_rejected(e):
+                self.logger.fail(f"{username}:{process_secret(password)} Key type rejected by server (pubkey algorithm not allowed)")
             else:
                 self.logger.exception(e)
         except Exception as e:

--- a/tests/test_ssh_key_type_rejection.py
+++ b/tests/test_ssh_key_type_rejection.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for the SSH key-type rejection detection added for issue #1356.
+
+When an sshd server rejects a public key because its algorithm is not in
+`PubkeyAcceptedAlgorithms` (e.g. server allows only ssh-ed25519 while the
+key is RSA), Paramiko raises with one of a few known messages. NetExec must
+recognise those and report "Key type rejected by server" instead of the
+misleading "Could not decrypt private key, invalid password".
+
+These tests load the real helper from nxc/protocols/ssh.py without pulling
+in the heavy nxc dependency tree (which fails to build on Python 3.14).
+"""
+import importlib.util
+import os
+import sys
+import types
+
+import paramiko
+from paramiko.ssh_exception import AuthenticationException, SSHException
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SSH_MODULE = os.path.join(REPO_ROOT, "nxc", "protocols", "ssh.py")
+
+
+def _load_helper():
+    # Stub the nxc.* imports so we can import ssh.py in isolation.
+    for name in ("nxc", "nxc.config", "nxc.connection", "nxc.logger"):
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+    spec = importlib.util.spec_from_file_location("nxc_ssh_isolated", SSH_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    # Provide the symbols ssh.py expects from nxc without real implementations.
+    sys.modules["nxc.config"].process_secret = lambda s: s
+    nxc_connection = sys.modules.setdefault("nxc.connection", types.ModuleType("nxc.connection"))
+    nxc_connection.connection = object
+    nxc_connection.highlight = lambda s: s
+    nxc_logger = sys.modules.setdefault("nxc.logger", types.ModuleType("nxc.logger"))
+    nxc_logger.NXCAdapter = object
+    sys.modules["nxc_ssh_isolated"] = module
+    spec.loader.exec_module(module)
+    return module._is_key_type_rejected
+
+
+_is_key_type_rejected = _load_helper()
+
+
+def _real_paramiko_messages():
+    """Build the actual exception messages Paramiko 5.x emits for this case."""
+    return [
+        SSHException("Auth rejected: pubkey algorithm 'ssh-rsa' unsupported or disabled"),
+        AuthenticationException(
+            "Unable to agree on a pubkey algorithm for signing a 'ssh-rsa' key!"
+        ),
+        SSHException(
+            "An RSA key was specified, but no RSA pubkey algorithms are configured!"
+        ),
+    ]
+
+
+def test_real_paramiko_rejection_messages_are_detected():
+    for exc in _real_paramiko_messages():
+        assert _is_key_type_rejected(exc), f"failed to detect: {exc}"
+
+
+def test_wrong_passphrase_is_not_flagged_as_rejection():
+    # The existing "Invalid key" path must NOT be misclassified as a server
+    # rejection, otherwise we'd hide the real "invalid password" message.
+    assert not _is_key_type_rejected(SSHException("Invalid key"))
+
+
+def test_unrelated_ssh_exception_is_not_flagged():
+    assert not _is_key_type_rejected(
+        SSHException("Error reading SSH protocol banner")
+    )
+
+
+def test_private_key_encrypted_is_not_flagged():
+    assert not _is_key_type_rejected(
+        AuthenticationException("Private key file is encrypted")
+    )


### PR DESCRIPTION
## Description
Fixes #1356. When an sshd server rejects a public key because its algorithm is not in `PubkeyAcceptedAlgorithms` (e.g. server allows only `ssh-ed25519` while the key is RSA), NetExec currently prints the misleading `Could not decrypt private key, invalid password`. That sends the user down the wrong path (blaming the passphrase instead of the server config).

**Root cause (verified against Paramiko 5.0.0 `auth_handler.py`):** in this situation Paramiko raises with one of:
- `Auth rejected: pubkey algorithm '...' unsupported or disabled`
- `Unable to agree on a pubkey algorithm for signing a '...' key!` (`AuthenticationException`)
- `An RSA key was specified, but no RSA pubkey algorithms are configured!`

**Change:** added `_is_key_type_rejected()` in `nxc/protocols/ssh.py` and call it from `plaintext_login()` in both the `AuthenticationException` and `SSHException` branches, emitting `Key type rejected by server (pubkey algorithm not allowed)`. Wrong-passphrase (`Invalid key`) and encrypted-key (`Private key file is encrypted`) cases keep their existing behavior.

**Dependencies:** none new; only touches SSH login error handling.

**AI usage disclosure:** this PR was produced with the assistance of an AI agent (Hermes Agent, model tencent/hy3). The change and the new tests were written and executed by the agent; the human contributor performed the final self-review and verification (see Checklist). Per the project AI policy, this references an accepted issue (#1356).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (Hermes Agent / tencent-hy3; see Description for extent)

## Setup guide for the review
- **Trigger the bug:** set on the target SSH server `PubkeyAcceptedAlgorithms ssh-ed25519` in `sshd_config`, then run `netexec ssh <host> -u <user> --key-file <rsa_or_ecdsa_key> -p <wrong_or_right_pass>`.
  - Before: NetExec prints `Could not decrypt private key, invalid password` (misleading).
  - After: NetExec prints `Key type rejected by server (pubkey algorithm not allowed)`.
- **Regression check:** with a key whose algorithm *is* allowed, a wrong passphrase still prints `Could not decrypt private key, invalid password` (unchanged).
- **Local test:** `pytest tests/test_ssh_key_type_rejection.py` (4 tests, using the real Paramiko 5.x rejection messages). Note: I could not run the full NetExec suite locally because `aardwolf` does not build on Python 3.14 (see #1241); the change is isolated to SSH login error handling and is covered by the new unit tests.

## Screenshots (if appropriate):
N/A (CLI log-level change; see "Setup guide" for before/after output).

## Checklist:
- [x] I have ran Ruff against my changes (`poetry run ruff check .`)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (SSH key-rejection is not a new module/feature; covered by unit test)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (Paramiko 5.0.0 `paramiko/auth_handler.py` rejection messages; see Description)
- [x] I have performed a self-review of my own code (_not_ an AI review) — done by the human contributor
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)