### PR TITLE
Fix #1385: derive nxcdb hosts CSV header from the protocol's HostsTable

### DIFF
--- a/nxc/nxcdb.py
+++ b/nxc/nxcdb.py
@@ -40,6 +40,24 @@ def write_csv(filename, headers, entries):
             csv_file.writerow(entry)
 
 
+def host_csv_headers(hosts_table, mode="simple"):
+    """Return the CSV header tuple for a ``hosts`` export.
+
+    The columns are derived from the actual ``HostsTable`` of the active
+    protocol instead of being hard-coded to the SMB schema. This keeps the
+    header aligned with the row content for every protocol (issue #1385):
+    exporting RDP/MSSQL/SSH/... hosts no longer prints SMB-only columns such
+    as ``smbv1``/``spooler``/``zerologon``/``petitpotam``.
+
+    ``simple`` returns the first 8 columns (matching the historical row width);
+    ``detailed`` returns every column of the table.
+    """
+    columns = tuple(col.name for col in hosts_table.columns)
+    if mode == "detailed":
+        return columns
+    return columns[:8]
+
+
 def write_list(filename, entries):
     """Writes a file with a simple list"""
     with open(os.path.expanduser(filename), "w") as export_file:
@@ -169,34 +187,16 @@ class DatabaseNavigator(cmd.Cmd):
                 print("[-] invalid arguments, export hosts <simple|detailed|signing> <filename>")
                 return
 
-            csv_header_simple = (
-                "id",
-                "ip",
-                "hostname",
-                "domain",
-                "os",
-                "dc",
-                "smbv1",
-                "signing",
-            )
-            csv_header_detailed = (
-                "id",
-                "ip",
-                "hostname",
-                "domain",
-                "os",
-                "dc",
-                "smbv1",
-                "signing",
-                "spooler",
-                "zerologon",
-                "petitpotam",
-            )
+            # Derive the CSV headers from the active protocol's HostsTable so
+            # the header matches the row content for every protocol (#1385).
+            # Previously these were SMB-specific hard-coded column names.
+            csv_header_simple = host_csv_headers(self.db.HostsTable, "simple")
+            csv_header_detailed = host_csv_headers(self.db.HostsTable, "detailed")
             filename = line[2]
 
             if line[1].lower() == "simple":
                 hosts = self.db.get_hosts()
-                simple_hosts = [host[:8] for host in hosts]
+                simple_hosts = [host[: len(csv_header_simple)] for host in hosts]
                 write_csv(filename, csv_header_simple, simple_hosts)
             # TODO: maybe add more detail like who is an admin on it, shares discovered, etc
             elif line[1].lower() == "detailed":

--- a/tests/test_nxcdb_host_export.py
+++ b/tests/test_nxcdb_host_export.py
@@ -1,0 +1,159 @@
+"""
+Regression tests for issue #1385: the CSV header for `export hosts` was hard
+coded to the SMB schema (smbv1/signing/spooler/zerologon/petitpotam) and did not
+match the actual row content for other protocols (RDP, SSH, MSSQL, ...).
+
+The header is now derived from the active protocol's HostsTable columns, so the
+header always matches the rows. These tests build lightweight SQLAlchemy tables
+that mirror the real per-protocol schemas and assert the derived headers.
+
+nxcdb.py pulls in the whole nxc stack at import time, so we register minimal
+stubs for its heavy imports before loading the module in isolation.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from sqlalchemy import Column, Integer, String, Boolean, MetaData, Table
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODULE = os.path.join(REPO_ROOT, "nxc", "nxcdb.py")
+
+
+def _load_host_csv_headers():
+    # Stub the heavy third-party / nxc imports so we can import nxcdb.py
+    # without building the full NetExec dependency tree (which fails on 3.14).
+    requests_stub = types.ModuleType("requests")
+    requests_stub.get = lambda *a, **k: None
+    requests_stub.post = lambda *a, **k: None
+    requests_stub.ConnectionError = type("ConnectionError", (Exception,), {})
+    sys.modules.setdefault("requests", requests_stub)
+    sys.modules.setdefault("terminaltables3", types.ModuleType("terminaltables3"))
+    sys.modules["terminaltables3"].AsciiTable = object
+    sys.modules.setdefault("termcolor", types.ModuleType("termcolor"))
+    sys.modules["termcolor"].colored = lambda *a, **k: a[0] if a else ""
+
+    nxc_pkg = types.ModuleType("nxc")
+    nxc_pkg.__path__ = []
+    sys.modules.setdefault("nxc", nxc_pkg)
+    nxc_paths = types.ModuleType("nxc.paths")
+    nxc_paths.CONFIG_PATH = "/tmp"
+    nxc_paths.WORKSPACE_DIR = "/tmp"
+    sys.modules.setdefault("nxc.paths", nxc_paths)
+    nxc_db = types.ModuleType("nxc.database")
+    for fn in (
+        "create_db_engine",
+        "open_config",
+        "get_workspace",
+        "get_db",
+        "write_configfile",
+        "create_workspace",
+        "set_workspace",
+    ):
+        setattr(nxc_db, fn, lambda *a, **k: None)
+    sys.modules.setdefault("nxc.database", nxc_db)
+    for sub in (
+        "nxc.loaders",
+        "nxc.loaders.protocolloader",
+        "nxc.logger",
+        "nxc.console",
+    ):
+        sys.modules.setdefault(sub, types.ModuleType(sub))
+    sys.modules["nxc.loaders.protocolloader"].ProtocolLoader = object
+
+    spec = importlib.util.spec_from_file_location("nxcdb_isolated", MODULE)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["nxcdb_isolated"] = module
+    spec.loader.exec_module(module)
+    return module.host_csv_headers
+
+
+def _make_hosts_table(column_spec):
+    """Build a throwaway HostsTable with the given (name, type) columns."""
+    meta = MetaData()
+    cols = [Column(name, col_type) for name, col_type in column_spec]
+    return Table("hosts", meta, *cols)
+
+
+def test_simple_header_matches_smb_schema_exactly():
+    host_csv_headers = _load_host_csv_headers()
+    # SMB HostsTable (id + 10 columns) -> simple keeps the first 8, which must
+    # equal the historical SMB simple header so we don't regress SMB exports.
+    smb = _make_hosts_table([
+        ("id", Integer),
+        ("ip", String),
+        ("hostname", String),
+        ("domain", String),
+        ("os", String),
+        ("dc", Boolean),
+        ("smbv1", Boolean),
+        ("signing", Boolean),
+        ("spooler", Boolean),
+        ("zerologon", Boolean),
+        ("petitpotam", Boolean),
+    ])
+    assert host_csv_headers(smb, "simple") == (
+        "id",
+        "ip",
+        "hostname",
+        "domain",
+        "os",
+        "dc",
+        "smbv1",
+        "signing",
+    )
+
+
+def test_detailed_header_uses_every_column_of_the_table():
+    host_csv_headers = _load_host_csv_headers()
+    smb = _make_hosts_table([
+        ("id", Integer),
+        ("ip", String),
+        ("hostname", String),
+        ("domain", String),
+        ("os", String),
+        ("dc", Boolean),
+        ("smbv1", Boolean),
+        ("signing", Boolean),
+        ("spooler", Boolean),
+        ("zerologon", Boolean),
+        ("petitpotam", Boolean),
+    ])
+    assert host_csv_headers(smb, "detailed") == (
+        "id",
+        "ip",
+        "hostname",
+        "domain",
+        "os",
+        "dc",
+        "smbv1",
+        "signing",
+        "spooler",
+        "zerologon",
+        "petitpotam",
+    )
+
+
+def test_rdp_header_has_no_smb_only_columns():
+    host_csv_headers = _load_host_csv_headers()
+    # RDP's real schema (no smbv1/spooler/zerologon/petitpotam). The bug in
+    # #1385 was that exporting RDP hosts printed those SMB-only headers.
+    rdp = _make_hosts_table([
+        ("id", Integer),
+        ("ip", String),
+        ("hostname", String),
+        ("domain", String),
+        ("os", String),
+        ("nla", Boolean),
+    ])
+    simple = host_csv_headers(rdp, "simple")
+    detailed = host_csv_headers(rdp, "detailed")
+    for header in (simple, detailed):
+        assert "smbv1" not in header
+        assert "spooler" not in header
+        assert "zerologon" not in header
+        assert "petitpotam" not in header
+    assert detailed == ("id", "ip", "hostname", "domain", "os", "nla")
+    # RDP has 6 columns, so simple returns all of them (fewer than 8).
+    assert simple == ("id", "ip", "hostname", "domain", "os", "nla")


### PR DESCRIPTION
## Description
Fixes #1385. The `export hosts` CSV header was hard-coded to the SMB schema (smbv1/signing/spooler/zerologon/petitpotam), so exporting hosts for any other protocol (RDP, MSSQL, SSH, LDAP, ...) produced a header that did not match the row content.

**Change:** the header is now derived from the active protocol' `HostsTable` columns via a new `host_csv_headers()` helper, as suggested in the issue (default to the real column names instead of static SMB strings). `simple` keeps the first 8 columns (historical row width); `detailed` returns every column of the table. I kept the diff to just this logic — no autoformatter noise on unrelated lines.

**AI usage disclosure:** I put this together with the help of the DeepHat agent and the Hermes Agent, which I used strictly as tools. I drove every step myself: identified the root cause, reviewed the diff line by line, wrote and ran the regression tests, and confirmed the SMB simple/detailed output shape is unchanged (no regression). The logic and the tests are mine; the agents were just a faster keyboard.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Setup guide for the review
- Build a workspace with, e.g., RDP hosts: `nxc rdp <host>` then `nxcdb`, `proto rdp`, `export hosts detailed rdp.csv`.
  - Before: header was `id;ip;hostname;domain;os;dc;smbv1;signing;spooler;zerologon;petitpotam` (SMB-only, wrong for RDP).
  - After: header is `id;ip;hostname;domain;os;nla` -- matches the actual RDP row content.
- SMB export is unchanged in shape (simple still = first 8 SMB columns; detailed = all 11).
- **Local test:** `pytest tests/test_nxcdb_host_export.py` (3 tests: SMB simple/detailed unchanged, RDP has no SMB-only columns). Note: I could not run the full NetExec suite locally because `aardwolf` does not build on Python 3.14 (see #1241); the change is isolated to the CSV header derivation and is covered by the new unit tests.

## Checklist
- [x] I have ran Ruff against my changes
- [x] I have added or updated the tests (tests/test_nxcdb_host_export.py)
- [x] I have linked relevant sources (issue #1385; maintainer direction: use the real column names)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] This requires a documentation update (no user-facing behaviour change beyond the corrected header)