### PR TITLE
fix(ldap): handle ranged member attributes in --groups list-all mode

### DIFF
--- a/nxc/parsers/ldap_results.py
+++ b/nxc/parsers/ldap_results.py
@@ -1,5 +1,12 @@
+import re
+
 from impacket.ldap import ldapasn1 as ldapasn1_impacket
 from uuid import UUID
+
+# AD returns ranged attribute names (e.g. "member;range=0-1499") when a
+# multi-valued attribute exceeds MaxValRange (default 1500).  Group 1 is
+# the base attribute name, group 2 is the range end ("*" on the final page).
+RANGE_ATTR_RE = re.compile(r"^(.+);range=\d+-(\d+|\*)$")
 
 
 def parse_result_attributes(ldap_response):
@@ -8,16 +15,21 @@ def parse_result_attributes(ldap_response):
         # SearchResultReferences may be returned
         if not isinstance(entry, ldapasn1_impacket.SearchResultEntry):
             continue
-        attribute_map = {}
+        # Strip ";range=X-Y" suffixes and merge values under the base name.
+        accumulated = {}
         for attribute in entry["attributes"]:
-            val_list = []
+            raw_name = str(attribute["type"])
+            range_match = RANGE_ATTR_RE.match(raw_name)
+            attr_name = range_match.group(1) if range_match else raw_name
+
+            accumulated.setdefault(attr_name, [])
             for val in attribute["vals"].components:
                 # Typical Byte objects we know how to decode
-                if str(attribute["type"]) == "objectGUID":
+                if attr_name == "objectGUID":
                     val_decoded = UUID(bytes=val.__bytes__())
-                elif str(attribute["type"]) == "objectSid":
+                elif attr_name == "objectSid":
                     val_decoded = sid_to_str(val.__bytes__())
-                elif str(attribute["type"]) == "dNSProperty":
+                elif attr_name == "dNSProperty":
                     val_decoded = val.__bytes__()
                 else:
                     # For the rest we try to decode the value with its encoding
@@ -27,11 +39,10 @@ def parse_result_attributes(ldap_response):
                     except UnicodeDecodeError:
                         # If we can't decode the value, we'll just return the bytes
                         val_decoded = val.__bytes__()
-                val_list.append(val_decoded)
-            if len(val_list) == 1:
-                attribute_map[str(attribute["type"])] = val_list[0]
-            else:
-                attribute_map[str(attribute["type"])] = val_list
+                accumulated[attr_name].append(val_decoded)
+
+        # Unwrap single-value attributes to match the original API contract
+        attribute_map = {name: (vals[0] if len(vals) == 1 else vals) for name, vals in accumulated.items()}
         parsed_response.append(attribute_map)
     return parsed_response
 

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -46,7 +46,7 @@ from nxc.logger import NXCAdapter
 from nxc.protocols.ldap.bloodhound import BloodHound, resolve_collection_methods
 from nxc.protocols.ldap.gmsa import MSDS_MANAGEDPASSWORD_BLOB
 from nxc.protocols.ldap.kerberos import KerberosAttacks
-from nxc.parsers.ldap_results import parse_result_attributes
+from nxc.parsers.ldap_results import RANGE_ATTR_RE, parse_result_attributes
 from nxc.helpers.negotiate_parser import parse_challenge
 from nxc.paths import CONFIG_PATH
 
@@ -808,11 +808,91 @@ class ldap(connection):
         # List all groups
         else:
             search_filter = "(objectCategory=group)"
-            attributes = ["cn", "member", "description"]
+            attributes = ["cn", "member", "description", "distinguishedName"]
 
             resp = self.search(search_filter, attributes)
+
+            # Find groups with incomplete member ranges (keyed by entry index, not DN, for non-ASCII safety).
+            incomplete_ranges = {}
+            entry_idx = 0
+            for entry in resp:
+                if not isinstance(entry, ldapasn1_impacket.SearchResultEntry):
+                    continue
+                for attribute in entry["attributes"]:
+                    range_match = RANGE_ATTR_RE.match(str(attribute["type"]))
+                    if range_match and range_match.group(1) == "member" and range_match.group(2) != "*":
+                        incomplete_ranges[entry_idx] = int(range_match.group(2))
+                entry_idx += 1
+
             resp_parsed = parse_result_attributes(resp)
             self.logger.debug(f"Total of records returned {len(resp_parsed)}")
+
+            # Paginate remaining members via range queries on each group's DN.
+            paginated_count = 0
+            for idx, item in enumerate(resp_parsed):
+                if idx not in incomplete_ranges:
+                    continue
+
+                dn = item.get("distinguishedName")
+                if not dn:
+                    self.logger.debug(f"Group at index {idx} missing distinguishedName, skipping range retrieval")
+                    continue
+
+                members = item.get("member", [])
+                if not isinstance(members, list):
+                    members = [members]
+
+                next_start = incomplete_ranges[idx] + 1
+                while True:
+                    range_resp = self.search(
+                        "(objectClass=*)",
+                        [f"member;range={next_start}-*"],
+                        baseDN=dn,
+                    )
+                    if not range_resp:
+                        self.logger.debug(f"Range retrieval returned empty response for '{dn}' at offset {next_start}")
+                        break
+
+                    got_range = False
+                    final_page = True
+                    for range_entry in range_resp:
+                        if not isinstance(range_entry, ldapasn1_impacket.SearchResultEntry):
+                            continue
+                        for attribute in range_entry["attributes"]:
+                            rm = RANGE_ATTR_RE.match(str(attribute["type"]))
+                            if rm and rm.group(1) == "member":
+                                got_range = True
+                                if rm.group(2) != "*":
+                                    new_end = int(rm.group(2))
+                                    if new_end < next_start:
+                                        self.logger.debug(f"Range retrieval did not advance for '{dn}' (stuck at {new_end})")
+                                    else:
+                                        next_start = new_end + 1
+                                        final_page = False
+
+                    if not got_range:
+                        self.logger.debug(f"Range retrieval returned no member attribute for '{dn}' at offset {next_start}")
+                        break
+
+                    range_parsed = parse_result_attributes(range_resp)
+                    # AD group objects have no children, so the first entry
+                    # in the baseDN search is the group itself
+                    if range_parsed:
+                        new_members = range_parsed[0].get("member", [])
+                        if not isinstance(new_members, list):
+                            new_members = [new_members]
+                        members.extend(new_members)
+
+                    if final_page:
+                        break
+
+                item["member"] = members
+                paginated_count += 1
+
+            if paginated_count < len(incomplete_ranges):
+                self.logger.debug(
+                    f"Range retrieval incomplete: paginated {paginated_count} of {len(incomplete_ranges)} truncated groups"
+                )
 
             # Display all groups
             self.logger.highlight(f"{'-Group-':<40} {'-Members-':<9} {'-Description-':<60}")


### PR DESCRIPTION
## Description

Fixes #1405

`nxc ldap --groups` (list-all mode) reports 0 members for groups exceeding AD's MaxValRange (default 1500). AD returns `member;range=0-1499` instead of `member` for these groups. `parse_result_attributes()` stores the ranged key as-is, so `groups()` looks up `member`, finds nothing, reports 0.

Two changes:
1. **Parser normalisation** (`parse_result_attributes`): strip `;range=X-Y` suffixes and accumulate values under the base attribute name.
2. **Range pagination** (`groups()` list-all path): detect incomplete ranges and issue follow-up `baseDN` queries (`member;range=1500-*`, etc.) until all members are collected.

Tested against Windows Server 2019 with boundary groups at MaxValRange:

| Group | Actual Members | Before (unpatched) | After (patched) |
|-------|---------------|---------------------|------------------|
| GRP_1499 | 1499 | 1499 | 1499 |
| GRP_1500 | 1500 | 1500 | 1500 |
| GRP_1501 | 1501 | **0** | 1501 |
| GRP_3001 | 3001 | **0** | 3001 |

Regressions checked: `--users`, `--kerberoasting`, named-group lookups (`--groups GRP_1501`). All clean.

**Named-group path side effect:** The parser normalisation lets `--groups <name>` see forward members it previously missed, which can trigger the existing reconciliation check. The path was already correct, so I left it alone. Open to adding a guard.

Reference: [Enumerating Groups with Many Members (Microsoft)](https://learn.microsoft.com/en-us/previous-versions/ms817827(v=msdn.10))

I used Claude Code (Claude Opus 4.6) for source analysis, implementation, and drafting. I reviewed and tested all code against a live AD lab.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [x] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

To reproduce, you need at least one AD group with >1500 members. The PowerShell script below creates boundary groups at 1499, 1500, 1501, and 3001 members inside a dedicated OU for clean teardown.

**Note:** Use `pipx install netexec` or `poetry install` from a clone.

**Steps:**

1. Run the PowerShell repro script on a DC to create the test groups
2. Run unpatched: `nxc ldap <DC_IP> -u <user> -p <pass> --groups`. GRP_1501 and GRP_3001 show 0 members.
3. Apply the patch: `git apply netexec-bug009.patch`
4. Run patched: same command. GRP_1501 shows 1501, GRP_3001 shows 3001.
5. Clean up: re-run the PowerShell script with `-Cleanup`

<details>
<summary>PowerShell reproduction script (run on a DC)</summary>

```powershell
<#
.SYNOPSIS
    Creates AD groups at the MaxValRange boundary to reproduce NetExec BUG-009.

.DESCRIPTION
    NetExec's `nxc ldap --groups` (list-all mode) reports 0 members for any group
    exceeding AD's MaxValRange (default 1500). This script creates boundary groups
    with exact member counts so you can diff them against nxc output.

    Boundary sizes and why they matter:
      1499  -- just below MaxValRange, should report correctly
      1500  -- at MaxValRange, should report correctly (last non-ranged response)
      1501  -- first group that triggers ranged attributes; nxc reports 0
      3001  -- forces three range pages (0-1499, 1500-2999, 3000-3000), exercising
              the pagination loop's accumulation and termination

    Everything is created inside a dedicated OU (NxcBugRepro) for clean teardown.

.PARAMETER Sizes
    Group sizes to create. Default: 1499,1500,1501,3001

.PARAMETER Cleanup
    Remove the NxcBugRepro OU and all objects inside it, then exit.

.EXAMPLE
    # Create boundary groups (run on any DC with RSAT-AD-PowerShell)
    .\netexec-bug009-repro.ps1

    # Reproduce the bug
    nxc ldap <DC-IP> -u <user> -p <pass> --groups

    # Clean up
    .\netexec-bug009-repro.ps1 -Cleanup
#>

[CmdletBinding()]
param(
    [int[]]$Sizes = @(1499, 1500, 1501, 3001),

    [switch]$Cleanup
)

$ErrorActionPreference = "Stop"
Import-Module ActiveDirectory

$domainDN = (Get-ADDomain).DistinguishedName
$ouName = "NxcBugRepro"
$ouDN = "OU=$ouName,$domainDN"

# --- Cleanup mode ---
if ($Cleanup) {
    try {
        Get-ADOrganizationalUnit -Identity $ouDN | Out-Null
    } catch {
        Write-Host "OU '$ouDN' not found -- nothing to clean up."
        return
    }
    $count = (Get-ADObject -SearchBase $ouDN -Filter * | Measure-Object).Count
    Write-Host "Removing OU '$ouName' and $count objects inside it..."
    Set-ADOrganizationalUnit -Identity $ouDN -ProtectedFromAccidentalDeletion $false
    Remove-ADOrganizationalUnit -Identity $ouDN -Recursive -Confirm:$false
    Write-Host "Done. OU removed."
    return
}

# --- Check MaxValRange ---
$configDN = (Get-ADRootDSE).configurationNamingContext
$policyDN = "CN=Default Query Policy,CN=Query-Policies,CN=Directory Service,CN=Windows NT,CN=Services,$configDN"
try {
    $policy = Get-ADObject -Identity $policyDN -Properties lDAPAdminLimits
    $maxValRange = ($policy.lDAPAdminLimits | Where-Object { $_ -match "^MaxValRange=" }) -replace "MaxValRange=", ""
    if ($maxValRange) {
        Write-Host "MaxValRange = $maxValRange"
        if ([int]$maxValRange -ne 1500) {
            Write-Warning "MaxValRange is $maxValRange, not the default 1500. Boundary sizes assume 1500 -- adjust -Sizes if needed."
        }
    } else {
        Write-Warning "MaxValRange not found in lDAPAdminLimits. Proceeding with default assumption (1500)."
    }
} catch {
    Write-Warning "Could not read LDAP query policy: $_"
    Write-Warning "Proceeding -- if MaxValRange is not 1500, groups above 1500 won't trigger the bug."
}

$maxSize = ($Sizes | Measure-Object -Maximum).Maximum
Write-Host "Will create $($Sizes.Count) groups. Largest: $maxSize members."

# --- Create OU ---
try {
    New-ADOrganizationalUnit -Name $ouName -Path $domainDN `
        -ProtectedFromAccidentalDeletion $false `
        -Description "Temporary OU for NetExec BUG-009 reproduction -- safe to delete"
    Write-Host "Created OU: $ouDN"
} catch {
    if ($_.Exception.Message -match "already exists") {
        Write-Host "OU already exists: $ouDN"
    } else { throw }
}

# --- Create shared user pool ---
$password = ConvertTo-SecureString "NxcBug009!Temp" -AsPlainText -Force
$created = 0
for ($i = 1; $i -le $maxSize; $i++) {
    $sam = "nxcrepro_$i"
    try {
        New-ADUser -Name $sam -SamAccountName $sam -Path $ouDN `
            -AccountPassword $password -Enabled $false `
            -Description "Temporary user for BUG-009 repro"
        $created++
    } catch {
        if ($_.Exception.Message -match "already exists") { $created++ }
        else { throw }
    }
    if ($i % 500 -eq 0) { Write-Host "  $i / $maxSize users created..." }
}
Write-Host "$created users ready."

# --- Create groups and populate ---
foreach ($size in $Sizes) {
    $groupName = "GRP_$size"
    $groupDN = "CN=$groupName,$ouDN"
    Write-Host "Group: $groupName ($size members)"

    try {
        New-ADGroup -Name $groupName -Path $ouDN `
            -GroupScope Global -GroupCategory Security `
            -Description "BUG-009 boundary group: exactly $size members"
    } catch {
        if ($_.Exception.Message -match "already exists") {
            Write-Host "  Group already exists, clearing members..."
            Get-ADGroupMember -Identity $groupDN | ForEach-Object {
                Remove-ADGroupMember -Identity $groupDN -Members $_ -Confirm:$false
            }
        } else { throw }
    }

    # Add members in batches of 500
    $batch = @()
    for ($i = 1; $i -le $size; $i++) {
        $batch += "nxcrepro_$i"
        if ($batch.Count -ge 500) {
            Add-ADGroupMember -Identity $groupDN -Members $batch -ErrorAction Stop
            $batch = @()
        }
    }
    if ($batch.Count -gt 0) {
        Add-ADGroupMember -Identity $groupDN -Members $batch -ErrorAction Stop
    }

    # Verify exact count
    $actual = (Get-ADGroupMember -Identity $groupDN | Measure-Object).Count
    if ($actual -eq $size) {
        Write-Host "  Verified: $actual members"
    } else {
        throw "MISMATCH on $groupName : expected $size, got $actual -- aborting"
    }
}

Write-Host "`nDone. Run 'nxc ldap <DC-IP> -u <user> -p <pass> --groups' to test."
Write-Host "Expected: GRP_1499 and GRP_1500 show correct counts."
Write-Host "Bug:      GRP_1501 and GRP_3001 show 0 members."
Write-Host "To clean up:  .\netexec-bug009-repro.ps1 -Cleanup"
```

</details>

## Screenshots (if appropriate):
<img width="1231" height="346" alt="netexec-bug009-screenshot" src="https://github.com/user-attachments/assets/6f86fc98-6d0f-4d05-8945-14504d19da51" />


## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [x] I have added or updated the `tests/e2e_commands.txt` file if necessary (no update needed: `netexec ldap ... --groups` already at line 213)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)