### PR TITLE
Fix spelling mistakes across multiple files

### DIFF
--- a/nxc/modules/coerce_plus.py
+++ b/nxc/modules/coerce_plus.py
@@ -1083,7 +1083,7 @@ class EFS_HASH_BLOB(NDRSTRUCT):
 
 class ENCRYPTION_CERTIFICATE_HASH(NDRSTRUCT):
     structure = (
-        ("Lenght", DWORD),
+        ("Length", DWORD),
         ("SID", RPC_SID),
         ("Hash", EFS_HASH_BLOB),
         ("Display", LPWSTR),

--- a/nxc/modules/efsr_spray.py
+++ b/nxc/modules/efsr_spray.py
@@ -13,7 +13,7 @@ class NXCModule:
         """
         FILE_NAME      Name of the file which will be tried to create and afterwards delete
         SHARE_NAME     If set, ONLY this share will be used
-        EXCLUDED_SHARES List of share names which will not be used, seperated by comma
+        EXCLUDED_SHARES List of share names which will not be used, separated by comma
         """
 
     def on_login(self, context: Context, connection):

--- a/nxc/modules/impersonate.py
+++ b/nxc/modules/impersonate.py
@@ -101,7 +101,7 @@ class NXCModule:
                     context.log.fail("Invalid token ID submitted")
 
         except Exception as e:
-            context.log.fail(f"Error runing command: {e}")
+            context.log.fail(f"Error running command: {e}")
         finally:
             try:
                 connection.conn.deleteFile(self.share, f"{self.tmp_share}{self.impersonate}")

--- a/nxc/modules/ntds-dump-raw.py
+++ b/nxc/modules/ntds-dump-raw.py
@@ -519,10 +519,10 @@ class NXCModule:
         parsed_header = self.parse_MFT_header(curr_sector[Offset_to_the_first_attribute:])
 
         if "$FILE_NAME" in parsed_header:
-            filename_lenght = self.bytes_to_int_signed(parsed_header["$FILE_NAME"][0x58: 0x58 + 1])
+            filename_length = self.bytes_to_int_signed(parsed_header["$FILE_NAME"][0x58: 0x58 + 1])
             curr_MFA_sector.parent_record_number = self.bytes_to_int_unsigned(parsed_header["$FILE_NAME"][0x18: 0x18 + 3] + b"\x00")
 
-            curr_MFA_sector.filename = parsed_header["$FILE_NAME"][0x58 + 2: 0x58 + 2 + (filename_lenght * 2)].decode("utf-16")
+            curr_MFA_sector.filename = parsed_header["$FILE_NAME"][0x58 + 2: 0x58 + 2 + (filename_length * 2)].decode("utf-16")
 
         if "$DATA" in parsed_header:
             dataRun_offset = self.bytes_to_int_signed(parsed_header["$DATA"][0x20: 0x20 + 1])

--- a/nxc/modules/remove-mic.py
+++ b/nxc/modules/remove-mic.py
@@ -2,7 +2,7 @@
 #  Dirk-jan Mollema (@_dirkjan)
 #  dlive (@D1iv3)
 #
-# Refernece:
+# Reference:
 #  - https://dirkjanm.io/exploiting-CVE-2019-1040-relay-vulnerabilities-for-rce-and-domain-admin/
 #  - https://github.com/fox-it/cve-2019-1040-scanner
 #  - https://github.com/Dliv3/cve-2019-1040-scanner

--- a/nxc/modules/timeroast.py
+++ b/nxc/modules/timeroast.py
@@ -97,7 +97,7 @@ class NXCModule:
                 if ready:
                     reply = sock.recvfrom(120)[0]
 
-                    # Extract RID, hash and "salt" if succesful.
+                    # Extract RID, hash and "salt" if successful.
                     if len(reply) == 68:
                         salt = reply[:48]
                         answer_rid = unpack("<I", reply[-20:-16])[0] ^ keyflag

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -1237,7 +1237,7 @@ class ldap(connection):
         def printTable(items, header):
             colLen = []
 
-            # Calculating maximum lenght before parsing CN.
+            # Calculating maximum length before parsing CN.
             for i, col in enumerate(header):
                 rowMaxLen = max(len(row[1].split(",")[0].split("CN=")[-1]) for row in items) if i == 1 else max(len(str(row[i])) for row in items)
                 colLen.append(max(rowMaxLen, len(col)))

--- a/nxc/protocols/ldap/kerberos.py
+++ b/nxc/protocols/ldap/kerberos.py
@@ -167,7 +167,7 @@ class KerberosAttacks:
                 if e.errno == 113:
                     self.logger.fail(f"Unable to resolve KDC hostname: {e!s}")
                 else:
-                    self.logger.fail(f"Some other OSError occured: {e!s}")
+                    self.logger.fail(f"Some other OSError occurred: {e!s}")
                 return None
             except Exception as e:
                 self.logger.debug(f"TGT: {e!s}")

--- a/nxc/protocols/smb/proto_args.py
+++ b/nxc/protocols/smb/proto_args.py
@@ -23,7 +23,7 @@ def proto_args(parser, parents):
     smb_parser.add_argument("--no-admin-check", action="store_true", help="Avoid checking admin which queries the Service Control Manager")
     smb_parser.add_argument("--gen-relay-list", metavar="OUTPUT_FILE", help="outputs all hosts that don't require SMB signing to the specified file")
     smb_parser.add_argument("--smb-timeout", help="SMB connection timeout", type=int, default=2)
-    smb_parser.add_argument("--laps", dest="laps", metavar="LAPS", type=str, help="LAPS authentification", nargs="?", const="administrator")
+    smb_parser.add_argument("--laps", dest="laps", metavar="LAPS", type=str, help="LAPS authentication", nargs="?", const="administrator")
     smb_parser.add_argument("--generate-hosts-file", type=str, help="Generate a hosts file like from a range of IP")
     smb_parser.add_argument("--generate-krb5-file", type=str, help="Generate a krb5 file like from a range of IP")
     smb_parser.add_argument("--generate-tgt", type=str, help="Generate a tgt ticket")


### PR DESCRIPTION
Fixes nine spelling mistakes across comments, docstrings, and user-facing strings (CLI help text and log messages) in the SMB/LDAP protocols and several modules:

- `nxc/modules/coerce_plus.py`: NDR struct field `Lenght` -> `Length`
- `nxc/modules/efsr_spray.py`: docstring `seperated` -> `separated`
- `nxc/modules/impersonate.py`: log message `runing` -> `running`
- `nxc/modules/ntds-dump-raw.py`: local variable `filename_lenght` -> `filename_length`
- `nxc/modules/remove-mic.py`: header comment `Refernece` -> `Reference`
- `nxc/modules/timeroast.py`: comment `succesful` -> `successful`
- `nxc/protocols/ldap.py`: comment `lenght` -> `length`
- `nxc/protocols/ldap/kerberos.py`: log message `occured` -> `occurred`
- `nxc/protocols/smb/proto_args.py`: help text `authentification` -> `authentication`

All changes are purely cosmetic (comments, docstrings, help text, log messages, and one struct field/local variable name). No behavior changes and no new dependencies.

## Type of change
Insert an "x" inside the brackets for relevant items (do not delete options)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (tool/model and extent listed in the description)

Note: no GitHub issue is referenced; this is a cosmetic drive-by fix.

## Setup guide for the review

No special setup or target environment is required. The changes are limited to comments, docstrings, help text, log messages, and internal identifiers, so no runtime behavior or protocol handling is affected. Verification performed: `ruff check .` passes; a case-insensitive grep for all misspelled words returns zero matches.

## Checklist:
Insert an "x" inside the brackets for completed and relevant items (do not delete options)

- [x] I have ran Ruff against my changes (`ruff check .`)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (N/A - no new modules or features)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects (N/A)
- [ ] I have linked relevant sources that describes the added technique (N/A)
- [ ] I have performed a self-review of my own code (not an AI review - please confirm this yourself before submitting)
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [ ] I have made corresponding changes to the documentation (N/A)