### PR TITLE
Fix false positives on ldap signing and cbt checks when NTLM is disabled

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -287,7 +287,7 @@ class ldap(connection):
         self.logger.debug("Printing host info for LDAP")
         if self.signing_required is True:
             signing = colored("signing:Enforced", host_info_colors[0], attrs=["bold"])
-        if self.signing_required is False:
+        elif self.signing_required is False:
             signing = colored("signing:None", host_info_colors[1], attrs=["bold"])
         else:
             signing = colored("signing:Unknown", host_info_colors[2], attrs=["bold"])

--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -147,11 +147,12 @@ class ldap(connection):
         return ""
 
     def check_ldap_signing(self):
-        self.signing_required = False
+        self.signing_required = None
         ldap_url = f"ldap://{self.target}"
         try:
             ldap_connection = ldap_impacket.LDAPConnection(url=ldap_url, baseDN=self.baseDN, dstIp=self.host, signing=False, timeout=self.args.ldap_timeout)
             ldap_connection.login(domain=self.domain)
+            self.signing_required = False
             self.logger.debug(f"LDAP signing is not enforced on {self.host}")
         except ldap_impacket.LDAPSessionError as e:
             if str(e).find("strongerAuthRequired") >= 0:
@@ -185,6 +186,7 @@ class ldap(connection):
                         self.cbt_status = "When Supported"  # CBT is When Supported
             else:
                 self.logger.debug(f"LDAPSessionError while checking for channel binding requirements (likely NTLM disabled): {e!s}")
+                self.cbt_status = "Unknown"
         except SysCallError as e:
             self.logger.debug(f"Received SysCallError when trying to enumerate channel binding support: {e!s}")
             if e.args[1] in ["ECONNRESET", "WSAECONNRESET", "Unexpected EOF"]:
@@ -283,7 +285,12 @@ class ldap(connection):
 
     def print_host_info(self):
         self.logger.debug("Printing host info for LDAP")
-        signing = colored("signing:Enforced", host_info_colors[0], attrs=["bold"]) if self.signing_required else colored("signing:None", host_info_colors[1], attrs=["bold"])
+        if self.signing_required is True:
+            signing = colored("signing:Enforced", host_info_colors[0], attrs=["bold"])
+        if self.signing_required is False:
+            signing = colored("signing:None", host_info_colors[1], attrs=["bold"])
+        else:
+            signing = colored("signing:Unknown", host_info_colors[2], attrs=["bold"])
         cbt_status = colored(f"channel binding:{self.cbt_status}", host_info_colors[3], attrs=["bold"]) if self.cbt_status == "Always" else colored(f"channel binding:{self.cbt_status}", host_info_colors[2], attrs=["bold"])
         ntlm = colored(f"(NTLM:{not self.no_ntlm})", host_info_colors[2], attrs=["bold"]) if self.no_ntlm else ""
 


### PR DESCRIPTION
## Description

This PR changes the result returned by NetExec during ldap signing and channel binding checks. When NTLM is disabled on the environment, those checks fail with debug message "LDAPSessionError while checking for channel binding requirements (likely NTLM disabled)" but the result returned is ldap signing "none "and channel binding "never". This behaviour was modified to return ldap signing "unknown" and channel binding "unknown". 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation of feature or functionality
- [ ] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)
- [ ] This PR was created with the assistance of AI (list what type of assistance, tool(s)/model(s) in the description)

## Setup guide for the review

Tested on a Windows Server 2022 DC with ldap signing and channel binding enabled. 

Change register values : 

```powershell
## Signing
New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters' LDAPServerIntegrity -Value 2 -PropertyType DWord -Force; Restart-Service NTDS -Force

### binding
New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters' LdapEnforceChannelBinding -Value 2 -PropertyType DWord -Force; Restart-Service NTDS -Force
```
> [!CAUTION] 
> A certificate is needed 

Disable NTLM authentication: 
```
New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0' RestrictReceivingNTLMTraffic -Value 2 -PropertyType DWord -Force
```

## Screenshots:

- Checks with NTLM auth allowed: 

<img width="675" height="78" alt="initial-old" src="https://github.com/user-attachments/assets/2f264492-d09b-4c58-b343-0d7515c1cab3" />


- Before changes, NTLM disabled: 

<img width="591" height="79" alt="old" src="https://github.com/user-attachments/assets/0548c04a-e467-4bb6-88c3-7be59a27b94f" />


- After changes, NTLM disabled:

<img width="773" height="75" alt="new" src="https://github.com/user-attachments/assets/c8074b17-4ce8-4fce-920b-070adbe5376c" />


## Checklist:

- [x] I have ran Ruff against my changes (poetry: `poetry run ruff check .`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the `tests/e2e_commands.txt` file if necessary (new modules or features are _required_ to be added to the e2e tests)
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [ ] I have linked relevant sources that describes the added technique (blog posts, documentation, etc)
- [x] I have performed a self-review of my own code (_not_ an AI review)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
