### PR TITLE
[WinRM] Add --wmi-query and fix check_if_admin false positive

### DIFF
--- a/nxc/modules/bitlocker.py
+++ b/nxc/modules/bitlocker.py
@@ -1,7 +1,5 @@
 import re
-from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dtypes import NULL
-from impacket.dcerpc.v5.dcomrt import DCOMConnection
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from nxc.helpers.misc import CATEGORY
 
@@ -75,67 +73,44 @@ class BitLockerWMI:
         self.connection = connection
 
     def check_bitlocker_status(self):
+        # Reuse the wmi protocol's authenticated IWbemLevel1Login instead of
+        # creating a second DCOMConnection to the same target (whose disconnect
+        # would clash with the protocol's own)
         try:
-            # Create a DCOM connection
-            dcom_conn = DCOMConnection(
-                self.connection.host,
-                self.connection.username,
-                self.connection.password,
-                self.connection.domain,
-                self.connection.lmhash,
-                self.connection.nthash,
-                oxidResolver=True,
-                doKerberos=self.connection.kerberos,
-                kdcHost=self.connection.kdcHost)
+            iWbemLevel1Login = self.connection.iWbemLevel1Login
+            bitlockerNamespace = "root\\CIMv2\\Security\\MicrosoftVolumeEncryption"
+            iWbemServices = iWbemLevel1Login.NTLMLogin(bitlockerNamespace, NULL, NULL)
+            iWbemLevel1Login.RemRelease()
+            iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+
+            classQuery = "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume"
+            iEnumWbemClassObject = iWbemServices.ExecQuery(classQuery)
+            encryptionTypeMapping = {
+                0: "None",
+                1: "AES_128_WITH_DIFFUSER",
+                2: "AES_256_WITH_DIFFUSER",
+                3: "AES_128",
+                4: "AES_256",
+                5: "HARDWARE_ENCRYPTION",
+                6: "XTS_AES_128",
+                7: "XTS_AES_256_WITH_DIFFUSER"
+            }
 
             try:
-                # CoCreateInstanceEx for WMI login
-                i_interface = dcom_conn.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
-                iWbemLevel1Login = wmi.IWbemLevel1Login(i_interface)
+                while True:
+                    iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff, 1)
+                    encryptionMethod = int(iWbemClassObject[0].EncryptionMethod)
+                    if iWbemClassObject[0].ProtectionStatus == 1:
+                        self.context.log.highlight(f"BitLocker is enabled on drive {iWbemClassObject[0].DriveLetter} (Encryption Method: {encryptionTypeMapping.get(encryptionMethod, 'Unknown')})")
+                    else:
+                        if encryptionMethod == 0:  # Should be 0 if disabled
+                            self.context.log.highlight(f"BitLocker is disabled on drive {iWbemClassObject[0].DriveLetter}")
+            except Exception:
+                pass  # Using pass because if try to log or printing, getting "WMI Session Error: code: 0x1 - WBEM_S_FALSE"
 
-                # Specify the namespace for BitLocker
-                bitlockerNamespace = "root\\CIMv2\\Security\\MicrosoftVolumeEncryption"
-
-                # NTLM login for WMI
-                iWbemServices = iWbemLevel1Login.NTLMLogin(bitlockerNamespace, NULL, NULL)
-
-                # Set authentication level
-                iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-
-                # Query to get BitLocker status
-                classQuery = "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume"
-                iEnumWbemClassObject = iWbemServices.ExecQuery(classQuery)
-                encryptionTypeMapping = {
-                    0: "None",
-                    1: "AES_128_WITH_DIFFUSER",
-                    2: "AES_256_WITH_DIFFUSER",
-                    3: "AES_128",
-                    4: "AES_256",
-                    5: "HARDWARE_ENCRYPTION",
-                    6: "XTS_AES_128",
-                    7: "XTS_AES_256_WITH_DIFFUSER"
-                }
-
-                try:
-                    while True:
-                        iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff, 1)
-                        encryptionMethod = int(iWbemClassObject[0].EncryptionMethod)
-                        if iWbemClassObject[0].ProtectionStatus == 1:
-                            self.context.log.highlight(f"BitLocker is enabled on drive {iWbemClassObject[0].DriveLetter} (Encryption Method: {encryptionTypeMapping.get(encryptionMethod, 'Unknown')})")
-                        else:
-                            if encryptionMethod == 0:  # Should be 0 if disabled
-                                self.context.log.highlight(f"BitLocker is disabled on drive {iWbemClassObject[0].DriveLetter}")
-                except Exception:
-                    pass  # Using pass because if try to log or printing, getting "WMI Session Error: code: 0x1 - WBEM_S_FALSE"
-
-                # Release resources
-                iWbemLevel1Login.RemRelease()
-                iWbemServices.RemRelease()
-                dcom_conn.disconnect()
-            except Exception as e:
-                if "WBEM_E_INVALID_NAMESPACE" in str(e):
-                    self.context.log.fail("BitLockerNamespace not found on target.")
-                    dcom_conn.disconnect()
+            iWbemServices.RemRelease()
         except Exception as e:
-            self.context.log.error(f"Error occurred during BitLocker check: {e}")
-            dcom_conn.disconnect()
+            if "WBEM_E_INVALID_NAMESPACE" in str(e):
+                self.context.log.fail("BitLockerNamespace not found on target.")
+            else:
+                self.context.log.exception(f"Exception occurred: {e}")

--- a/nxc/modules/rdp.py
+++ b/nxc/modules/rdp.py
@@ -101,7 +101,8 @@ class NXCModule:
                             context.log.fail("Looks like target system version is under NT6, please add 'OLD=true' in module options.")
                         else:
                             context.log.fail(str(e))
-                wmi_rdp._RdpWmi__dcom.disconnect()
+                if wmi_rdp._RdpWmi__dcom is not None:
+                    wmi_rdp._RdpWmi__dcom.disconnect()
 
 
 class RdpSmb:
@@ -221,6 +222,14 @@ class RdpWmi:
         self.__remoteHost = connection.host
         self.__aesKey = connection.aesKey
         self.__timeout = timeout
+
+        self.__dcom = None
+        if self.__currentprotocol == "wmi":
+            # The wmi protocol already holds an authenticated IWbemLevel1Login:
+            # reuse it instead of creating a second DCOMConnection to the same
+            # target (whose disconnect would clash with the protocol's own)
+            self.__iWbemLevel1Login = connection.iWbemLevel1Login
+            return
 
         try:
             self.__dcom = DCOMConnection(

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -18,7 +18,7 @@ from impacket.examples.secretsdump import LocalOperations, LSASecrets, SAMHashes
 from impacket.uuid import bin_to_string
 
 from nxc.config import process_secret, host_info_colors
-from nxc.connection import connection
+from nxc.connection import connection, requires_admin
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.logger import highlight
 from nxc.helpers.misc import gen_random_string
@@ -247,6 +247,100 @@ class winrm(connection):
             else:
                 self.logger.fail(f"{self.domain}\\{self.username}:{process_secret(self.nthash)} {e!s}")
             return False
+
+    @requires_admin
+    def wmi_query(self, wql=None, namespace=None):
+        """Run a WQL query natively over WS-Management.
+
+        The query is sent as a wsman:Filter with the Microsoft WQL dialect and
+        executed server-side (projection and WHERE included) - no PowerShell
+        process is spawned on the target and no DCOM access is needed,
+        matching the smb/wmi protocols --wmi-query behavior.
+
+        Permissions: WinRM authentication creates a network-type logon
+        session, and two layers gate WMI over WS-Management for it: the
+        WinRM service WMI plugin only serves Administrators, Interactive
+        and Remote Management Users (network logons lack the Interactive
+        group), and the namespace itself requires Remote Enable for
+        network contexts (Administrators by default) - hence the
+        requires_admin gate.
+        """
+        records = []
+        if not wql:
+            wql = self.args.wmi_query.strip("\n")
+        if not namespace:
+            namespace = self.args.wmi_namespace
+
+        wsen, wsmn = NAMESPACES["wsen"], NAMESPACES["wsman"]
+        namespace_path = namespace.replace("\\", "/")
+        resource_uri = f"http://schemas.microsoft.com/wbem/wsman/1/wmi/{namespace_path}/*"
+        # https://learn.microsoft.com/en-us/windows/winrm/winrm-scripting-shell?tabs=filter-1
+        wql_dialect = "http://schemas.microsoft.com/wbem/wsman/1/WQL"
+
+        def parse_items(res):
+            items = []
+            for element in res.iter():
+                if not element.tag.endswith("}Items"):
+                    continue
+                for instance in element:
+                    props = {}
+                    for prop in instance:
+                        name = prop.tag.split("}")[-1]
+                        if name in props:
+                            # multi-valued WMI property arrives as repeated elements
+                            if not isinstance(props[name], list):
+                                props[name] = [props[name]]
+                            props[name].append(prop.text)
+                        else:
+                            props[name] = prop.text
+                    items.append(props)
+            return items
+
+        def find_context(res):
+            for element in res.iter():
+                if element.tag.endswith("}EnumerationContext") and element.text and element.text.strip():
+                    return element.text.strip()
+            return None
+
+        enum_msg = ET.Element(f"{{{wsen}}}Enumerate")
+        wql_filter = ET.SubElement(enum_msg, f"{{{wsmn}}}Filter")
+        wql_filter.set("Dialect", wql_dialect)
+        wql_filter.text = wql
+        ET.SubElement(enum_msg, f"{{{wsmn}}}OptimizeEnumeration")
+        ET.SubElement(enum_msg, f"{{{wsmn}}}MaxElements").text = "32000"
+
+        self.logger.info(f"Executing WQL syntax: {wql}")
+        try:
+            res = self.conn.wsman.enumerate(resource_uri=resource_uri, resource=enum_msg)
+        except Exception as e:
+            self.logger.fail(f"Failed to execute the WMI query: {e}")
+            return records
+
+        records.extend(parse_items(res))
+
+        # Pull the remaining pages until the server sends EndOfSequence
+        context = find_context(res)
+        while context:
+            pull_msg = ET.Element(f"{{{wsen}}}Pull")
+            context_element = ET.SubElement(pull_msg, f"{{{wsen}}}EnumerationContext")
+            context_element.text = context
+            ET.SubElement(pull_msg, f"{{{wsen}}}MaxElements").text = "32000"
+            try:
+                res = self.conn.wsman.pull(resource_uri, pull_msg)
+            except Exception as e:
+                self.logger.fail(f"Failed to pull the WMI query results: {e}")
+                break
+            records.extend(parse_items(res))
+            if any(element.tag.endswith("}EndOfSequence") for element in res.iter()):
+                break
+            context = find_context(res)
+
+        for record in records:
+            for k, v in record.items():
+                self.logger.highlight(f"{k} => {v}")
+        if not records:
+            self.logger.highlight("No entries found")
+        return records
 
     def execute(self, payload=None, get_output=False, shell_type="cmd"):
         if not payload:

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -1,5 +1,6 @@
 import os
 import base64
+import contextlib
 import traceback
 import requests
 import urllib3
@@ -7,9 +8,12 @@ import logging
 import ntpath
 import xml.etree.ElementTree as ET
 
+from pypsrp.exceptions import WSManFaultError
 from pypsrp.wsman import NAMESPACES
 from pypsrp.client import Client
-from pypsrp.powershell import PSDataStreams
+
+from pypsrp.powershell import PSDataStreams, RunspacePool
+from pypsrp.shell import WinRS
 from termcolor import colored
 
 from dploot.lib.utils import is_guid, is_credfile
@@ -41,6 +45,7 @@ class winrm(connection):
         self.challenge_header = None
         self.targetDomain = None
         self.no_ntlm = False
+        self.shell_types = []
 
         connection.__init__(self, args, db, host)
 
@@ -141,17 +146,61 @@ class winrm(connection):
         return False
 
     def check_if_admin(self):
-        wsman = self.conn.wsman
-        wsen = NAMESPACES["wsen"]
-        wsmn = NAMESPACES["wsman"]
+        """Set admin_privs from a WinRM service configuration read.
 
-        enum_msg = ET.Element(f"{{{wsen}}}Enumerate")
-        ET.SubElement(enum_msg, f"{{{wsmn}}}OptimizeEnumeration")
-        ET.SubElement(enum_msg, f"{{{wsmn}}}MaxElements").text = "32000"
+        Only administrators can read the WinRM configuration, and the
+        request answers in milliseconds on both paths. It doubles as the
+        first authenticated WSMan request of the session, so an
+        authentication error here fails the login.
+        """
+        try:
+            self.conn.wsman.get("http://schemas.microsoft.com/wbem/wsman/1/config")
+            self.admin_privs = True
+        except WSManFaultError:
+            self.admin_privs = False
 
-        wsman.enumerate("http://schemas.microsoft.com/wbem/wsman/1/windows/shell", enum_msg)
-        self.admin_privs = True
-        return True
+        # A shell type requested on the command line (-x runs a cmd shell,
+        # -X a PowerShell runspace) is counted as working without probing:
+        # the execution itself confirms it, and a failure is reported loudly.
+        shell_checks = {
+            "cmd": not getattr(self.args, "execute", None),
+            "powershell": not getattr(self.args, "ps_execute", None),
+        }
+        self.shell_types = [t for t in ("cmd", "powershell") if not shell_checks[t] or self.probe_shell(t)]
+        return self.admin_privs
+
+    def probe_shell(self, shell_type):
+        """Open and immediately close a shell to check the endpoint access.
+
+        No command is executed: the shell create alone is denied when the
+        account lacks the right. Authentication errors still fail the login,
+        only a WSMan fault counts as no access.
+        """
+        shell = None
+        try:
+            if shell_type == "cmd":
+                shell = WinRS(self.conn.wsman)
+            else:
+                shell = RunspacePool(self.conn.wsman)
+            shell.open()
+            return True
+        except WSManFaultError as e:
+            self.logger.debug(f"{shell_type} shell not accessible: {e}")
+            return False
+        finally:
+            if shell is not None:
+                with contextlib.suppress(Exception):
+                    shell.close()
+
+    def mark_shell_access(self):
+        if not self.shell_types:
+            return ""
+        if len(self.shell_types) == 2:
+            shell_type = "all"
+        else:
+            shell_type = f"{self.shell_types[0]} only"
+        prefix = " - " if self.admin_privs else " "
+        return f"{prefix}{highlight(f'Shell access! ({shell_type})')}"
 
     def plaintext_login(self, domain, username, password):
         # Add server hostname to the Workstation field in NTLM Authenticate Message (Message 3)
@@ -173,7 +222,7 @@ class winrm(connection):
             )
 
             self.check_if_admin()
-            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(self.password)} {self.mark_pwned()}")
+            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(self.password)} {self.mark_pwned()}{self.mark_shell_access()}")
 
             self.logger.debug(f"Adding credential: {domain}/{self.username}:{self.password}")
             self.db.add_credential("plaintext", domain, self.username, self.password)
@@ -226,7 +275,7 @@ class winrm(connection):
             )
 
             self.check_if_admin()
-            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(nthash)} {self.mark_pwned()}")
+            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(nthash)} {self.mark_pwned()}{self.mark_shell_access()}")
 
             self.db.add_credential("hash", domain, self.username, ntlm_hash)
             user_id = self.db.get_credential("hash", domain, self.username, ntlm_hash)
@@ -250,7 +299,7 @@ class winrm(connection):
 
     @requires_admin
     def wmi_query(self, wql=None, namespace=None):
-        """Run a WQL query natively over WS-Management.
+        """Run a WQL query natively over WS-Management and print the results.
 
         The query is sent as a wsman:Filter with the Microsoft WQL dialect and
         executed server-side (projection and WHERE included) - no PowerShell
@@ -265,12 +314,27 @@ class winrm(connection):
         network contexts (Administrators by default) - hence the
         requires_admin gate.
         """
-        records = []
         if not wql:
             wql = self.args.wmi_query.strip("\n")
         if not namespace:
             namespace = self.args.wmi_namespace
 
+        records = self.wql_enumerate(wql, namespace)
+        for record in records:
+            for k, v in record.items():
+                self.logger.highlight(f"{k} => {v}")
+        if not records:
+            self.logger.highlight("No entries found")
+        return records
+
+    @requires_admin
+    def wql_enumerate(self, wql, namespace):
+        """Run a WQL query natively over WS-Management, returning the records.
+
+        Raises WSManFaultError when the server rejects the query (e.g. access
+        denied) and authentication/transport errors as-is.
+        """
+        records = []
         wsen, wsmn = NAMESPACES["wsen"], NAMESPACES["wsman"]
         namespace_path = namespace.replace("\\", "/")
         resource_uri = f"http://schemas.microsoft.com/wbem/wsman/1/wmi/{namespace_path}/*"
@@ -310,11 +374,7 @@ class winrm(connection):
         ET.SubElement(enum_msg, f"{{{wsmn}}}MaxElements").text = "32000"
 
         self.logger.info(f"Executing WQL syntax: {wql}")
-        try:
-            res = self.conn.wsman.enumerate(resource_uri=resource_uri, resource=enum_msg)
-        except Exception as e:
-            self.logger.fail(f"Failed to execute the WMI query: {e}")
-            return records
+        res = self.conn.wsman.enumerate(resource_uri=resource_uri, resource=enum_msg)
 
         records.extend(parse_items(res))
 
@@ -325,21 +385,12 @@ class winrm(connection):
             context_element = ET.SubElement(pull_msg, f"{{{wsen}}}EnumerationContext")
             context_element.text = context
             ET.SubElement(pull_msg, f"{{{wsen}}}MaxElements").text = "32000"
-            try:
-                res = self.conn.wsman.pull(resource_uri, pull_msg)
-            except Exception as e:
-                self.logger.fail(f"Failed to pull the WMI query results: {e}")
-                break
+            res = self.conn.wsman.pull(resource_uri, pull_msg)
             records.extend(parse_items(res))
             if any(element.tag.endswith("}EndOfSequence") for element in res.iter()):
                 break
             context = find_context(res)
 
-        for record in records:
-            for k, v in record.items():
-                self.logger.highlight(f"{k} => {v}")
-        if not records:
-            self.logger.highlight("No entries found")
         return records
 
     def execute(self, payload=None, get_output=False, shell_type="cmd"):

--- a/nxc/protocols/winrm/proto_args.py
+++ b/nxc/protocols/winrm/proto_args.py
@@ -19,6 +19,10 @@ def proto_args(parser, parents):
     cgroup.add_argument("--lsa", action="store_true", help="dump LSA secrets from target systems")
     cgroup.add_argument("--dpapi", action="store_true", help="dump user's Credential Manager secrets from target systems")
 
+    wmi_group = winrm_parser.add_argument_group("WMI Queries")
+    wmi_group.add_argument("--wmi-query", metavar="QUERY", dest="wmi_query", type=str, help="Issues the specified WMI query via PowerShell CIM cmdlets")
+    wmi_group.add_argument("--wmi-namespace", metavar="NAMESPACE", default="root\\cimv2", help="WMI Namespace (default: %(default)s)")
+
     mapping_enum_group = winrm_parser.add_argument_group("Mapping/Enumeration")
     mapping_enum_group.add_argument("--dir", nargs="?", type=str, const="", help="List the content of a path (default path: '%(const)s')")
 

--- a/tests/e2e_commands.txt
+++ b/tests/e2e_commands.txt
@@ -258,6 +258,8 @@ netexec ldap TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -M shadow-
 ##### WINRM
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS # need an extra space after this command due to regex
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS -X ipconfig
+netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --wmi-query "select Name,Domain from win32_computersystem"
+netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --wmi-query "SELECT ProcessId,Name FROM Win32_Process WHERE ProcessId > 0"
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sam
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sam --dump-method cmd
 netexec winrm TARGET_HOST -u LOGIN_USERNAME -p LOGIN_PASSWORD KERBEROS --sam --dump-method powershell


### PR DESCRIPTION
## Description

Adds `--wmi-query` / `--wmi-namespace` to the winrm protocol: native WQL execution over WS-Management (wsman:Filter with the Microsoft WQL dialect, Enumerate+Pull paging). No PowerShell runspace or DCOM — the query runs entirely at the WSMan protocol level. Also fixes a `check_if_admin` false positive: enumerating the shell resource succeeds for any WinRM-authorized user, so every valid login was reported as `(Pwn3d!)`. admin_privs now comes from a WinRM configuration read (admin-only, milliseconds), and shell access is probed separately by opening each endpoint (cmd / PowerShell runspace) without running a command, shown SSH-style:

```
[+] dom\admin:pass (Pwn3d!) Shell access! (all)
[+] dom\user:pass  Shell access! (cmd only)
```

## AI Usage

Claude Code (Anthropic) was used for implementation and live testing. All code was reviewed and tested by the author.
