### PR TITLE
[WMI] Reuse DCOM fix

### DIFF
--- a/nxc/modules/bitlocker.py
+++ b/nxc/modules/bitlocker.py
@@ -1,7 +1,5 @@
 import re
-from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dtypes import NULL
-from impacket.dcerpc.v5.dcomrt import DCOMConnection
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from nxc.helpers.misc import CATEGORY
 
@@ -75,67 +73,44 @@ class BitLockerWMI:
         self.connection = connection
 
     def check_bitlocker_status(self):
+        # Reuse the wmi protocol's authenticated IWbemLevel1Login instead of
+        # creating a second DCOMConnection to the same target (whose disconnect
+        # would clash with the protocol's own)
         try:
-            # Create a DCOM connection
-            dcom_conn = DCOMConnection(
-                self.connection.host,
-                self.connection.username,
-                self.connection.password,
-                self.connection.domain,
-                self.connection.lmhash,
-                self.connection.nthash,
-                oxidResolver=True,
-                doKerberos=self.connection.kerberos,
-                kdcHost=self.connection.kdcHost)
+            iWbemLevel1Login = self.connection.iWbemLevel1Login
+            bitlockerNamespace = "root\\CIMv2\\Security\\MicrosoftVolumeEncryption"
+            iWbemServices = iWbemLevel1Login.NTLMLogin(bitlockerNamespace, NULL, NULL)
+            iWbemLevel1Login.RemRelease()
+            iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+
+            classQuery = "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume"
+            iEnumWbemClassObject = iWbemServices.ExecQuery(classQuery)
+            encryptionTypeMapping = {
+                0: "None",
+                1: "AES_128_WITH_DIFFUSER",
+                2: "AES_256_WITH_DIFFUSER",
+                3: "AES_128",
+                4: "AES_256",
+                5: "HARDWARE_ENCRYPTION",
+                6: "XTS_AES_128",
+                7: "XTS_AES_256_WITH_DIFFUSER"
+            }
 
             try:
-                # CoCreateInstanceEx for WMI login
-                i_interface = dcom_conn.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
-                iWbemLevel1Login = wmi.IWbemLevel1Login(i_interface)
+                while True:
+                    iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff, 1)
+                    encryptionMethod = int(iWbemClassObject[0].EncryptionMethod)
+                    if iWbemClassObject[0].ProtectionStatus == 1:
+                        self.context.log.highlight(f"BitLocker is enabled on drive {iWbemClassObject[0].DriveLetter} (Encryption Method: {encryptionTypeMapping.get(encryptionMethod, 'Unknown')})")
+                    else:
+                        if encryptionMethod == 0:  # Should be 0 if disabled
+                            self.context.log.highlight(f"BitLocker is disabled on drive {iWbemClassObject[0].DriveLetter}")
+            except Exception:
+                pass  # Using pass because if try to log or printing, getting "WMI Session Error: code: 0x1 - WBEM_S_FALSE"
 
-                # Specify the namespace for BitLocker
-                bitlockerNamespace = "root\\CIMv2\\Security\\MicrosoftVolumeEncryption"
-
-                # NTLM login for WMI
-                iWbemServices = iWbemLevel1Login.NTLMLogin(bitlockerNamespace, NULL, NULL)
-
-                # Set authentication level
-                iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-
-                # Query to get BitLocker status
-                classQuery = "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume"
-                iEnumWbemClassObject = iWbemServices.ExecQuery(classQuery)
-                encryptionTypeMapping = {
-                    0: "None",
-                    1: "AES_128_WITH_DIFFUSER",
-                    2: "AES_256_WITH_DIFFUSER",
-                    3: "AES_128",
-                    4: "AES_256",
-                    5: "HARDWARE_ENCRYPTION",
-                    6: "XTS_AES_128",
-                    7: "XTS_AES_256_WITH_DIFFUSER"
-                }
-
-                try:
-                    while True:
-                        iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff, 1)
-                        encryptionMethod = int(iWbemClassObject[0].EncryptionMethod)
-                        if iWbemClassObject[0].ProtectionStatus == 1:
-                            self.context.log.highlight(f"BitLocker is enabled on drive {iWbemClassObject[0].DriveLetter} (Encryption Method: {encryptionTypeMapping.get(encryptionMethod, 'Unknown')})")
-                        else:
-                            if encryptionMethod == 0:  # Should be 0 if disabled
-                                self.context.log.highlight(f"BitLocker is disabled on drive {iWbemClassObject[0].DriveLetter}")
-                except Exception:
-                    pass  # Using pass because if try to log or printing, getting "WMI Session Error: code: 0x1 - WBEM_S_FALSE"
-
-                # Release resources
-                iWbemLevel1Login.RemRelease()
-                iWbemServices.RemRelease()
-                dcom_conn.disconnect()
-            except Exception as e:
-                if "WBEM_E_INVALID_NAMESPACE" in str(e):
-                    self.context.log.fail("BitLockerNamespace not found on target.")
-                    dcom_conn.disconnect()
+            iWbemServices.RemRelease()
         except Exception as e:
-            self.context.log.error(f"Error occurred during BitLocker check: {e}")
-            dcom_conn.disconnect()
+            if "WBEM_E_INVALID_NAMESPACE" in str(e):
+                self.context.log.fail("BitLockerNamespace not found on target.")
+            else:
+                self.context.log.exception(f"Exception occurred: {e}")

--- a/nxc/modules/rdp.py
+++ b/nxc/modules/rdp.py
@@ -101,7 +101,8 @@ class NXCModule:
                             context.log.fail("Looks like target system version is under NT6, please add 'OLD=true' in module options.")
                         else:
                             context.log.fail(str(e))
-                wmi_rdp._RdpWmi__dcom.disconnect()
+                if wmi_rdp._RdpWmi__dcom is not None:
+                    wmi_rdp._RdpWmi__dcom.disconnect()
 
 
 class RdpSmb:
@@ -221,6 +222,14 @@ class RdpWmi:
         self.__remoteHost = connection.host
         self.__aesKey = connection.aesKey
         self.__timeout = timeout
+
+        self.__dcom = None
+        if self.__currentprotocol == "wmi":
+            # The wmi protocol already holds an authenticated IWbemLevel1Login:
+            # reuse it instead of creating a second DCOMConnection to the same
+            # target (whose disconnect would clash with the protocol's own)
+            self.__iWbemLevel1Login = connection.iWbemLevel1Login
+            return
 
         try:
             self.__dcom = DCOMConnection(


### PR DESCRIPTION
## Description

The `rdp` and `bitlocker` modules were creating their own DCOMConnection when running over the wmi protocol, which already holds one. Two DCOMConnections to the same target share impacket's global registries (`INTERFACE.CONNECTIONS`, `PORTMAPS`, OXID resolver): whichever disconnects first deletes the shared entries, and the other's disconnect raises `KeyError`. Both modules now reuse the protocol's authenticated `connection.iWbemLevel1Login` instead — one DCOM per target, the lifecycle stays with the protocol.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Just install imapcket

## Screenshots (if appropriate):

- Before (RDP)
<img width="1560" height="663" alt="image" src="https://github.com/user-attachments/assets/9c300510-6e79-4e81-9ec2-b998ff87318d" />

- After
<img width="1340" height="130" alt="image" src="https://github.com/user-attachments/assets/ddb3ffc1-aae4-477b-86de-c05a68ea997a" />

## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
